### PR TITLE
Add Super-Equatorial Africa for GEM

### DIFF
--- a/Gameplay/GamePlayText.xml
+++ b/Gameplay/GamePlayText.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameData>
-	
-	
+
+
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++++++ -->
 	<!-- Europe City Names: Default Layer (Modern) <en_US> -->
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++++++ -->
-	
-	
+
+
 	<LocalizedText>		<!-- IBERIA -->
 
 		<Replace Tag="LOC_CITY_NAME_ALBACETE" Text="Albacete" Language="en_US" />
@@ -102,7 +102,7 @@
 		<Replace Tag="LOC_CITY_NAME_EVORA_ROME" Text="Ebora" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FARO" Text="Faro" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FARO_ARABIA" Text="Uhsunubah" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_FARO_ROME" Text="Ossonoba" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_FARO_ROME" Text="Ossonoba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FARO_ROME" Text="Ossonoba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GIBRALTAR" Text="Gibraltar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GIBRALTAR_ARABIA" Text="Jabal Tāriq" Language="en_US" />
@@ -278,9 +278,9 @@
 		<Replace Tag="LOC_CITY_NAME_ZARAGOZA_FRANCE" Text="Saragosse" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZARAGOZA_GERMANY" Text="Saragossa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZARAGOZA_ROME" Text="Cæsaraugusta" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- FRANCE -->
 
 		<Replace Tag="LOC_CITY_NAME_AIX_EN_PROVENCE" Text="Aix-en-Provence" Language="en_US" />
@@ -367,7 +367,7 @@
 		<Replace Tag="LOC_CITY_NAME_LYON_ENGLAND" Text="Lyons" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LYON_POLAND" Text="Lwów Francuski" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LYON_ROME" Text="Lugdunum" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_LYON_SPAIN" Text="León de Francia" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_LYON_SPAIN" Text="León de Francia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE" Text="Marseille" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_ARABIA" Text="Marsīliyā" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_ENGLAND" Text="Marseilles" Language="en_US" />
@@ -470,11 +470,11 @@
 		<Replace Tag="LOC_CITY_NAME_VICHY_ROME" Text="Augustonementum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VIRE" Text="Vire" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VIRE_ROME" Text="Ingena" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- ITALY, SICILY, SARDINIA & CORSICA -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_AGRIGENTO" Text="Agrigento" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AGRIGENTO_ARABIA" Text="Kirkent" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AGRIGENTO_GREECE" Text="Akragas" Language="en_US" />
@@ -730,7 +730,9 @@
 		<Replace Tag="LOC_CITY_NAME_SIENA" Text="Siena" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIENA_FRANCE" Text="Sienne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIENA_ROME" Text="Sæna Julia" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SIRACUSA" Text="Syracuse" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIRACUSA" Text="Siracusa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIRACUSA_ENGLAND" Text="Syracuse" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIRACUSA_FRANCE" Text="Syracuse" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIRACUSA_GREECE" Text="Syrakousai" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIRACUSA_ROME" Text="Syracusæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TARANTO" Text="Taranto" Language="en_US" />
@@ -763,8 +765,6 @@
 		<Replace Tag="LOC_CITY_NAME_VALLETTA_ARABIA" Text="Fālītā" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VALLETTA_FRANCE" Text="La Valette" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VALLETTA_GREECE" Text="Valéta" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_VALLETTA_POLAND" Text="La Valletta" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_VALLETTA_ROME" Text="Valletta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VASTO" Text="Vasto" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VASTO_ROME" Text="Larinum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VENETIA" Text="Venice" Language="en_US" />
@@ -779,11 +779,11 @@
 		<Replace Tag="LOC_CITY_NAME_VIESTE_ROME" Text="Vesta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VITERBO" Text="Viterbo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VITERBO_ROME" Text="Ferentium" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- BRITISH ISLES -->
-		
+
 		<!-- GREAT BRITAIN, MAN, SKYE, ORKNEYS, & FAROES -->
 		<Replace Tag="LOC_CITY_NAME_ABERDEEN" Text="Aberdeen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ABERDEEN_ARABIA" Text="Abradin" Language="en_US" />
@@ -928,7 +928,7 @@
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_BRAZIL" Text="Edimburgo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_CHINA" Text="Aidingbao" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_EGYPT" Text="Iidnbra" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_EDINBURGH_FRANCE" Text="Édimbourg" Language="en_US" /> 
+		<Replace Tag="LOC_CITY_NAME_EDINBURGH_FRANCE" Text="Édimbourg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_GERMANY" Text="Edinburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_GREECE" Text="Trimontion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_INDIA" Text="Edinabara" Language="en_US" />
@@ -1097,7 +1097,7 @@
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_INDIA" Text="Niukyasala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_JAPAN" Text="Nyukassuru" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_NORWAY" Text="Nýikastali" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_ROME" Text="Pons Aelius" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_ROME" Text="Pons Ælius" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_RUSSIA" Text="Nyukasl" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_SCYTHIA" Text="Nyukasl" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_SPAIN" Text="Castillo Nuevo" Language="en_US" />
@@ -1106,7 +1106,7 @@
 		<Replace Tag="LOC_CITY_NAME_NORWICH" Text="Norwich" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_ARABIA" Text="Nuruytsh" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_CHINA" Text="Nuoliqi" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_NORWICH_FRANCE" Text="Noroui" Language="en_US" /> 
+		<Replace Tag="LOC_CITY_NAME_NORWICH_FRANCE" Text="Noroui" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_GREECE" Text="Venta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_JAPAN" Text="Noritchi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_NORWAY" Text="Norvic" Language="en_US" />
@@ -1255,7 +1255,7 @@
 		<Replace Tag="LOC_CITY_NAME_VENTA_SILURUM" Text="Venta Silurum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VINDOLANDA" Text="Vindolanda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WESTON_SUPER_MARE" Text="Weston-super-Mare" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_WESTON_SUPER_MARE_ROME" Text="Lindinis" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_WESTON_SUPER_MARE_ROME" Text="Lindinis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICK" Text="Wick" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICK_GREECE" Text="Vervedrum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICK_NORWAY" Text="Vík" Language="en_US" />
@@ -1282,7 +1282,7 @@
 		<Replace Tag="LOC_CITY_NAME_YORK_NORWAY" Text="Jórvík" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YORK_ROME" Text="Eboracum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YORK_SPAIN" Text="Iorque" Language="en_US" />
-		
+
 		<!-- IRELAND -->
 		<Replace Tag="LOC_CITY_NAME_ARKLOW" Text="Arklow" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARMAGH" Text="Armagh" Language="en_US" />
@@ -1338,11 +1338,11 @@
 		<Replace Tag="LOC_CITY_NAME_WATERFORD_NORWAY" Text="Veðrafjǫrðr" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WESTPORT" Text="Westport" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WEXFORD" Text="Wexford" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- ICELAND -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_ABAER" Text="Ábær" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AKUREYRI" Text="Akureyri" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUTHARDALUR" Text="Búðardalur" Language="en_US" />
@@ -1376,11 +1376,11 @@
 		<Replace Tag="LOC_CITY_NAME_SKEITHA" Text="Skeiða" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STORI_NUPUR" Text="Stóri Núpur" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_THORSHOFN" Text="Þórshöfn" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- SCANDINAVIA (DENMARK, NORWAY, SWEDEN, FINLAND, RUSSIAN KARELIA, KOLA PENINSULA, & SAAREMAA/OSEL) -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_AALBORG" Text="Aalborg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AALBORG_RUSSIA" Text="Olborg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AARHUS" Text="Aarhus" Language="en_US" />
@@ -1667,9 +1667,9 @@
 		<Replace Tag="LOC_CITY_NAME_VYBORG" Text="Vyborg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VYBORG_NORWAY" Text="Viborg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YSTAD" Text="Ystad" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- GERMANY (INCLUDING BENELUX & HELVETIA) -->
 
 		<Replace Tag="LOC_CITY_NAME_AACHEN" Text="Aachen" Language="en_US" />
@@ -1678,13 +1678,13 @@
 		<Replace Tag="LOC_CITY_NAME_AACHEN_POLAND" Text="Akwizgran" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AACHEN_ROME" Text="Aquæ Granni" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AACHEN_RUSSIA" Text="Aakhen" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AACHEN_SPAIN" Text="Aquisgrán" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_AACHEN_SPAIN" Text="Aquisgrán" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMSTERDAM" Text="Amsterdam" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMSTERDAM_CHINA" Text="Amusitedan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMSTERDAM_GREECE" Text="Amstelodamon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMSTERDAM_JAPAN" Text="Amusuterudamu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMSTERDAM_ROME" Text="Flevum" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AMSTERDAM_SPAIN" Text="Ámsterdam" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_AMSTERDAM_SPAIN" Text="Ámsterdam" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARNHEM" Text="Arnhem" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARNHEM_GERMANY" Text="Arnheim" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARNHEM_ROME" Text="Arenacum" Language="en_US" />
@@ -1984,11 +1984,11 @@
 		<Replace Tag="LOC_CITY_NAME_ZURICH_SPAIN" Text="Zúrich" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZWICKAU" Text="Zwickau" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZWOLLE" Text="Zwolle" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- GREECE -->
-		
+
 		<!-- GREECE (MAINLAND) -->
 		<Replace Tag="LOC_CITY_NAME_AGRINIO" Text="Agrinio" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AGRINIO_ARABIA" Text="Vrachori" Language="en_US" /> <!--Turkish -->
@@ -2107,9 +2107,9 @@
 		<Replace Tag="LOC_CITY_NAME_VARDA" Text="Varda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VLORE" Text="Vlöre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VOLOS" Text="Volos" Language="en_US" />
-		
+
 		<!-- GREECE (AEGEAN ISLANDS) -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_AGIOS_NIKOLAOS" Text="Agios Nikolaos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ANDROS" Text="Andros" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHANIA" Text="Chania" Language="en_US" />
@@ -2126,11 +2126,11 @@
 		<Replace Tag="LOC_CITY_NAME_RHODES_RUSSIA" Text="Rodosa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAMOS" Text="Samos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SKYROS" Text="Skyros" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- BALKANS -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA" Text="Alba Iulia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA_ARABIA" Text="Erdel Belgradı" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA_GERMANY" Text="Weißenburg" Language="en_US" />
@@ -2366,9 +2366,9 @@
 		<Replace Tag="LOC_CITY_NAME_ZRENJANIN" Text="Zrenjanin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_ARABIA" Text="Großbetschkerek" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_GERMANY" Text="Beşkelek" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_ROME" Text="Acumincum" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_ROME" Text="Acumincum" Language="en_US" />
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- CENTRAL & EASTERN EUROPE (AUSTRIA, CZECHIA, POLAND, HUNGARY, SLOVAKIA, BELARUS, WESTERN UKRAINE, MOLDOVA, NORTHERN ROMANIA, & SOUTHERN LITHUANIA) -->
 
 		<Replace Tag="LOC_CITY_NAME_ASIPOVICHY" Text="Asipovichy" Language="en_US" />
@@ -2803,7 +2803,6 @@
 		<Replace Tag="LOC_CITY_NAME_ZHYTOMYR" Text="Zhytomyr" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZHYTOMYR_GERMANY" Text="Schytomyr" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZHYTOMYR_POLAND" Text="Żytomierz" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ZHYTOMYR_RUSSIA" Text="Zhitomir" Language="en_US" />	
 		<Replace Tag="LOC_CITY_NAME_ZHYTOMYR_RUSSIA" Text="Zhitomir" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZIELONA_GORA" Text="Zielona Góra" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZIELONA_GORA_GERMANY" Text="Grünberg in Schlesien" Language="en_US" />
@@ -2812,11 +2811,11 @@
 		<Replace Tag="LOC_CITY_NAME_ZVOLEN" Text="Zvolen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZVOLEN_GERMANY" Text="Altsohl" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZVOLEN_ROME" Text="Vetus Solium" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ZYTKAVICY" Text="Žytkavičy" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_ZYTKAVICY" Text="Žytkavičy" Language="en_US" />
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- BALTIC -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_AIZKRAUKLE" Text="Aizkraukle" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALUKSNE" Text="Alūksne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHUDOVO" Text="Chudovo" Language="en_US" />
@@ -2854,11 +2853,11 @@
 		<Replace Tag="LOC_CITY_NAME_VELIZH" Text="Velizh" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VENTSPILS" Text="Ventspils" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VERKHNYADZVINSK" Text="Verkhnyadzvinsk" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText> 	<!-- EUROPEAN RUSSIA -->
-		
+
 		<!-- CENTRAL RUSSIA -->
 		<Replace Tag="LOC_CITY_NAME_ARZAMAS" Text="Arzamas" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BALAKOVO" Text="Balakovo" Language="en_US" />
@@ -2995,7 +2994,7 @@
 		<Replace Tag="LOC_CITY_NAME_YOSHKAR_OLA" Text="Yoshkar Ola" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZELENOGRAD" Text="Zelenograd" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZHARKOVSKIY" Text="Zharkovskiy" Language="en_US" />
-		
+
 		<!-- EASTERN RUSSIA -->
 		<Replace Tag="LOC_CITY_NAME_BELEBEY" Text="Belebey" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BELORETSK" Text="Beloretsk" Language="en_US" />
@@ -3061,7 +3060,7 @@
 		<Replace Tag="LOC_CITY_NAME_YEKATERINBURG" Text="Yekaterinburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YUGORSK" Text="Yugorsk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZHETIKARA" Text="Zhetikara" Language="en_US" />
-		
+
 		<!-- ARCTIC RUSSIA -->
 		<Replace Tag="LOC_CITY_NAME_AGIRISH" Text="Agirish" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AKSARKA" Text="Aksarka" Language="en_US" />
@@ -3157,11 +3156,11 @@
 		<Replace Tag="LOC_CITY_NAME_YEMVA" Text="Yemva" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YUROMA" Text="Yuroma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZELENNIK" Text="Zelennik" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- UKRAINE, SOUTHERN RUSSIA, & KAZAKHSTAN -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_AKTAU" Text="Aktau" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AKTOBE" Text="Aktobe" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AKTOBE_RUSSIA" Text="Aktyubinsk" Language="en_US" />
@@ -3210,7 +3209,7 @@
 		<Replace Tag="LOC_CITY_NAME_KAMYSHIN" Text="Kamyshin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KERCH" Text="Kerch" Language="en_US"/>
 		<Replace Tag="LOC_CITY_NAME_KERCH_GREECE" Text="Pantikapaion" Language="en_US"/>
-		<Replace Tag="LOC_CITY_NAME_KERCH_ROME" Text="Pantikapæum" Language="en_US"/>
+		<Replace Tag="LOC_CITY_NAME_KERCH_ROME" Text="Panticapæum" Language="en_US"/>
 		<Replace Tag="LOC_CITY_NAME_KHARKIV" Text="Kharkiv" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KHERSON" Text="Kherson" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KIEV" Text="Kiev" Language="en_US" />
@@ -3295,11 +3294,11 @@
 		<Replace Tag="LOC_CITY_NAME_YUZHNOUKRAINSK" Text="Yuzhnoukrainsk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZHANAOZEN" Text="Zhanaozen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZHANBAY" Text="Zhanbay" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- GEM RUSSIA -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_ARALSK" Text="Aralsk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BELUSHYA_GUBA" Text="Belushya Guba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BEREZNIKI" Text="Berezniki" Language="en_US" />
@@ -3318,17 +3317,17 @@
 		<Replace Tag="LOC_CITY_NAME_VARNEK" Text="Varnek" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VYUCHEYSKIY" Text="Vyucheyskiy" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YASNY" Text="Yasny" Language="en_US" />
-		
+
 	</LocalizedText>
-	
-	
+
+
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++ -->
 	<!-- Europe City Names: Civ-Specific Layer <en_US> -->
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++ -->
 
-	
+
 	<LocalizedText> <!-- CLASSICAL GREECE -->
-		
+
 		<!-- CLASSICAL GREECE (MAINLAND) -->
 		<Replace Tag="LOC_CITY_NAME_ACTIA_NICOPOLIS" Text="Actia Nicopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AENUS" Text="Ænus" Language="en_US" />
@@ -3414,7 +3413,7 @@
 		<Replace Tag="LOC_CITY_NAME_THESPIAE" Text="Thespiæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_THESSALONICA" Text="Thessalonica" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_THESSALONIKI" Text="Thessaloniki" Language="en_US" />
-		
+
 		<!-- CLASSICAL GREECE (AEGEAN ISLANDS) -->
 		<Replace Tag="LOC_CITY_NAME_CNOSSOS" Text="Cnossos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COS" Text="Cos" Language="en_US" />
@@ -3431,17 +3430,17 @@
 		<Replace Tag="LOC_CITY_NAME_SAMOS" Text="Samos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SKYROS" Text="Skyros" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_THERA" Text="Thera" Language="en_US" />
-		
+
 	</LocalizedText>
-		
-		
+
+
 	<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 	<!-- Middle East City Names: Default Layer (Modern) <en_US> -->
 	<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-	
-	
+
+
 	<LocalizedText>		<!-- CAUCASUS -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_AGJABEDI" Text="Agjabedi" Language="en_US"/>
 		<Replace Tag="LOC_CITY_NAME_AKHALKALAKI" Text="Akhalkalaki" Language="en_US"/>
 		<Replace Tag="LOC_CITY_NAME_AKHALTSIKHE" Text="Akhaltsikhe" Language="en_US"/>
@@ -3600,11 +3599,11 @@
 		<Replace Tag="LOC_CITY_NAME_ZUGDIDI" Text="Zugdidi" Language="en_US"/>
 		<Replace Tag="LOC_CITY_NAME_ZUGDIDI_GREECE" Text="Archaiopolis" Language="en_US"/>
 		<Replace Tag="LOC_CITY_NAME_ZUGDIDI_ROME" Text="Archæopolis" Language="en_US"/>
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- ANATOLIA & CYPRUS -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_ACIPAYAM" Text="Acıpayam" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ADANA" Text="Adana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ADAPAZARI" Text="Adapazarı" Language="en_US" />
@@ -3646,8 +3645,10 @@
 		<Replace Tag="LOC_CITY_NAME_MARMARIS" Text="Marmaris" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MERSIN" Text="Mersin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NICOSIA" Text="Nicosia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NICOSIA_ARABIA" Text="Lefkoşa" Language="en_US" /> <!--Turkish -->
 		<Replace Tag="LOC_CITY_NAME_NIGDE" Text="Niğde" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PAPHOS" Text="Paphos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PAPHOS_ARABIA" Text="Baf" Language="en_US" /> <!--Turkish -->
 		<Replace Tag="LOC_CITY_NAME_POLI_CRYSOCHOUS" Text="Poli Chysochous" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAMSUN" Text="Samsun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SEYDISEHIR" Text="Seydişehir" Language="en_US" />
@@ -3657,11 +3658,11 @@
 		<Replace Tag="LOC_CITY_NAME_YALOVA" Text="Yalova" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YOZGAT" Text="Yozgat" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZONGULDAK" Text="Zonguldak" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- MIDDLE EAST (NORTH) & IRAN/PERSIA -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_ABHAR" Text="Abhar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ADIYAMAN" Text="Adıyaman" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANEH" Text="Baneh" Language="en_US" />
@@ -3746,12 +3747,15 @@
 		<Replace Tag="LOC_CITY_NAME_YEREVAN" Text="Yerevan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YEREVAN_SUMERIA" Text="Artashat" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZULFUQARLI" Text="Zülfüqarlı" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- MIDDLE EAST (SOUTH) -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_ABU_DHABI" Text="Abu Dhabi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADEN" Text="Aden" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADEN_GREECE" Text="Eudaimon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADEN_ROME" Text="Eudæmon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AHVAZ" Text="Ahvaz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALEPPO" Text="Aleppo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALEPPO_ARABIA" Text="Halab" Language="en_US" />
@@ -3775,6 +3779,7 @@
 		<Replace Tag="LOC_CITY_NAME_BAGHDAD_SUMERIA" Text="Babili" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANDAR_ABBAS" Text="Bandar Abbas" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANDAR_ABBAS_ARABIA" Text="Jaroon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BANDAR_ABBAS_BRAZIL" Text="Porto Comorão" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANDAR_ABBAS_ENGLAND" Text="Gombroon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANDAR_ABBAS_GREECE" Text="Harmozeia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANDAR_ABBAS_PERSIA" Text="Hormirzad" Language="en_US" />
@@ -3832,7 +3837,7 @@
 		<Replace Tag="LOC_CITY_NAME_JERUSALEM_NUBIA" Text="Urušalim" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JERUSALEM_PERSIA" Text="Urušalim" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JERUSALEM_POLAND" Text="Jerozolima" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_JERUSALEM_ROME" Text="Aelia Capitolina" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JERUSALEM_ROME" Text="Ælia Capitolina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JERUSALEM_RUSSIA" Text="Ierusalim" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JERUSALEM_SPAIN" Text="Jerusalén" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JERUSALEM_SUMERIA" Text="Rushalim" Language="en_US" />
@@ -3920,17 +3925,17 @@
 		<Replace Tag="LOC_CITY_NAME_YAZD_GREECE" Text="Pasargadae" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YAZD_ROME" Text="Pasargadae" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YAZD_SUMERIA" Text="Pasargad" Language="en_US" />
-		
+
 	</LocalizedText>
-	
-	
+
+
 	<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 	<!-- Middle East City Names: Civ-Specific Layer <en_US> -->
 	<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-	
-	
+
+
 	<LocalizedText>		<!-- CLASSICAL ANATOLIA & CYPRUS (GREECE & ROME) -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_ABONITEICHOS" Text="Aboniteichos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ACHERUSIA_CHERSONESOS" Text="Acherusia Chersonesos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ADANA" Text="Adana" Language="en_US" />
@@ -4060,7 +4065,7 @@
 		<Replace Tag="LOC_CITY_NAME_PTERIA" Text="Pteria" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PYLAE" Text="Pylæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PYLAI" Text="Pylai" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PYTHOPOLIS" Text="Pythopolis" Language="en_US" /> 
+		<Replace Tag="LOC_CITY_NAME_PYTHOPOLIS" Text="Pythopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SALAMIS" Text="Salamis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SARDEIS" Text="Sardeis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SARDIS" Text="Sardis" Language="en_US" />
@@ -4085,11 +4090,11 @@
 		<Replace Tag="LOC_CITY_NAME_TRIPOLIS_AD_MAEANDRUM" Text="Tripolis ad Mæandrum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TROY" Text="Troy" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TYANA" Text="Tyana" Language="en_US" />
-		
+
 	</LocalizedText>
-		
+
 	<LocalizedText>		<!-- CLASSICAL MIDDLE EAST (NORTH) (GREECE & ROME) -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_ACILISENE" Text="Acilisene" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ADATHA" Text="Adatha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALEXANDRIA_AD_ISSUM" Text="Alexandria ad Issum" Language="en_US" />
@@ -4147,16 +4152,16 @@
 		<Replace Tag="LOC_CITY_NAME_TRAPEZOUS" Text="Trapezous" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TRAPEZUS" Text="Trapezus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZEUGMA" Text="Zeugma" Language="en_US" />
-		
+
 	</LocalizedText>
-		
-		
+
+
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++++++ -->
 	<!-- Africa City Names: Default Layer (Modern) <en_US> -->
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++++++ -->
-	
+
 	<LocalizedText>		<!-- SUB-EQUATORIAL AFRICA -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_ALEXANDER_BAY" Text="Alexander Bay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALEXANDER_BAY_BOER" Text="Alexanderbaai" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALEXANDER_BAY_NETHERLANDS" Text="Alexanderbaai" Language="en_US" />
@@ -4181,8 +4186,8 @@
 		<Replace Tag="LOC_CITY_NAME_BELO_TSIRIBIHINA" Text="Belo Tsiribihina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BELO_TSIRIBIHINA_FRANCE" Text="Belo sur Tsiribihina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENGUELA" Text="Benguela" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENGUELA_BRAZIL" Text="Benguella" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENGUELA_PORTUGAL" Text="Benguella" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BENI" Text="Beni" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BETHANIE" Text="Bethanie" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BINGA" Text="Binga" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLOEMFONTEIN" Text="Bloemfontein" Language="en_US" />
@@ -4194,6 +4199,7 @@
 		<Replace Tag="LOC_CITY_NAME_BUKOBA" Text="Bukoba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BULAWAYO" Text="Bulawayo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUNKEYA" Text="Bunkeya" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUTEMBO" Text="Butembo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CABINDA" Text="Cabinda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CACOLO" Text="Cacolo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANDANGALA" Text="Candangala" Language="en_US" />
@@ -4235,6 +4241,7 @@
 		<Replace Tag="LOC_CITY_NAME_HARARE" Text="Harare" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HARARE_ENGLAND" Text="Salisbury" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HUAMBO" Text="Huambo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HUAMBO_BRAZIL" Text="Nova Lisboa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HUAMBO_PORTUGAL" Text="Nova Lisboa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HUMBE" Text="Humbe" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HWANGE" Text="Hwange" Language="en_US" />
@@ -4288,15 +4295,20 @@
 		<Replace Tag="LOC_CITY_NAME_KISANGANI_GERMANY" Text="Stanleystadt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KISANGANI_NETHERLANDS" Text="Stanleystad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KISMAYO" Text="Kismayo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KISMAYO_ARABIA" Text="Kīsmāyū" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KISMAYO_GREECE" Text="Nikon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KISMAYO_ROME" Text="Nicon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KISUMU" Text="Kisumu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KISUMU_ENGLAND" Text="Port Florence" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KITWE" Text="Kitwe" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KOLWEZI" Text="Kolwezi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KONGOLO" Text="Kongolo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUITO" Text="Kuito" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUITO_BRAZIL" Text="Silva Porto" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUITO_PORTUGAL" Text="Silva Porto" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KULE" Text="Kule" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUVANGO" Text="Kuvango" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUVANGO_BRAZIL" Text="Cuvango" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUVANGO_PORTUGAL" Text="Cuvango" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIBREVILLE" Text="Libreville" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIKASI" Text="Likasi" Language="en_US" />
@@ -4314,8 +4326,10 @@
 		<Replace Tag="LOC_CITY_NAME_LUANGWA" Text="Luangwa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUANGWA_ENGLAND" Text="Feira" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUAU" Text="Luau" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LUAU_BRAZIL" Text="Teixeira de Sousa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUAU_PORTUGAL" Text="Teixeira de Sousa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUBANGO" Text="Lubango" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LUBANGO_BRAZIL" Text="Sá da Bandeira" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUBANGO_PORTUGAL" Text="Sá da Bandeira" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUBEFU" Text="Lubefu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUBUMBASHI" Text="Lubumbashi" Language="en_US" />
@@ -4327,6 +4341,7 @@
 		<Replace Tag="LOC_CITY_NAME_LUBUTU" Text="Lubutu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUEDERITZ" Text="Lüderitz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUENA" Text="Luena" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LUENA_BRAZIL" Text="Luso" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUENA_PORTUGAL" Text="Luso" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUKOLELA" Text="Lukolela" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUSAKA" Text="Lusaka" Language="en_US" />
@@ -4346,6 +4361,7 @@
 		<Replace Tag="LOC_CITY_NAME_MANSA" Text="Mansa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANSA_ENGLAND" Text="Fort Roseberry" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MAPUTO" Text="Maputo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAPUTO_BRAZIL" Text="Lourenço Marques" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MAPUTO_PORTUGAL" Text="Lourenço Marques" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARIENTAL" Text="Mariental" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MASAKA" Text="Masaka" Language="en_US" />
@@ -4366,6 +4382,7 @@
 		<Replace Tag="LOC_CITY_NAME_MBANDAKA_GERMANY" Text="Coquilhatstadt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MBANDAKA_NETHERLANDS" Text="Coquilhatstad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MBANZA_KONGO" Text="Mbanza Kongo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MBANZA_KONGO_BRAZIL" Text="São Salvador" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MBANZA_KONGO_PORTUGAL" Text="São Salvador" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MBEYA" Text="Mbeya" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MBUJI_MAYI" Text="Mbuji-Mayi" Language="en_US" />
@@ -4381,6 +4398,7 @@
 		<Replace Tag="LOC_CITY_NAME_MPANDAMATENGA" Text="Mpandamatenga" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MPIKA" Text="Mpika" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MTWARA" Text="Mtwara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MTWARA_BRAZIL" Text="Montewara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MTWARA_PORTUGAL" Text="Montewara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MUCONDA" Text="Muconda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MUFULIRA" Text="Mufulira" Language="en_US" />
@@ -4394,11 +4412,13 @@
 		<Replace Tag="LOC_CITY_NAME_NACALA" Text="Nacala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAIROBI" Text="Nairobi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAMIBE" Text="Namibe" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAMIBE_BRAZIL" Text="Moçâmedes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAMIBE_PORTUGAL" Text="Moçâmedes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAMPULA" Text="Nampula" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NDOLA" Text="Ndola" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ONDANGWA" Text="Ondangwa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ONDJIVA" Text="Ondjiva" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ONDJIVA_BRAZIL" Text="Pereica de Eça" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ONDJIVA_PORTUGAL" Text="Pereica de Eça" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OPALA" Text="Opala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OPUWA" Text="Opuwa" Language="en_US" />
@@ -4407,6 +4427,7 @@
 		<Replace Tag="LOC_CITY_NAME_OWANDO" Text="Owando" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OWANDO_FRANCE" Text="Fort-Rousset" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PEMBA" Text="Pemba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PEMBA_BRAZIL" Text="Porto Amélia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PEMBA_PORTUGAL" Text="Porto Amélia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POLOKWANE" Text="Polokwane" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POLOKWANE_BOER" Text="Pietersburg" Language="en_US" />
@@ -4436,6 +4457,7 @@
 		<Replace Tag="LOC_CITY_NAME_SAMPWE" Text="Sampwe" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SANDOA" Text="Sandoa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAURIMO" Text="Saurimo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SAURIMO_BRAZIL" Text="Henrique de Carvalho" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAURIMO_PORTUGAL" Text="Henrique de Carvalho" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SEROWE" Text="Serowe" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SESFONTEIN" Text="Sesfontein" Language="en_US" />
@@ -4457,6 +4479,7 @@
 		<Replace Tag="LOC_CITY_NAME_TOLNARO" Text="Tôlnaro" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOLNARO_FRANCE" Text="Fort Dauphin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOMBWA" Text="Tômbwa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TOMBWA_BRAZIL" Text="Porto Alexandre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOMBWA_PORTUGAL" Text="Porto Alexandre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TRANOROA" Text="Tranoroa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TSAU" Text="Tsau" Language="en_US" />
@@ -4464,6 +4487,7 @@
 		<Replace Tag="LOC_CITY_NAME_TSHANE" Text="Tshane" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TSHIKAPA" Text="Tshikapa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UIGE" Text="Uíge" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_UIGE_BRAZIL" Text="Carmona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UIGE_PORTUGAL" Text="Carmona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UJIJI" Text="Ujiji" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UPINGTON" Text="Upington" Language="en_US" />
@@ -4472,6 +4496,7 @@
 		<Replace Tag="LOC_CITY_NAME_USAKOS" Text="Usakos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VICTORIA_FALLS" Text="Victoria Falls" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VILANKULO" Text="Vilankulo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_VILANKULO_BRAZIL" Text="Vilanculos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VILANKULO_PORTUGAL" Text="Vilanculos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WALVIS_BAY" Text="Walvis Bay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WALVIS_BAY_BOER" Text="Walvisbaai" Language="en_US" />
@@ -4480,6 +4505,7 @@
 		<Replace Tag="LOC_CITY_NAME_WINDHOEK" Text="Windhoek" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WINDHOEK_GERMANY" Text="Windhuk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_XAI_XAI" Text="Xai-Xai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_XAI_XAI_BRAZIL" Text="João Belo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_XAI_XAI_PORTUGAL" Text="João Belo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_XANGONGO" Text="Xangongo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YANGAMBI" Text="Yangambi" Language="en_US" />
@@ -4487,54 +4513,495 @@
 		<Replace Tag="LOC_CITY_NAME_ZANZIBAR" Text="Zanzibar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZOMBA" Text="Zomba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZUMBO" Text="Zumbo" Language="en_US" />
-		
+
 	</LocalizedText>
-	
-	<LocalizedText>		<!-- WESTERN NORTH AFRICA (MOROCCO, WESTERN SAHARA, MAURITANIA, & WESTERN ALGERIA) -->
-		
+
+	<LocalizedText>		<!-- CENTRAL & EAST AFRICA -->
+
+		<Replace Tag="LOC_CITY_NAME_ABECHE" Text="Abéché" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABECHE_ARABIA" Text="Abishī" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABUJA" Text="Abuja" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABYEI" Text="Abyei" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADDIS_ABABA" Text="Addis Ababa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADWA" Text="Adwa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AKETI" Text="Aketi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AKSUM" Text="Aksum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AKSUM_ENGLAND" Text="Axum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AKSUM_FRANCE" Text="Aksoum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AKSUM_GREECE" Text="Axoume" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AKSUM_ROME" Text="Axumis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AL_FASHIR" Text="Al Fashir" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AL_JUNAYNAH" Text="Al Junaynah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AM_DAFOK" Text="Am Dafok" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AM_TIMAN" Text="Am Timan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AM_TIMAN_ARABIA" Text="Umm Tīmān" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ARUA" Text="Arua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATBARA" Text="Atbara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATBARA_ARABIA" Text="Atbarah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATBARA_GREECE" Text="Abale" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATBARA_ROME" Text="Abale" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATI" Text="Ati" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWEIL" Text="Aweil" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BABANUSA" Text="Babanusa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAFIA" Text="Bafia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAFOUSSAM" Text="Bafoussam" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAHIR_DAR" Text="Bahir Dar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAIDOA" Text="Baidoa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAMBARI" Text="Bambari" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAMENDA" Text="Bamenda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BANGASSOU" Text="Bangassou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BANGUI" Text="Bangui" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARAH" Text="Barah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARAH_ROME" Text="Bara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARDERA" Text="Bardera" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARINGA" Text="Baringa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BASANKUSU" Text="Basankusu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BASOKO" Text="Basoko" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BATA" Text="Bata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYLA" Text="Bayla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYLA_ARABIA" Text="Bandar Beyla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYLA_GREECE" Text="Tave" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYLA_ROME" Text="Tave" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BELEDWEYNE" Text="Beledweyne" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENI" Text="Beni" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERBERA" Text="Berbera" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERBERA_GREECE" Text="Malao" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERBERA_ROME" Text="Malao" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERBERATI" Text="Berbérati" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERTOUA" Text="Bertoua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIDA" Text="Bida" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIEM" Text="Biem" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BLANGOUA" Text="Blangoua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BONGOR" Text="Bongor" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOSASO" Text="Bosaso" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOSASO_ARABIA" Text="Bandar Qasim" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOSASO_GREECE" Text="Mosylon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOSASO_ROME" Text="Mosullon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOUAR" Text="Bouar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BRIA" Text="Bria" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUMBA" Text="Bumba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUNIA" Text="Bunia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUTA" Text="Buta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMATURU" Text="Damaturu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DILA" Text="Dila" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DILLING" Text="Dilling" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DILLING_ARABIA" Text="al-Dalanj" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DILLING_EGYPT" Text="Dalang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DIRE_DAWA" Text="Dire Dawa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DIRE_DAWA_FRANCE" Text="Dire-Daoua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DJIBOUTI" Text="Djibouti" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DJIBOUTI_ENGLAND" Text="Djibouti City" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DJIBOUTI_FRANCE" Text="Ville de Djibouti" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DOUALA" Text="Douala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DOUALA_BRAZIL" Text="Rio dos Camarões" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DOUALA_ENGLAND" Text="Cameroons Town" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DOUALA_GERMANY" Text="Kamerunstadt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DOUALA_PORTUGAL" Text="Rio dos Camarões" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DUNGU" Text="Dungu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ED_DUEIM" Text="Ed Dueim" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ED_DUEIM_ARABIA" Text="Ad Duwaym" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ED_DUEIM_FRANCE" Text="Ad Douiem" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_DAEIN" Text="El Daein" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_OBEID" Text="El Obeid" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_OBEID_ARABIA" Text="Al Ubayyid" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ELAI" Text="Elai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ELDORET" Text="Eldoret" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EN_NAHUD" Text="En Nahud" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ENTEBBE" Text="Entebbe" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FANGAK" Text="Fangak" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FORT_PORTAL" Text="Fort Portal" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GALKAYO" Text="Galkayo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAMBELA" Text="Gambela" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAROUA" Text="Garoua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAROWE" Text="Garowe" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GASHUA" Text="Gashua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GEMENA" Text="Gemena" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GEREIDA" Text="Gereida" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GOMBE" Text="Gombe" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GONDAR" Text="Gondar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GOZ_BEIDA" Text="Goz Beïda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GULU" Text="Gulu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HADIBU" Text="Hadibu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HADIBU_ARABIA" Text="Hādībū" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HADIBU_GREECE" Text="Tamrida" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HADIBU_ROME" Text="Tamrida" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HAFUN" Text="Hafun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HAFUN_GREECE" Text="Opone" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HAFUN_ROME" Text="Opone" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HARAR" Text="Harar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HARGEISA" Text="Hargeisa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HEIS" Text="Heis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HEIS_GREECE" Text="Moundos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HEIS_ROME" Text="Mundus" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOBYO" Text="Hobyo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOBYO_GREECE" Text="Obbia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOBYO_ROME" Text="Obbia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_IDAH" Text="Idah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_IPPY" Text="Ippy" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_IMPFONDO" Text="Impfondo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ISIRO" Text="Isiro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JAMAME" Text="Jamame" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JINKA" Text="Jinka" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JUBA" Text="Juba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KADUQLI" Text="Kaduqli" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAMPALA" Text="Kampala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KANO" Text="Kano" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KASSALA" Text="Kassala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KASSALA_ITALY" Text="Cassala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KASSALA_ROME" Text="Cassala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KATSINA" Text="Katsina" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAYO_KEJI" Text="Kayo Keji" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARTOUM" Text="Khartoum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARTOUM_ARABIA" Text="al-Khartūm" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARTOUM_NORTH" Text="Khartoum North" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARTOUM_NORTH_ARABIA" Text="al-Khartūm Bahrī" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOBOKO" Text="Koboko" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KODOK" Text="Kodok" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KODOK_EGYPT" Text="Fashoda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KODOK_ENGLAND" Text="Fashoda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KODOK_FRANCE" Text="Fashoda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KODOK_GERMANY" Text="Fashoda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KODOK_ROME" Text="Fashoda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KODOK_SPAIN" Text="Fashoda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOSTI" Text="Kosti" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOUMRA" Text="Koumra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOUSSERI" Text="Kousséri" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KRIBI" Text="Kribi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUKAWA" Text="Kukawa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUMBA" Text="Kumba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUMBO" Text="Kumbo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUTUM" Text="Kutum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAFIA" Text="Lafia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LIRANGA" Text="Liranga" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LISALA" Text="Lisala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LODWAR" Text="Lodwar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LOKUTU" Text="Lokutu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LOKUTU_FRANCE" Text="Elisabetha" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAIDUGURU" Text="Maiduguru" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAJI" Text="Maji" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAKANZA" Text="Makanza" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAKANZA_BOER" Text="Nieu-Antwerpen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAKANZA_ENGLAND" Text="Bangala Station" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAKANZA_FRANCE" Text="Nouvelle-Anvers" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAKANZA_GERMANY" Text="Neu-Antwerpen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAKANZA_NETHERLANDS" Text="Nieuw-Antwerpen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAKOUA" Text="Makoua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAKURDI" Text="Makurdi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MALAKAL" Text="Malakal" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAO" Text="Mao" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAROUA" Text="Maroua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARSABIT" Text="Marsabit" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MASSAKORY" Text="Massakory" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MASSAWA" Text="Massawa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MASSAWA_EGYPT" Text="Adouli" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MASSAWA_GREECE" Text="Adoulis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MASSAWA_NUBIA" Text="Adouli" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MASSAWA_ROME" Text="Adulis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELFI" Text="Melfi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MERCA" Text="Merca" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MERCA_ARABIA" Text="Marka" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MERCA_GREECE" Text="Essina" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MERCA_ROME" Text="Essina" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MEROE" Text="Meroë" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MEROE_ARABIA" Text="Meruwah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MERU" Text="Meru" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOGADISHU" Text="Mogadishu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOGADISHU_GREECE" Text="Sarapion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOGADISHU_ROME" Text="Sarapion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MONGALLA" Text="Mongalla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MONGO" Text="Mongo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOUNDOU" Text="Moundou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOUSSORO" Text="Moussoro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NANGA_EBOKO" Text="Nanga-Eboko" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NASIR" Text="Nasir" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NDJAMENA" Text="N'Djamena" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NDJAMENA_ARABIA" Text="Injāmīnā" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NDJAMENA_ENGLAND" Text="Fort Lamy" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NDJAMENA_FRANCE" Text="Fort-Lamy" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEKEMTE" Text="Nekemte" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NGAOUNDERE" Text="Ngaoundéré" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NGUIGMI" Text="N'Guigmi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NIA_NIA" Text="Nia Nia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NIANGARA" Text="Niangara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NYALA" Text="Nyala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NZARA" Text="Nzara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OBO" Text="Obo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OMDURMAN" Text="Omdurman" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OMDURMAN_ARABIA" Text="Umm Durmān" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ONITSHA" Text="Onitsha" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUESSO" Text="Ouesso" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUM_HADJER" Text="Oum Hadjer" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OYEM" Text="Oyem" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_HARCOURT" Text="Port Harcourt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_HARCOURT_KONGO" Text="Iguocha" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_HARCOURT_ROME" Text="Portus Harcurtensis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_POKO" Text="Poko" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RABAK" Text="Rabak" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAFAI" Text="Rafaï" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAGA" Text="Raga" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAMCIEL" Text="Ramciel" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RENK" Text="Renk" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RUBKONA" Text="Rubkona" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RUMBEK" Text="Rumbek" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SARH" Text="Sarh" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SARH_FRANCE" Text="Fort Archambault" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SHENDI" Text="Shendi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SHENDI_ROME" Text="Summarum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SUAKIN" Text="Suakin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SUAKIN_ARABIA" Text="Sawákin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SUAKIN_EGYPT" Text="Limen Evangelis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SUAKIN_GREECE" Text="Limen Evangelis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SUAKIN_NUBIA" Text="Limen Evangelis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SUAKIN_ROME" Text="Limen Evangelis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TADJOURA" Text="Tadjoura" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TADJOURA_ARABIA" Text="Tajūrah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TORIT" Text="Torit" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_UMM_BADR" Text="Umm Badr" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_UMM_RUWABA" Text="Umm Ruwaba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YAGOUA" Text="Yagoua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YALINGA" Text="Yalinga" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YAMBIO" Text="Yambio" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YAO" Text="Yao" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YAOUNDE" Text="Yaoundé" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YAOUNDE_GERMANY" Text="Jaunde" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEI" Text="Yei" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YOKADOUMA" Text="Yokadouma" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WAU" Text="Wau" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZEILA" Text="Zeila" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZEILA_GREECE" Text="Avalites" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZEILA_ROME" Text="Avalites" Language="en_US" />
+
+	</LocalizedText>
+
+	<LocalizedText>		<!-- WEST AFRICA -->
+
+		<Replace Tag="LOC_CITY_NAME_ABENGOROU" Text="Abengorou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABEOKUTA" Text="Abeokuta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABIDJAN" Text="Abidjan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ACCRA" Text="Accra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AGADEZ" Text="Agadez" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AGADEZ_FRANCE" Text="Agadès" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANSONGO" Text="Ansongo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AOUDAGHOST" Text="Aoudaghost" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AOUDAGHOST_MALI" Text="Tegdaoust" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AOUDAGHOST_SONGHAI" Text="Tegdaoust" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ASABA" Text="Asaba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATAKPAME" Text="Atakpamé" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAMAKO" Text="Bamako" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAMBA" Text="Bamba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BANFORA" Text="Banfora" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BANJUL" Text="Banjul" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BANJUL_ENGLAND" Text="Bathurst" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BANORA" Text="Banora" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARANI" Text="Barani" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAWKU" Text="Bawku" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN" Text="Benin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_AMERICA" Text="Benin City" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_AUSTRALIA" Text="Benin City" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_BOER" Text="Benin-stad" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_BRAZIL" Text="Cidade do Benin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_ENGLAND" Text="Benin City" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_FRANCE" Text="Ville de Benin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_GERMANY" Text="Benin-Stadt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_INDONESIA" Text="Kota Benin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_NETHERLANDS" Text="Benin-Stad" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_NORWAY" Text="Beninborg" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_PORTUGAL" Text="Cidade do Benin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_ROME" Text="Urbs Beninensis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENIN_SPAIN" Text="Ciudad de Benín" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIRNIN_KONNI" Text="Birnin Konni" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BISSAU" Text="Bissau" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOBO_DIOULASSO" Text="Bobo-Dioulasso" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOHICON" Text="Bohicon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BONDOUKOU" Text="Bondoukou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOUAKE" Text="Bouaké" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOUGOUNI" Text="Bougouni" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOUNA" Text="Bouna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOUREM" Text="Bourem" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOUTILIMIT" Text="Boutilimit" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAPE_COAST" Text="Cape Coast" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAPE_COAST_BRAZIL" Text="Cabo Corso" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAPE_COAST_PORTUGAL" Text="Cabo Corso" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAPE_COAST_NORWAY" Text="Carolusborg" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAPE_COAST_SWEDEN" Text="Carolusborg" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CONAKRY" Text="Conakry" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_COTONOU" Text="Cotonou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAKAR" Text="Dakar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMBAI" Text="Dambai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DEDOUGOU" Text="Dédougou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DIAFARABE" Text="Diafarabé" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DIRE" Text="Diré" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DJENNE" Text="Djenné" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DJOUGOU" Text="Djougou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FILINGUE" Text="Filingué" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FREETOWN" Text="Freetown" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FREETOWN_ROME" Text="Urbs Libera" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAO" Text="Gao" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAYA" Text="Gaya" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GOSSI" Text="Gossi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GOUNDAM" Text="Goundam" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GUECKEDOU" Text="Guéckédou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HO" Text="Ho" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOHOE" Text="Hohoe" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_IBADAN" Text="Ibadan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_IFE" Text="Ife" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ILORIN" Text="Ilorin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_INEKAR" Text="Inékar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KADUNA" Text="Kaduna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAEDI" Text="Kaédi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KANKAN" Text="Kankan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KARA" Text="Kara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KATIOLA" Text="Katiola" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAYA" Text="Kaya" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAYES" Text="Kayes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KETE_KRACHI" Text="Kete Krachi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KINDIA" Text="Kindia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KIRCHAMBA" Text="Kirchamba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOLDA" Text="Kolda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOLDA_FRANCE" Text="Haute Casamance" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KORHOGO" Text="Korhogo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KORO" Text="Koro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOULIKORO" Text="Koulikoro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOUTIALA" Text="Koutiala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KPONG" Text="Kpong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUMASI" Text="Kumasi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUMBI_SALEH" Text="Kumbi Saleh" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUMBI_SALEH_FRANCE" Text="Koumbi Saleh" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LABE" Text="Labé" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAGOS" Text="Lagos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAGOS_ROME" Text="Lacupolis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LOKOJA" Text="Lokoja" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LOME" Text="Lomé" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAHINA" Text="Mahina" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MALANVILLE" Text="Malanville" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MAN" Text="Man" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MATAM" Text="Matam" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MENAKA" Text="Ménaka" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOKWA" Text="Mokwa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MONROVIA" Text="Monrovia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOPTI" Text="Mopti" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NIAMEY" Text="Niamey" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NIKKI" Text="Nikki" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NIONO" Text="Niono" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NKAWKAW" Text="Nkawkaw" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NOUAKCHOTT" Text="Nouakchott" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NZEREKORE" Text="Nzérékoré" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ODIENNE" Text="Odienné" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OGBOMOSHO" Text="Ogbomosho" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUADANE" Text="Ouadane" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUADANE_ARABIA" Text="Wādān" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUAGADOUGOU" Text="Ouagadougou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUAGADOUGOU_ENGLAND" Text="Wagadugu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUAGADOUGOU_POLAND" Text="Wagadugu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUAHIGOUYA" Text="Ouahigouya" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUALLAM" Text="Ouallam" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OWO" Text="Owo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OYO" Text="Oyo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PARAKOU" Text="Parakou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PATEGI" Text="Pategi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PODOR" Text="Podor" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORTO_NOVO" Text="Porto Novo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORTO_NOVO_FRANCE" Text="Porto-Novo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORTO_NOVO_ROME" Text="Portus Novus" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_POUYTENGA" Text="Pouytenga" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PRAIA" Text="Praia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SAN" Text="San" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SAN_PEDRO" Text="San-Pédro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SANDARE" Text="Sandare" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SAREYAMOU" Text="Sareyamou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEGBANA" Text="Ségbana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEGOU" Text="Ségou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEGUELA" Text="Séguéla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEKONDI_TAKORADI" Text="Sekondi-Takoradi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEKONDI_TAKORADI_BOER" Text="Fort Oranje" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEKONDI_TAKORADI_ENGLAND" Text="Fort Sekondi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEKONDI_TAKORADI_NETHERLANDS" Text="Fort Oranje" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEREKUNDA" Text="Serekunda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEREKUNDA_FRANCE" Text="Serrekunda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIKASSO" Text="Sikasso" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOKOTO" Text="Sokoto" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAHOUA" Text="Tahoua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAKEDDA" Text="Takedda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMALE" Text="Tamale" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMBACOUNDA" Text="Tambacounda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TECHIMAN" Text="Techiman" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TESSIT" Text="Tessit" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TIMBUKTU" Text="Timbuktu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TIMBUKTU_FRANCE" Text="Tombouctou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TIMBUKTU_ROME" Text="Tombutum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TIMBUKTU_SONGHAI" Text="Tombouctou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TOUGAN" Text="Tougan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WA" Text="Wa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WALATA" Text="Walata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WALATA_FRANCE" Text="Oualata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YAMOUSSOUKRO" Text="Yamoussoukro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEJI" Text="Yeji" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YELWA_YAURI" Text="Yelwa Yauri" Language="en_US" />
+
+	</LocalizedText>
+
+	<LocalizedText>		<!-- WESTERN NORTH AFRICA (NORTHERN MAURITANIA & MALI, MOROCCO, & ALGERIA) -->
+
 		<Replace Tag="LOC_CITY_NAME_ABADLA" Text="Abadla" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ADRAR" Text="Adrar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AGADIR" Text="Agadir" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AIN_BEN_TILI" Text="Ain Ben Tili" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AIN_BNI_MATHAR" Text="Ain bni mathar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AIN_BNI_MATHAR" Text="Ain Bni Mathar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_MAHBES" Text="Al Mahbes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AOUFOUS" Text="Aoufous" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ARAWAN" Text="Arawan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ARAWAN_FRANCE" Text="Araouane" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ARAWAN_SONGHAI" Text="Araouane" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ARRECIFE" Text="Arrecife" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ASSA" Text="Assa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ATAR" Text="Atar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AZILAL" Text="Azilal" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AZROU" Text="Azrou" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BECHAR" Text="Béchar" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BENI_MELLAL" Text="Beni-Mellal" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENI_ABBES" Text="Béni Abbès" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENI_MELLAL" Text="Béni Mellal" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENI_OUNIF" Text="Béni Ounif" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BERRECHID" Text="Berrechid" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIR_LEULOU" Text="Bir Leulou" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIR_MOGHREIN" Text="Bir Moghrein" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOUARFA" Text="Bouarfa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOUCRAA" Text="Boucraa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CASABLANCA" Text="Casablanca" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CASABLANCA_ARABIA" Text="ad-Dar al-Bayda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CASABLANCA_PORTUGAL" Text="Casa Branca" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHEFCHAOUEN" Text="Chefchaouen" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_CHEFCHAOUEN_ROME" Text="Banasa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHEFCHAOUEN_ARABIA" Text="Shafshāwan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHEFCHAOUEN_ROME" Text="Iulia Valentia Banasa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHICHAOUA" Text="Chichaoua" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHOUM" Text="Choum" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_EL_AAIUN" Text="El-Aaiún" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_HANK" Text="El Hank" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_JADIDA" Text="El Jadida" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_JADIDA_BRAZIL" Text="Mazagão" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_JADIDA_PORTUGAL" Text="Mazagão" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_JADIDA_ROME" Text="Rutubis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_JADIDA_SPAIN" Text="Mazagan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_MENZEL" Text="El Menzel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ERFOUD" Text="Erfoud" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ERFOUD_ARABIA" Text="Arfud" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ERFOUD_FRANCE" Text="Arfoud" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ERG_IGUIDI" Text="Erg Iguidi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ERRACHIDIA" Text="Errachidia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ERRACHIDIA_ARABIA" Text="ar-Rachīdīya" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ESSAOUIRA" Text="Essaouira" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FDERIK" Text="Fderik" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_FES" Text="Fes" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_FES_ROME" Text="Volubilis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FEZ" Text="Fez" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FEZ_FRANCE" Text="Fès" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FIGUIG" Text="Figuig" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FUNCHAL" Text="Funchal" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GOULMIMA" Text="Goulmima" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GUELMIM" Text="Guelmim" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GUERCIF" Text="Guercif" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HAMAGUIR" Text="Hamaguir" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HOCEIMA" Text="Hoceima" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOCEIMA_ARABIA" Text="Al Hoceima" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOCEIMA_FRANCE" Text="Al Hoceïma" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOCEIMA_PORTUGAL" Text="Villa Alhucemas" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOCEIMA_SPAIN" Text="Villa Sanjurjo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ICHT" Text="Icht" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IGLI" Text="Igli" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IMLIL" Text="Imlil" Language="en_US" />
@@ -4547,34 +5014,82 @@
 		<Replace Tag="LOC_CITY_NAME_KHENIFRA" Text="Khenifra" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KHOURIBGA" Text="Khouribga" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KSAR_ES_SOUK" Text="Ksar Es Souk" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAAYOUNE" Text="Laâyoune" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAAYOUNE_ARABIA" Text="El-Aiun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAAYOUNE_BOER" Text="Al-Ajoen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAAYOUNE_BRAZIL" Text="El Aiune" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAAYOUNE_NETHERLANDS" Text="Al-Ajoen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAAYOUNE_POLAND" Text="Al-Ujun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAAYOUNE_PORTUGAL" Text="El Aiune" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAAYOUNE_SPAIN" Text="El-Aaiún" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAS_PALMAS_DE_GRAN_CANARIA" Text="Las Palmas de Gran Canaria" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAS_PALMAS_DE_GRAN_CANARIA_ROME" Text="Palmæ Canariæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIXUS" Text="Lixus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MAHBES" Text="Mahbés" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARRAKECH" Text="Marrakech" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARRAKECH_ARABIA" Text="Murrākuš" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARRAKECH_BOER" Text="Marrakesj" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARRAKECH_BRAZIL" Text="Marraquexe" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARRAKECH_GERMANY" Text="Marrakesch" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARRAKECH_NETHERLANDS" Text="Marrakesj" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARRAKECH_POLAND" Text="Marrakesz" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARRAKECH_PORTUGAL" Text="Marraquexe" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARRAKECH_ROME" Text="Marochium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MEKNES" Text="Meknes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MEKNES_GREECE" Text="Volubilis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MEKNES_ROME" Text="Volubilis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELILLA" Text="Melilla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELILLA_ARABIA" Text="Maliliyyah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELILLA_CARTHAGE" Text="Rus-Adir" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELILLA_GREECE" Text="Russadeiron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELILLA_MACEDON" Text="Russadeiron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELILLA_ROME" Text="Rusadir" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MIDELT" Text="Midelt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NADOR" Text="Nador" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_NADOR_ROME" Text="Rusadir" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_NADOR_SPAIN" Text="Melilla" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_OUADANE" Text="Ouadane" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OUARZAZATE" Text="Ouarzazate" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OUJDA" Text="Oujda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OUJDA_ROME" Text="Numerus Syrorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OULMES" Text="Oulmes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OUM_EL_ASSEL" Text="Oum El Assel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RABAT" Text="Rabat" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_RABAT_ROME" Text="Sala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RABAT_CARTHAGE" Text="Sala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RABAT_GREECE" Text="Sala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RABAT_ROME" Text="Sala Colonia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAFI" Text="Safi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SALE" Text="Sale" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SALE_ROME" Text="Sala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SALE_CARTHAGE" Text="Sala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SALE_GREECE" Text="Sala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SALE_ROME" Text="Sala Colonia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAMARA" Text="Samara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SANTA_CRUZ_DE_TENERIFE" Text="Santa Cruz de Tenerife" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SANTA_CRUZ_DE_TENERIFE_ROME" Text="Sancta Crux Nivariæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SEFROU" Text="Sefrou" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SETTAT" Text="Settat" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIJILMASA" Text="Sijilmasa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIJILMASA_FRANCE" Text="Sijilmassa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIJILMASA_GERMANY" Text="Sidschilmasa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TABALBALA" Text="Tabalbala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TAFRAOUTE" Text="Tafraoute" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAGHAZA" Text="Taghaza" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TAGHIT" Text="Taghit" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMDOULT" Text="Tamdoult" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMDOULT_ARABIA" Text="Tamdlt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMDOULT_ENGLAND" Text="Tamdult" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMDOULT_FRANCE" Text="Tamedoult" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMENTIT" Text="Tamentit" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TANGIER" Text="Tangier" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANGIER_ARABIA" Text="Tanjah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANGIER_BRAZIL" Text="Tânger" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANGIER_CARTHAGE" Text="Tingi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANGIER_ENGLAND" Text="Tangiers" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANGIER_FRANCE" Text="Tanger" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANGIER_GREECE" Text="Tingis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANGIER_SPAIN" Text="Tánger" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANGIER_PORTUGAL" Text="Tânger" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TANGIER_ROME" Text="Tingis" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TAN_TAN" Text="Tan-tan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAN_TAN" Text="Tan-Tan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAOUDENNI" Text="Taoudenni" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAOUDENNI_MALI" Text="Taudeni" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TAOUNATE" Text="Taounate" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TAROUDANNT" Text="Taroudannt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TATA" Text="Tata" Language="en_US" />
@@ -4587,6 +5102,8 @@
 		<Replace Tag="LOC_CITY_NAME_TIGHMERT" Text="Tighmert" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TIMICHA" Text="Timicha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TINDUF" Text="Tinduf" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TINDUF_ARABIA" Text="Tindūf" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TINDUF_FRANCE" Text="Tindouf" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TINFOUCHY" Text="Tinfouchy" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TINGHIR" Text="Tinghir" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TIRIS_ZEMMOUR" Text="Tiris Zemmour" Language="en_US" />
@@ -4595,17 +5112,28 @@
 		<Replace Tag="LOC_CITY_NAME_TOURZA" Text="Tourza" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZERHAMRA" Text="Zerhamra" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZOUERAT" Text="Zouérat" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- CENTRAL NORTH AFRICA (ALGERIA, TUNISIA, & NORTHERN LIBYA) -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_AIN_BEIDA" Text="Ain Beida" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AIN_BEIDA_ROME" Text="Tipasa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AIN_OUSSERA" Text="Ain Oussera" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AIN_SALAH" Text="Ain Salah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AIN_SEFRA" Text="Ain Sefra" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALGIERS" Text="Algiers" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ALGIERS_ROME" Text="Cæsarea Mauretaniæ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_ARABIA" Text="Dzayer" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_BRAZIL" Text="Argel" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_CARTHAGE" Text="Ikosim" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_FRANCE" Text="Alger" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_GERMANY" Text="Algier" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_GREECE" Text="Ikosion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_NORWAY" Text="Alger" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_POLAND" Text="Algier" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_PORTUGAL" Text="Argel" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_ROME" Text="Icosium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALGIERS_SPAIN" Text="Argel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALI_MENDJELI" Text="Ali Mendjeli" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALI_MENDJELI_ROME" Text="Civitas Nattabutum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALRIYAYNA" Text="Alriyayna" Language="en_US" />
@@ -4614,12 +5142,21 @@
 		<Replace Tag="LOC_CITY_NAME_AL_JAWSH" Text="Al Jawsh" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_JAWSH_ROME" Text="Tillibari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_KHUMS" Text="Al Khums" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AL_KHUMS_CARTHAGE" Text="Leptis Magna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_KHUMS_GREECE" Text="Leptis Magna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_KHUMS_ROME" Text="Leptis Magna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_QAYRAWAN" Text="Al-Qayrawan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_QAYRAWAN_ROME" Text="Hadrumentum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ANNABA" Text="Annaba" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANNABA_CARTHAGE" Text="Hippo Regius" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANNABA_FRANCE" Text="Bône" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANNABA_GREECE" Text="Hippone" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ANNABA_ROME" Text="Hippo Regius" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AQUAE_CALIDAE" Text="Aquæ Calidæ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWAYNAT" Text="Awaynat" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWAYNAT_ARABIA" Text="Al Awaynat" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWAYNAT_EGYPT" Text="el-Auenat" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWAYNAT_ROME" Text="Serdeles" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANI_WALID" Text="Bani Walid" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANI_WALID_ROME" Text="Thenadassa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARIKA" Text="Barika" Language="en_US" />
@@ -4627,37 +5164,93 @@
 		<Replace Tag="LOC_CITY_NAME_BATNA" Text="Batna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BATNA_ROME" Text="Diana Veteranorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BEJAIA" Text="Béjaïa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BEJAIA_ARABIA" Text="Bijāyah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BEJAIA_BRAZIL" Text="Bugia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BEJAIA_CARTHAGE" Text="Saldæ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BEJAIA_FRANCE" Text="Bougie" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BEJAIA_GERMANY" Text="Budschaja" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BEJAIA_ITALY" Text="Bugia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BEJAIA_PORTUGAL" Text="Bugia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BEJAIA_ROME" Text="Saldæ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BEJAIA_SPAIN" Text="Bugía" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENOUD" Text="Benoud" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BISKRA" Text="Biskra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BISKRA_CARTHAGE" Text="Vescera" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BISKRA_ROME" Text="Vescera" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIZERTA" Text="Bizerta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIZERTA_ARABIA" Text="Banzart" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIZERTA_CARTHAGE" Text="Hippo Acra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIZERTA_FRANCE" Text="Bizerte" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIZERTA_GREECE" Text="Hippo Diarrhytos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIZERTA_ROME" Text="Hippo Diarrhytus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLIDA" Text="Blida" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BLIDA_ROME" Text="Aquæ Calidæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BORDJ_BOU_ARRERIDJ" Text="Bordj Bou Arreridj" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BORDJ_BOU_ARRERIDJ_ROME" Text="Ad Sava Municipium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BORDJ_OMAR_DRISS" Text="Bordj Omar Driss" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BORJ_EL_KHADRA" Text="Borj El Khadra" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BORJ_EL_KHADRA_GARAMANTES" Text="Garama" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BORJ_EL_KHADRA_FRANCE" Text="Fort Saint" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOU_SAADA" Text="Bou Saada" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BREZINA" Text="Brézina" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHERCHELL" Text="Cherchell" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHERCHELL_ARABIA" Text="Sharshal" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHERCHELL_CARTHAGE" Text="Iol" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHERCHELL_GREECE" Text="Iol Kaisáreia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHERCHELL_ROME" Text="Cæsarea Mauretaniæ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHLEF" Text="Chlef" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHLEF_ARABIA" Text="Al-Asnam" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHLEF_FRANCE" Text="Orléansville" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHLEF_ROME" Text="Castellum Tingitanum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COLLO" Text="Collo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COLLO_ROME" Text="Chullu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CONSTANTINE" Text="Constantine" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_CONSTANTINE_ROME" Text="Cirta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CONSTANTINE_ARABIA" Text="Qusantina" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CONSTANTINE_BYZANTIUM" Text="Constantina Cirtensium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CONSTANTINE_CARTHAGE" Text="Cirta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CONSTANTINE_GREECE" Text="Kirta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CONSTANTINE_ROME" Text="Cirta Sittianorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DEBDEB" Text="Debdeb" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DJELFA" Text="Djelfa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DOUAR_EL_MA" Text="Douar El Ma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_BADIYAH" Text="El Badiyah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_BAYADH" Text="El Bayadh" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_BAYADH_FRANCE" Text="Géryville" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_BORMA" Text="El Borma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_EULMA" Text="El Eulma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_EULMA_ROME" Text="Cuicul" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_GUERRARA" Text="El Guerrara" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_EL_MENIA" Text="El Menia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_GUERRARA_ARABIA" Text="al-Qarārah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_MENIA" Text="El Ménia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_MENIA_FRANCE" Text="El Goléa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_OUED" Text="El Oued" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_OUED_FRANCE" Text="Oued Souf" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ESSOUK" Text="Essouk" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ESSOUK_ARABIA" Text="Tadmekka" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ESSOUK_MALI" Text="Tadmekka" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ESSOUK_SONGHAI" Text="Tadmekka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FOGGARET_EZ_ZOUA" Text="Foggaret Ez Zoua" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GABES" Text="Gabes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GABES_ARABIA" Text="Gābis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GABES_CARTHAGE" Text="Tacape" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GABES_FRANCE" Text="Gabès" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GABES_GREECE" Text="Takape" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GABES_ROME" Text="Tacapæ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAFSA" Text="Gafsa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAFSA_CARTHAGE" Text="Capsa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAFSA_ROME" Text="Capsa Iustiniana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GASSI_EL_AGREB" Text="Gassi El Agreb" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GHADAMES" Text="Ghadames" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GHADAMES_ARABIA" Text="Gadamis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHADAMES_BRAZIL" Text="Gadamés" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHADAMES_CARTHAGE" Text="Cydamus" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHADAMES_GREECE" Text="Kydamos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHADAMES_PORTUGAL" Text="Gadamés" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GHADAMES_ROME" Text="Cidamus" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GHARDAIA" Text="Ghardaia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHADAMES_SPAIN" Text="Gadamés" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHARDAIA" Text="Ghardaïa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GHARYAN" Text="Gharyan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHARYAN_GREECE" Text="Garian" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHARYAN_ROME" Text="Garian" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GHAT" Text="Ghat" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRAND_ERG_OCCIDENTAL" Text="Grand Erg Occidental" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRAND_ERG_ORIENTAL" Text="Grand Erg Oriental" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GUELMA" Text="Guelma" Language="en_US" />
@@ -4666,50 +5259,112 @@
 		<Replace Tag="LOC_CITY_NAME_HASSI_BEL_GUEBBOUR" Text="Hassi Bel Guebbour" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HASSI_FEHAL" Text="Hassi Fehal" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HASSI_MESSAOUD" Text="Hassi Messaoud" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_IDLES" Text="Idlès" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ILLIZI" Text="Illizi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JEBIL" Text="Jebil" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KEBILI" Text="Kébili" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KEBILI_ARABIA" Text="Qibilī" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KEBILI_CARTHAGE" Text="Turres Tamalleni" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KEBILI_ROME" Text="Turres Tamalleni" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHENCHELA" Text="Khenchela" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHENCHELA_CARTHAGE" Text="Mascula" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHENCHELA_ROME" Text="Mascula Tiberia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LAGHOUAT" Text="Laghouat" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAGHOUAT_ENGLAND" Text="Laghwat" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANSOURA" Text="Mansoura" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_MECHERIA" Text="Mecheria" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MECHERIA" Text="Mécheria" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MEDEA" Text="Médéa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MEDEA_ROME" Text="Medix" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MERIXEN" Text="Merixen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MESSAAD" Text="Messaad" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MESSAAD_CARTHAGE" Text="Castellum Dimmidi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MESSAAD_ROME" Text="Castellum Dimmidi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MGUIDEN" Text="M'guiden" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MILA" Text="Mila" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MILA_GREECE" Text="Miraeon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MILA_ROME" Text="Milevum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MILIANA" Text="Miliana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MILIANA_CARTHAGE" Text="Zuccabar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MILIANA_GREECE" Text="Zouchábbari" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MILIANA_ROME" Text="Zucchabar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MISRATA" Text="Misrata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MISRATA_ARABIA" Text="Misurāta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MISRATA_CARTHAGE" Text="Thubactis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MISRATA_GREECE" Text="Thubactis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MISRATA_ROME" Text="Thubactis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MOGHRAR" Text="Moghrar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOSTAGANEM" Text="Mostaganem" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOSTAGANEM_CARTHAGE" Text="Quiza Xenitana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOSTAGANEM_GREECE" Text="Quiza Xenitana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MOSTAGANEM_ROME" Text="Quiza Cenitana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MSALLATA" Text="Msallata" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MSILA" Text="M'Sila" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MSILA_ROME" Text="Zabi Iustiniana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAAMA" Text="Naama" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NALUT" Text="Nalut" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NALUT_FRANCE" Text="Nalout" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NALUT_CARTHAGE" Text="Tabuinati" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NALUT_ROME" Text="Tabuinati" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEGRINE" Text="Negrine" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEGRINE_CARTHAGE" Text="Casæ Nigræ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEGRINE_ROME" Text="Casæ Nigræ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ORAN" Text="Oran" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ORAN_ROME" Text="Siga" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ORAN_ARABIA" Text="Wahrān" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OUARGLA" Text="Ouargla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORTUS_SIGENSIS" Text="Portus Sigensis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAPIDUM" Text="Rapidum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_REMADA" Text="Remada" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_REMADA_ROME" Text="Tillibari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAIDA" Text="Saida" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAIDA_ROME" Text="Regiæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SETIF" Text="Setif" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SETIF_ROME" Text="Sitifis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SFAX" Text="Sfax" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SFAX_ARABIA" Text="Safāqis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SFAX_CARTHAGE" Text="Taparura" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SFAX_GREECE" Text="Saphakis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SFAX_ROME" Text="Thænæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIDI_AISSA" Text="Sidi Aissa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIDI_AISSA_ROME" Text="Auzia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIDI_BOUZID" Text="Sidi Bouzid" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIDI_BOUZID_ROME" Text="Sufetula" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIGA" Text="Siga" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SINAWIN" Text="Sinawin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SKIKDA" Text="Skikda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SKIKDA_CARTHAGE" Text="Rusicade" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SKIKDA_FRANCE" Text="Philippeville" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SKIKDA_GREECE" Text="Rusicade" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SKIKDA_ROME" Text="Rusicade" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOUK_AHRAS" Text="Souk Ahras" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOUK_AHRAS_ARABIA" Text="Sūq Ahrās" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOUK_AHRAS_CARTHAGE" Text="Tagast" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOUK_AHRAS_GREECE" Text="Thagaste" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOUK_AHRAS_ROME" Text="Thagaste" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STAH" Text="Stah" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TABAQAH" Text="Tabaqah" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TAMALOUS" Text="Tamalous" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TAMALOUS_ROME" Text="Rusicade" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TABAQA" Text="Tabaqa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TABAQA_ARABIA" Text="Tabaqah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TABAQA_FRANCE" Text="Toubga" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAIBET" Text="Taibet" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TAMANGHASSET" Text="Tamanghasset" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMENTFOUST" Text="Tamentfoust" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMENTFOUST_CARTHAGE" Text="Rusgunia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMENTFOUST_FRANCE" Text="La Pérouse" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMENTFOUST_GREECE" Text="Rusgunia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMENTFOUST_ROME" Text="Rusguniæ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMENTFOUST_SPAIN" Text="Matifou" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TATAOUINE" Text="Tataouine" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TATAOUINE_ROME" Text="Gigthis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TATAOUINE_CARTHAGE" Text="Tabalati" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TATAOUINE_ROME" Text="Tabalati" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TEBESSA" Text="Tebessa" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TEBESSA_GREECE" Text="Theveste" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TEBESSA_CARTHAGE" Text="Theveste" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TEBESSA_FRANCE" Text="Tébessa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TEBESSA_GREECE" Text="Hekatontapylon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TEBESSA_ROME" Text="Theveste" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TENES" Text="Ténès" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TENES_ARABIA" Text="Tinas" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TENES_CARTHAGE" Text="Cartenna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TENES_GREECE" Text="Karténnai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TENES_ROME" Text="Cartennæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TIARET" Text="Tiaret" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TIARET_ROME" Text="Tigava" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TLEMCEN" Text="Tlemcen" Language="en_US" />
@@ -4719,52 +5374,66 @@
 		<Replace Tag="LOC_CITY_NAME_TOZEUR" Text="Tozeur" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOZEUR_ROME" Text="Tusuros" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TRIPOLI" Text="Tripoli" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TRIPOLI_ARABIA" Text="Tarābulus al-Gharb" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TRIPOLI_CARTHAGE" Text="Oea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TRIPOLI_GREECE" Text="Oea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TRIPOLI_ROME" Text="Oea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TUNIS" Text="Tunis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TUNIS_CARTHAGE" Text="Carthage" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TUNIS_GREECE" Text="Karkhēdōn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TUNIS_ROME" Text="Carthago" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEFREN" Text="Yefren" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEFREN_ARABIA" Text="Ifrin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEFREN_ROME" Text="Auru" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZINTAN" Text="Zintan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZINTAN_ARABIA" Text="Al Zintan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZINTAN_CARTHAGE" Text="Tigharmin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZINTAN_GREECE" Text="Thenteos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZINTAN_ROME" Text="Thenteos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZUWARA" Text="Zuwara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZUWARA_ARABIA" Text="Zuwarah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZUWARA_CARTHAGE" Text="Sabrata" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZUWARA_GREECE" Text="Sabratha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZUWARA_ROME" Text="Sabratha" Language="en_US" />
-		
+
 	</LocalizedText>
-	
-	<LocalizedText>		<!-- LIBYA & EGYPT -->
-	
+
+	<LocalizedText>		<!-- EASTERN NORTH AFRICA (LIBYA & EGYPT) -->
+
+		<Replace Tag="LOC_CITY_NAME_ABU_HAMAD" Text="Abu Hamad" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABU_MINQAR" Text="Abu Minqar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABU_MINQAR_ARABIA" Text="Abū Minqār" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADDIA" Text="Addia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADIRI" Text="Adiri" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADIRI_ARABIA" Text="Adrī" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AGADEM" Text="Agadem" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AJDABIYA" Text="Ajdabiya" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AJDABIYA_GREECE" Text="Automala" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AJDABIYA_ROME" Text="Anabucis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AJDABIYA_ARABIA" Text="Ajdābiyā" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AJDABIYA_ITALY" Text="Agedábia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AJDABIYA_GREECE" Text="Corniclanum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AJDABIYA_ROME" Text="Corniclanum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALEXANDRIA" Text="Alexandria" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALEXANDRIA_ARABIA" Text="al-Iskandariyah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALEXANDRIA_EGYPT" Text="Râ-Kedet" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_BAYDA" Text="Al Bayda" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_BAYDA_EGYPT" Text="Cyrene" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_BAYDA_GREECE" Text="Kyrene" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_BAYDA_NUBIA" Text="Cyrene" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_BAYDA_ROME" Text="Cyrene" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AL_DABBAH" Text="Al Dabbah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AL_DABBAH_ROME" Text="Zamnes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_FUQAHA" Text="Al Fuqaha" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AL_FUQAHA_EGPYT" Text="El Foqaha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_HARRAH" Text="Al Harrah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_JAGHBUB" Text="Al_Jaghbub" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_JAWF" Text="Al Jawf" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_MAHALLAH" Text="Al Mahallah" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_MAHALLAH_EGYPT" Text="Tjebnutjer" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_MAHALLAH_GREECE" Text="Sebennytos" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_MAHALLAH_NUBIA" Text="Tjebnutjer" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AL_MAHALLAH_ROME" Text="Sebennytus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_MARJ" Text="Al Marj" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_MARJ_GREECE" Text="Barca" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AL_MARJ_ROME" Text="Barca" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AN_NAWFALIYAH" Text="An Nawfaliyah" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_APOLLONIA_CYRENAICA" Text="Apollonia Cyrenaica" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_APOLLONIA_CYRENAICA" Text="Apollonia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARISH" Text="Arish" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARISH_ARABIA" Text="El Arish" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARISH_EGYPT" Text="Sena" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARISH_GREECE" Text="Ostrakine" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARISH_NUBIA" Text="Sena" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARISH_ROME" Text="Ostium Pelusiacum" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ARSINOE_CYRENAICA" Text="Arsinoe Cyrenaica" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ARLIT" Text="Arlit" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ARSINOE_CYRENAICA" Text="Arsinoe" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ASH_SHWAYRIF" Text="Ash Shwayrif" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ASH_SHWAYRIF_ROME" Text="Gholaia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ASYUT" Text="Asyut" Language="en_US" />
@@ -4772,9 +5441,19 @@
 		<Replace Tag="LOC_CITY_NAME_ASYUT_GREECE" Text="Lykopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ASYUT_NUBIA" Text="Syawt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ASYUT_ROME" Text="Lycopolis" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AWJILAH" Text="Awjilah" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AWJILAH_ROME" Text="Augila" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATFIH" Text="Atfih" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATFIH_EGYPT" Text="Tpyhwt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATFIH_GREECE" Text="Aphroditopolis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATFIH_NUBIA" Text="Busiris" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATFIH_ROME" Text="Aphroditopolis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AOUZOU" Text="Aouzou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWJILA" Text="Awjila" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWJILA_ARABIA" Text="Awjilah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWJILA_GREECE" Text="Augila" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AWJILA_ROME" Text="Augila" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAHARIYA_OASIS" Text="Bahariya Oasis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAHARIYA_OASIS_ARABIA" Text="el-Wahat el-Bahariya" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAHARIYA_OASIS_GREECE" Text="Oasis Mirka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAHARIYA_OASIS_EGYPT" Text="Djesdjes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAHARIYA_OASIS_NUBIA" Text="Djesdjes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAHARIYA_OASIS_ROME" Text="Oasis Parva" Language="en_US" />
@@ -4783,33 +5462,124 @@
 		<Replace Tag="LOC_CITY_NAME_BALTIM_GREECE" Text="Buto" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BALTIM_NUBIA" Text="Per-Wadjet" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BALTIM_ROME" Text="Butosus" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARANIS" Text="Baranis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARANIS_ARABIA" Text="Bender el-Kebir" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARANIS_EGYPT" Text="Berenice Troglodytica" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARANIS_GREECE" Text="Berenike Troglodytai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARANIS_NUBIA" Text="Berenice Troglodytica" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARANIS_ROME" Text="Berenice Troglodytica" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARDAI" Text="Bardaï" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARIS" Text="Baris" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARIS_GREECE" Text="Kysis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARIS_ROME" Text="Kysis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYDA" Text="Bayda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYDA_ARABIA" Text="Al Baidā" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYDA_CARTHAGE" Text="Cyrene" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYDA_EGYPT" Text="Cyrene" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYDA_GREECE" Text="Kyrene" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYDA_NUBIA" Text="Cyrene" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BAYDA_ROME" Text="Cyrene" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENGHAZI" Text="Benghazi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENGHAZI_CARTHAGE" Text="Hesperides" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENGHAZI_GREECE" Text="Euesperides" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENGHAZI_ROME" Text="Hesperides" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENI_SUEF" Text="Beni Suef" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENI_SUEF_ARABIA" Text="Baniswēf" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENI_SUEF_EGYPT" Text="Henen-nesut" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENI_SUEF_GREECE" Text="Herakleópolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENI_SUEF_NUBIA" Text="Henen-nesut" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENI_SUEF_ROME" Text="Heracleopolis Magna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERBER" Text="Berber" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERBER_GREECE" Text="Scammos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERBER_ROME" Text="Scammos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BILMA" Text="Bilma" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BILTINE" Text="Biltine" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIN_JAWAD" Text="Bin Jawad" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIN_JAWAD_CARTHAGE" Text="Digdida" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIN_JAWAD_GREECE" Text="Digdida" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIN_JAWAD_ROME" Text="Digdida Selorum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIR_NATRUN" Text="Bir Natrun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOURO" Text="Bouro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BREGA" Text="Brega" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BREGA_ARABIA" Text="Marsā al Burayqah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BREGA_ROME" Text="Boreum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUZEMA" Text="Buzema" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUZEMA_ARABIA" Text="Buzaymah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAIRO" Text="Cairo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAIRO_EGYPT" Text="Memphis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAIRO_GREECE" Text="Memphis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAIRO_NUBIA" Text="Memphis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAIRO_SUMER" Text="Memphis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAIRO_ROME" Text="Memphis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CATARACTA_QUARTA" Text="Cataracta Quarta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CATARACTA_TERTIA" Text="Cataracta Tertia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMANHUR" Text="Damanhur" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMANHUR_ARABIA" Text="Damanhūr" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMANHUR_EGYPT" Text="Damanhūr" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMANHUR_FRANCE" Text="Damanhour" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMANHUR_GREECE" Text="Hermopolis Mikra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMANHUR_NUBIA" Text="Temenhor" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMANHUR_ROME" Text="Hermopolis Parva" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMIETTA" Text="Damietta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMIETTA_ARABIA" Text="Dumyāt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMIETTA_EGYPT" Text="Tamiat" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMIETTA_FRANCE" Text="Damiette" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMIETTA_GREECE" Text="Tamiathis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMIETTA_NUBIA" Text="Tamiat" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAMIETTA_ROME" Text="Tamiathis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DENDERA" Text="Dendera" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DENDERA_EGYPT" Text="Iunet" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DENDERA_GREECE" Text="Tentyra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DENDERA_NUBIA" Text="Tantere" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DENDERA_ROME" Text="Tentryris" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DERNA" Text="Derna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DERNA_ARABIA" Text="Dernah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DERNA_GREECE" Text="Dernis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DERNA_ROME" Text="Dernis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DIRJ" Text="Dirj" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DIRJ_ARABIA" Text="Derj" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DIRKOU" Text="Dirkou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DISHNA" Text="Dishna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DISHNA_EGPYT" Text="Sheneset" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DISHNA_GREECE" Text="Chenoboskion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DISHNA_NUBIA" Text="Sheneset" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DISHNA_ROME" Text="Chenoboscium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DJADO" Text="Djado" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DONGOLA" Text="Dongola" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EASTERN_DESERT" Text="Eastern Desert" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EDFU" Text="Edfu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EDFU_FRANCE" Text="Edfou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EDFU_GREECE" Text="Apollonopolis Magna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EDFU_ROME" Text="Apollonopolis Magna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_AGHEILA" Text="El Agheila" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_AGHEILA_CARTHAGE" Text="Automala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_AGHEILA_GREECE" Text="Automala" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_AGHEILA_ROME" Text="Anabucis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_MAHALLAH_EL_KUBRA" Text="El Mahallah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_MAHALLAH_EL_KUBRA_EGYPT" Text="Tjebnutjer" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_MAHALLAH_EL_KUBRA_GREECE" Text="Sebennytos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_MAHALLAH_EL_KUBRA_NUBIA" Text="Tjebnutjer" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_MAHALLAH_EL_KUBRA_ROME" Text="Sebennytus" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QASR" Text="El Qasr" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QASR_GREECE" Text="Trimithis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QASR_ROME" Text="Trimitheos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QUSEIR" Text="El Quseir" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QUSEIR_EGYPT" Text="Saww" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QUSEIR_GREECE" Text="Myos Hormos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QUSEIR_MACEDON" Text="Myos Hormos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QUSEIR_NUBIA" Text="Mersa Gawasis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_QUSEIR_ROME" Text="Leucus Limen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_SALLOUM" Text="El Salloum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_SALLOUM_ROME" Text="Catabathmus Maior" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_TAG" Text="El Tag" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EL_TAG_ARABIA" Text="at-Tāj" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_TOR" Text="El Tor" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_TOR_EGYPT" Text="Raithu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_TOR_GREECE" Text="Raithu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_TOR_NUBIA" Text="Raithu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EL_TOR_ROME" Text="Raithu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FACHI" Text="Fachi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FADA" Text="Fada" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FAIYUM" Text="Faiyum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FAIYUM_ARABIA" Text="El Fayyūm" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FAIYUM_EGYPT" Text="Shedet" Language="en_US" />
@@ -4817,29 +5587,69 @@
 		<Replace Tag="LOC_CITY_NAME_FAIYUM_NUBIA" Text="Shedet" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FAIYUM_ROME" Text="Arsinoë in Arcadia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FARAFRA" Text="Farafra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FARAFRA_ARABIA" Text="Qasr Al Farafra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FARAFRA_EGYPT" Text="Ana Akhet" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FARAFRA_NUBIA" Text="Ana Akhet" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FARAS" Text="Faras" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FARAS_EGYPT" Text="Phrse" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FARAS_GREECE" Text="Pakhoras" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FARAS_NUBIA" Text="Para" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FARAS_ROME" Text="Pachoras" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FAYA_LARGEAU" Text="Faya-Largeau" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GERMA" Text="Germa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GERMA_CARTHAGE" Text="Garama" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GERMA_EGYPT" Text="Garama" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GERMA_GARAMANTES" Text="Garama" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GERMA_GREECE" Text="Garama" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GERMA_NUBIA" Text="Garama" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GERMA_ROME" Text="Garama" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GILF_KEBIR_PLATEAU" Text="Gilf Kebir" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GILF_KEBIR_PLATEAU_ROME" Text="Kellis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GIZA" Text="Giza" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GIZA_ARABIA" Text="al-Jizah" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GIZA_GREECE" Text="Busiris" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GIZA_ROME" Text="Aphroditopolis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GOURE" Text="Gouré" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GUEREDA" Text="Guéréda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HOUN" Text="Houn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HURGHADA" Text="Hurghada" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_HURGHADA_EGYPT" Text="Saww" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_HURGHADA_NUBIA" Text="Mersa Gawasis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HURGHADA_ARABIA" Text="Al Ghardaqah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISMAILIA" Text="Ismalia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISMAILIA_EGYPT" Text="Heliopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISMAILIA_GREECE" Text="Heliopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISMAILIA_NUBIA" Text="Heliopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISMAILIA_ROME" Text="Heliopolis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ISMANT_EL_KHARAB" Text="Ismant el-Kharab" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ISMANT_EL_KHARAB_GREECE" Text="Kellis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ISMANT_EL_KHARAB_ROME" Text="Kellis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JAKHARRAH" Text="Jakharrah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JALU" Text="Jalu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JALU_ITALY" Text="Gialo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KARIMA" Text="Karima" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KARIMA_EGYPT" Text="Napata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KARIMA_GREECE" Text="Napata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KARIMA_NUBIA" Text="Napata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KARIMA_ROME" Text="Napata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARGA" Text="Kharga" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARGA_ARABIA" Text="El Kharga" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARGA_EGYPT" Text="Hebet" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARGA_ENGLAND" Text="Karga Oasis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARGA_GREECE" Text="Hibis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARGA_NUBIA" Text="Hebet" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KHARGA_ROME" Text="Hibeos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KORO_TORO" Text="Koro Toro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KORTI" Text="Korti" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KORTI_ROME" Text="Cortum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUFRA" Text="Kufra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUFRA_ARABIA" Text="Al Jawf" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUFRA_FRANCE" Text="Koufra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUFRA_ITALY" Text="Cufra" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KUFRA_ROME" Text="Cufra" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUXOR" Text="Luxor" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUXOR_ARABIA" Text="al-Uqsur" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUXOR_EGYPT" Text="Thebes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUXOR_GREECE" Text="Thebai" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUXOR_NUBIA" Text="Thebes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LUXOR_ROME" Text="Thebæ" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MADAMA" Text="Madama" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MALLAWI" Text="Mallawi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MALLAWI_EGYPT" Text="Akhetaten" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MALLAWI_GREECE" Text="Hermopolis" Language="en_US" />
@@ -4851,7 +5661,9 @@
 		<Replace Tag="LOC_CITY_NAME_MANSOURA_GREECE" Text="Mendes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANSOURA_NUBIA" Text="Djedet" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANSOURA_ROME" Text="Mendes" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_MARADAH" Text="Maradah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARADA" Text="Marada" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARADA_ARABIA" Text="Maradah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARADI" Text="Maradi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARINA_EL_ALAMEIN" Text="Marina El Alamein" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARINA_EL_ALAMEIN_GREECE" Text="Leukaspis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARINA_EL_ALAMEIN_ROME" Text="Antiphræ" Language="en_US" />
@@ -4862,33 +5674,73 @@
 		<Replace Tag="LOC_CITY_NAME_MARSA_MATRUH_ROME" Text="Parætonium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARTUBA" Text="Martuba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MECHILI" Text="Mechili" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MUT_EL_KHARAB" Text="Mut el-Kharab" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MUT_EL_KHARAB_GREECE" Text="Mothiton Polis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MUT_EL_KHARAB_ROME" Text="Mothis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAUCRATIS" Text="Naucratis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAUCRATIS_ARABIA" Text="Kom Gieif" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAUCRATIS_EGYPT" Text="Piemro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAUCRATIS_GREECE" Text="Naukratis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAUCRATIS_ITALY" Text="Naucrati" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAUCRATIS_NUBIA" Text="Piemro" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEKHEL" Text="Nekhel" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NGOURTI" Text="N'Gourti" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NURI" Text="Nuri" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OUNIANGA_KEBIR" Text="Ounianga Kébir" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORT_SAID" Text="Port Said" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PORT_SAID_ARABIA" Text="Borsa'id" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_SAID_ARABIA" Text="Būr Sa'īd" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORT_SAID_EGYPT" Text="Per-Amun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORT_SAID_GREECE" Text="Pelousion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORT_SAID_NUBIA" Text="Per-Amun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORT_SAID_ROME" Text="Pelusium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORT_SAID_SUMERIA" Text="Seyân" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_SUDAN" Text="Port Sudan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_SUDAN_ARABIA" Text="Bur Sudan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_SUDAN_EGYPT" Text="Ptolemais Theron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_SUDAN_FRANCE" Text="Port-Soudan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_SUDAN_GREECE" Text="Ptolemais Theron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_SUDAN_NUBIA" Text="Ptolemais Theron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORT_SUDAN_ROME" Text="Ptolemais Theron" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PTOLEMAIS" Text="Ptolemais" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QAMINIS" Text="Qaminis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QAMINIS_GREECE" Text="Chaminos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QAMINIS_ROME" Text="Chaminos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QARA_OASIS" Text="Qara Oasis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QARA_OASIS_ARABIA" Text="Qarat Umm El Sagheir" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QARA_OASIS_CARTHAGE" Text="Cara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QARA_OASIS_EGYPT" Text="Qarat Umm El Sagheir" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QARA_OASIS_GREECE" Text="Alexandrou Parembole" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QARA_OASIS_NUBIA" Text="Cara" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QARA_OASIS_ROME" Text="Alexandrou Parembole" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QATRUN" Text="Qatrun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QENA" Text="Qena" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QENA_BYZANTIUM" Text="Maximianopolis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QENA_GREECE" Text="Kaine" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QENA_ROME" Text="Cæne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QUS" Text="Qus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QUS_EGYPT" Text="Gesa" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_QUS_GREECE" Text="Apollonopolis Parva" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUS_GREECE" Text="Apollonopolis Mirka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QUS_NUBIA" Text="Gesa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QUS_ROME" Text="Apollonopolis Parva" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAS_GHARIB" Text="Ras Gharib" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAS_GHARIB_ARABIA" Text="Rās Gāreb" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAS_LANUF" Text="Ras Lanuf" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_RAS_LANUF_ROME" Text="Arae Philaenorum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAS_LANUF_CARTHAGE" Text="Aræ Philænorum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAS_LANUF_ROME" Text="Aræ Philænorum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_REBIANA" Text="Rebiana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SABHA" Text="Sabha" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SABHA_ARABIA" Text="Sabhā" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SABHA_FRANCE" Text="Sebha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAFAGA" Text="Safaga" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAFAGA_GREECE" Text="Philotera" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAFAGA_ROME" Text="Philotera" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SALAL" Text="Salal" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SALIMA_OASIS" Text="Salima Oasis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHARM_EL_SHEIKH" Text="Sharm El Sheikh" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIRTE" Text="Sirte" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIRTE_CARTHAGE" Text="Macomades" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIRTE_GREECE" Text="Euphranta" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SIRTE_ROME" Text="Euphranta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIRTE_ROME" Text="Macomades Selorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIWA_OASIS" Text="Siwa Oasis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIWA_OASIS_ARABIA" Text="Wāhat Sīwah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIWA_OASIS_GREECE" Text="Ammon" Language="en_US" />
@@ -4898,14 +5750,19 @@
 		<Replace Tag="LOC_CITY_NAME_SOHAG_GREECE" Text="Panopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOHAG_NUBIA" Text="Khent-min" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOHAG_ROME" Text="Panopolis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOKNA" Text="Sokna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOKNA_ARABIA" Text="Sawknah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOKNA_ROME" Text="Socna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SUEZ" Text="Suez" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SUEZ_GREECE" Text="Klysma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SUEZ_ROME" Text="Clysma" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TABELOT" Text="Tabelot" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TANTA" Text="Tanta" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TANTA_GREECE" Text="Naukratis" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TANTA_ROME" Text="Naucratis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TAZIRBU" Text="Tazirbu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TMASSA" Text="Tmassa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TMASSA_ARABIA" Text="Tmassah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOBRUK" Text="Tobruk" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TOBRUK_ARABIA" Text="Tubruq" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOBRUK_GREECE" Text="Antipyrgos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOBRUK_ROME" Text="Antipyrgus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOD" Text="Tod" Language="en_US" />
@@ -4914,34 +5771,46 @@
 		<Replace Tag="LOC_CITY_NAME_TOD_GREECE" Text="Touphion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOD_NUBIA" Text="Djerty" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOD_ROME" Text="Tuphium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_UBARI" Text="Ubari" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_UBARI_ARABIA" Text="Awbari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UMM_RIZAM" Text="Umm Rizam" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UMM_RIZAM_GREECE" Text="Dionysos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UMM_RIZAM_ROME" Text="Dionysus" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WADDAN" Text="Waddan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WADI_HALFA" Text="Wadi Halfa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WADI_HALFA_GREECE" Text="Primis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WADI_HALFA_NUBIA" Text="Pedeme" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WADI_HALFA_ROME" Text="Primis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WHITE_DESERT" Text="White Desert" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WHITE_DESERT_ARABIA" Text="Sahara el Beyda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WHITE_DESERT_EGPYT" Text="Ana Akhet" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZAAFARANA" Text="Zaafarana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZALTAN" Text="Zaltan" Language="en_US" />
-		
+		<Replace Tag="LOC_CITY_NAME_ZELLA" Text="Zella" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZELLA_ARABIA" Text="Zillah" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZINDER" Text="Zinder" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZINDER_FRANCE" Text="Fort Cazemajou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ZOUAR" Text="Zouar" Language="en_US" />
+
 	</LocalizedText>
-	
-	
+
+
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 	<!-- Asia-Pacific City Names: Default Layer (Modern) <en_US> -->
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-	
-	
+
+
 	<LocalizedText>		<!-- SOUTH PACIFIC ISLANDS -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_FIJI" Text="Fiji" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HONIARA" Text="Honiara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOUMEA" Text="Noumea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAMOA" Text="Samoa" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- AOTEAROA/NEW ZEALAND -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_AUCKLAND" Text="Auckland" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLENHEIM" Text="Blenheim" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLUFF" Text="Bluff" Language="en_US" />
@@ -4967,11 +5836,11 @@
 		<Replace Tag="LOC_CITY_NAME_WHANGANUI" Text="Whanganui" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WHANGANUI_ENGLAND" Text="Wanganui" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WHANGAREI" Text="Whangarei" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- AUSTRALIA -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_ADELAIDE" Text="Adelaide" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALBANY" Text="Albany" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALBURY_WODONGA" Text="Albury-Wodonga" Language="en_US" />
@@ -5168,11 +6037,11 @@
 		<Replace Tag="LOC_CITY_NAME_YALATA" Text="Yalata" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YALSRA" Text="Yalsra" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YUENDUMU" Text="Yuendumu" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- PAPUA -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_AGATS" Text="Agats" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAIMURU" Text="Baimuru" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DARU" Text="Daru" Language="en_US" />
@@ -5193,11 +6062,11 @@
 		<Replace Tag="LOC_CITY_NAME_TELEFOMIN" Text="Telefomin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VANIMO" Text="Vanimo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WEWAK" Text="Wewak" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- SOUTH EAST ASIA -->
-		
+
 		<!-- VIETNAM, LAOS, MYANMAR, THAILAND & CAMBODIA -->
 		<Replace Tag="LOC_CITY_NAME_NUJIANG" Text="Nujiang" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONYWA" Text="Monywa" Language="en_US" />
@@ -5298,7 +6167,7 @@
 		<Replace Tag="LOC_CITY_NAME_PALANGKA_RAYA" Text="Palangka Raya" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMUNTAI" Text="Amuntai" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PALOPO" Text="Palopo" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BENGKULU" Text="Bengkulu" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_BENGKULU" Text="Bengkulu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PALAU_JAMDENA" Text="Palau Jamdena" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PULUA_SIBERUT" Text="Pulua Siberut" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAMPIT" Text="Sampit" Language="en_US" />
@@ -5320,7 +6189,7 @@
 	</LocalizedText>
 
 	<LocalizedText>		<!-- INDIAN SUBCONTINENT -->
-		
+
 		<!-- INDIA, PAKISTAN, BANGLADESH, & SRI LANKA -->
 		<Replace Tag="LOC_CITY_NAME_MALAKAND" Text="Malakand" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ABBOTTABAD" Text="Abbottabad" Language="en_US" />
@@ -5427,15 +6296,15 @@
 		<Replace Tag="LOC_CITY_NAME_HOSHANGABAD" Text="Hoshangabad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAJNANDGAON" Text="Rajnandgaon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAIPUR" Text="Raipur" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SAMBALPUR" Text="Sambalpur" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_SAMBALPUR" Text="Sambalpur" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CUTTACK" Text="Cuttack" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SURAT" Text="Surat" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DHULE" Text="Dhule" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AMRAVATI" Text="Amravati" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_AMRAVATI" Text="Amravati" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAGPUR" Text="Nagpur" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRAHMAPUR" Text="Brahmapur" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NASHIK" Text="Nashik" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_AURANGABAD" Text="Aurangabad" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_AURANGABAD" Text="Aurangabad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NANDED" Text="Nanded" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KARIMNAGAR" Text="Karimnagar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAJAHMUNDRY" Text="Rajahmundry" Language="en_US" />
@@ -5459,11 +6328,11 @@
 		<Replace Tag="LOC_CITY_NAME_COLOMBO" Text="Colombo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BATTICOLOA" Text="Batticoloa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MALDIVES" Text="Maldives" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- CHINA -->
-	
+
 		<Replace Tag="LOC_CITY_NAME_HAINAN" Text="Hainan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRATAS_ISLAND" Text="Pratas Island" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZHANJIANG" Text="Zhanjiang" Language="en_US" />
@@ -5606,11 +6475,11 @@
 		<Replace Tag="LOC_CITY_NAME_SUIHUA" Text="Suihua" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DAXINGANLING" Text="Daxing'anling" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MAGDAGACHI" Text="Magdagachi" Language="en_US" />
-		
+
 	</LocalizedText>
- 	
+
 	<LocalizedText>		<!-- JAPAN & KOREA -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_OKINAWA" Text="Okinawa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OSHIMA" Text="Oshima" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KAGOSHIMA" Text="Kagoshima" Language="en_US" />
@@ -5675,17 +6544,17 @@
 		<Replace Tag="LOC_CITY_NAME_SAPPORO" Text="Sapporo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ASAHIKAWA" Text="Asahikawa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUSHIRO" Text="Kushiro" Language="en_US" />
- 		
+
 	</LocalizedText>
-	
-	
+
+
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 	<!-- The Americas City Names: Default Layer (Modern) <en_US> -->
 	<!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-	
-	
+
+
 	<LocalizedText>		<!-- GREENLAND -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_KANGERLUSSAQ" Text="Kangerlussaq" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MYGGBUKTA" Text="Mosquito Bay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MYGGBUKTA_NORWAY" Text="Myggbukta" Language="en_US" />
@@ -5702,39 +6571,39 @@
 		<Replace Tag="LOC_CITY_NAME_GREENLAND_GLACIER_NORTH" Text="Greenland glacier north" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GREENLAND_GLACIER_NORTH_NORWAY" Text="Grønland isbre nord" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NARSARSUAQ" Text="Bluie West One" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_NANSARSUAQ_NORWAY" Text="Narsarsuaq" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_NANSARSUAQ_NORWAY" Text="Narsarsuaq" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NANORTALIK" Text="Nanortalik" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_NANORTALIK_NORWAY" Text="Nennortalik" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_NANORTALIK_NORWAY" Text="Nennortalik" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GREENLAND_GLACIER_CENTER" Text="Greenland glacier center" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GREENLAND_GLACIER_CENTER_NORWAY" Text="Grønland isbre sentral" Language="en_US" />			
+		<Replace Tag="LOC_CITY_NAME_GREENLAND_GLACIER_CENTER_NORWAY" Text="Grønland isbre sentral" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QAQORTOQ" Text="Qaqortoq" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_QAQORTOQ_NORWAY" Text="Julianehåb" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_QAQORTOQ_NORWAY" Text="Julianehåb" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GREENLAND_GLACIER_WEST" Text="Greenland glacier west" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GREENLAND_GLACIER_WEST_NORWAY" Text="Grønland isbre west" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_GREENLAND_GLACIER_WEST_NORWAY" Text="Grønland isbre west" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KAPISILLIT" Text="Kapisillit" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KAPISILLIT_NORWAY" Text="Kapisillit" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_KAPISILLIT_NORWAY" Text="Kapisillit" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PAAMIUT" Text="Paamiut" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PAAMIUT_NORWAY" Text="Frederikshåb" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_PAAMIUT_NORWAY" Text="Frederikshåb" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KANGERLUSSUAQ" Text="Bluie West Eight" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KANGERLUSSUAQ_NORWAY" Text="Søndre Strømfjord" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_KANGERLUSSUAQ_NORWAY" Text="Søndre Strømfjord" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANIITSOQ" Text="Maniitsoq" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_MANIITSOQ_NORWAY" Text="Sukkertoppen" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_MANIITSOQ_NORWAY" Text="Sukkertoppen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NUUK" Text="Nuuk" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_NUUK_NORWAY" Text="Godthåb" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_NUUK_NORWAY" Text="Godthåb" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SISIMIUT" Text="Sisimiut" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SISIMIUT_NORWAY" Text="Holsteinsborg" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_SISIMIUT_NORWAY" Text="Holsteinsborg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ILULISSAT" Text="Ilulissat" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ILULISSAT_NORWAY" Text="Jakobshavn" Language="en_US" />			
+		<Replace Tag="LOC_CITY_NAME_ILULISSAT_NORWAY" Text="Jakobshavn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AASIAAT" Text="Aasiaat" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AASIAAT_NORWAY" Text="Egedesminde" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- CANADA -->
-		
+
 		<!-- NORTHWEST TERRITORIES -->
 		<Replace Tag="LOC_CITY_NAME_COLVILLE_LAKE" Text="Colville Lake" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_DELINE" Text="Délįne" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_DELINE" Text="Délįne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_SIMPSON" Text="Fort Simpson" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_SMITH" Text="Fort Smith" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GAMETI" Text="Gameti" Language="en_US" />
@@ -5748,24 +6617,24 @@
 		<Replace Tag="LOC_CITY_NAME_PAULATUK" Text="Paulatuk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SACHS_HARBOUR" Text="Sachs Harbour" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAWMILL_BAY" Text="Sawmill Bay" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TUKTOYAKTUK" Text="Tuktoyaktuk" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_URUKHAKTOK" Text="Urukhaktok" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_TUKTOYAKTUK" Text="Tuktoyaktuk" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_URUKHAKTOK" Text="Urukhaktok" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WHATI" Text="Whatì" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YELLOWKNIFE" Text="Yellowknife" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YELLOWKNIFE_CHINA" Text="Huangdaozhen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YELLOWKNIFE_RUSSIA" Text="Yyellounayf" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YELLOWKNIFE_JAPAN" Text="Ieronaifu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YELLOWKNIFE_ARABIA" Text="Ylunayf" Language="en_US" />
-		
+
 		<!-- NUNAVUT -->
 		<Replace Tag="LOC_CITY_NAME_AMADJUAK" Text="Amadjuak" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARCTIC_BAY" Text="Arctic Bay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARVIAT" Text="Arviat" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BAKER_LAKE" Text="Baker Lake" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_BATHURST_INLET" Text="Bathurst Inlet" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_BATHURST_ISLAND" Text="Bathurst Island" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_BAY" Text="Cambridge Bay" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_CAPE_DORSET" Text="Cape Dorset" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_BAKER_LAKE" Text="Baker Lake" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BATHURST_INLET" Text="Bathurst Inlet" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BATHURST_ISLAND" Text="Bathurst Island" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_BAY" Text="Cambridge Bay" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAPE_DORSET" Text="Cape Dorset" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CLYDE_RIVER" Text="Clyde River" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CORAL_HARBOUR" Text="Coral Harbour" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUBAWNT_LAKE" Text="Dubawnt Lake" Language="en_US" />
@@ -5773,30 +6642,30 @@
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_ISLAND" Text="Edinburgh Island" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ENNADAI" Text="Ennadai" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_ROSS" Text="Fort Ross" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GJOA_HAVEN" Text="Gjoa Haven" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_GJOA_HAVEN" Text="Gjoa Haven" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HALL_BEACH" Text="Hall Beach" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IQALUIT" Text="Iqaluit" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IQALUIT_ENGLAND" Text="Frobisher Bay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KILLINIQ" Text="Killiniq" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KIMMIRUT" Text="Kimmirut" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_KIMMIRUT" Text="Kimmirut" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUGLUKTUK" Text="Kugluktuk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MACALPINE_LAKE" Text="MacAlpine Lake" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANSEL_ISLAND" Text="Mansel Island" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PADLEI" Text="Padlei" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_PANGNIRTUNG" Text="Pangnirtung" Language="en_US" />				
-		<Replace Tag="LOC_CITY_NAME_POLARIS" Text="Polaris" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_PADLEI" Text="Padlei" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PANGNIRTUNG" Text="Pangnirtung" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_POLARIS" Text="Polaris" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRINCE_OF_WALES_ISLAND" Text="Prince of Wales Island" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RANKIN_INLET" Text="Rankin Inlet" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_REPULSE_BAY" Text="Repulse Bay" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_RESOLUTE" Text="Resolute" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RESOLUTION_ISLAND" Text="Resolution Island" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_RESOLUTE" Text="Resolute" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RESOLUTION_ISLAND" Text="Resolution Island" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SANIKILUAQ" Text="Sanikiluaq" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SHIMIK" Text="Shimik" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_SHIMIK" Text="Shimik" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TAKIJUQ_LAKE" Text="Takijuq Lake" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TALOYOAK" Text="Taloyoak" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UMINGMAKTOK" Text="Umingmaktok" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_VICTORIA_ISLAND" Text="Victoria Island" Language="en_US" />	
-		
+		<Replace Tag="LOC_CITY_NAME_VICTORIA_ISLAND" Text="Victoria Island" Language="en_US" />
+
 		<!-- YUKON -->
 		<Replace Tag="LOC_CITY_NAME_CARMACKS" Text="Carmacks" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARMACKS_JAPAN" Text="Kamakkusu" Language="en_US" />
@@ -5827,13 +6696,13 @@
 		<Replace Tag="LOC_CITY_NAME_MAYO" Text="Mayo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROSS_RIVER" Text="Ross River" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OLD_CROW" Text="Old Crow" Language="en_US" />
-		
+
 		<!-- MANITOBA -->
 		<Replace Tag="LOC_CITY_NAME_BRANDON" Text="Brandon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRANDON_CHINA" Text="Bulandeng" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRANDON_JAPAN" Text="Burandon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRANDON_ARABIA" Text="Buranidun" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BROCHET" Text="Brochet" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_BROCHET" Text="Brochet" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHURCHILL" Text="Churchill" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DAUPHIN" Text="Dauphin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EGG_ISLAND" Text="Egg Island" Language="en_US" />
@@ -5861,7 +6730,7 @@
 		<Replace Tag="LOC_CITY_NAME_WINNIPEG_RUSSIA" Text="Vinnipeg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WINNIPEG_Rome" Text="Vinnipega" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YORK_FACTORY" Text="York Factory" Language="en_US" />
-		
+
 		<!-- SASKATCHEWAN -->
 		<Replace Tag="LOC_CITY_NAME_BLACK_LAKE" Text="Black Lake" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLACK_LAKE_CHINA" Text="Heihu" Language="en_US" />
@@ -5885,7 +6754,7 @@
 		<Replace Tag="LOC_CITY_NAME_SASKATOON_JAPAN" Text="Sasukato~un" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SASKATOON_RUSSIA" Text="Saskatun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SASKATOON_ARABIA" Text="Saskatun" Language="en_US" />
-		
+
 		<!-- ALBERTA -->
 		<Replace Tag="LOC_CITY_NAME_BANFF" Text="Banff" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANFF_CHINA" Text="Banfu" Language="en_US" />
@@ -5912,19 +6781,19 @@
 		<Replace Tag="LOC_CITY_NAME_LETHBRIDGE_RUSSIA" Text="Letbridzh" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LETHBRIDGE_ARABIA" Text="Ythbridj" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MEDICINE_HAT" Text="Medicine Hat" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_RED_DEER" Text="Red Deer" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_CHINA" Text="Hong Lu Shi" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_JAPAN" Text="Akai Shika" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_RUSSIA" Text="Krasnyy Olen'" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_ARABIA" Text="Ghazal 'Ahmar" Language="en_US" />		
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_GREECE" Text="Kókkino Elafi" Language="en_US" />			
+		<Replace Tag="LOC_CITY_NAME_RED_DEER" Text="Red Deer" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_CHINA" Text="Hong Lu Shi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_JAPAN" Text="Akai Shika" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_RUSSIA" Text="Krasnyy Olen'" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_ARABIA" Text="Ghazal 'Ahmar" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_GREECE" Text="Kókkino Elafi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RED_DEER_MACEDON" Text="Kókkino Elafi" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_FRANCE" Text="Cerf Commun" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_GERMANY" Text="Rotwild" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_SPAIN" Text="Ciervo Rojo" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_BRAZIL" Text="Veado Vermelho" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_RED_DEER_POLAND" Text="Czerwony Jeleń" Language="en_US" />	
-		
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_FRANCE" Text="Cerf Commun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_GERMANY" Text="Rotwild" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_SPAIN" Text="Ciervo Rojo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_BRAZIL" Text="Veado Vermelho" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RED_DEER_POLAND" Text="Czerwony Jeleń" Language="en_US" />
+
 		<!-- BRITISH COLUMBIA -->
 		<Replace Tag="LOC_CITY_NAME_ATLIN" Text="Atlin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_GEORGE" Text="Fort George" Language="en_US" />
@@ -5956,9 +6825,9 @@
 		<Replace Tag="LOC_CITY_NAME_VICTORIA_JAPAN" Text="Bikutoria-shu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VICTORIA_RUSSIA" Text="Viktoriya" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VICTORIA_ARABIA" Text="Faykturia" Language="en_US" />
-		
+
 		<!-- NEWFOUNDLAND -->
-		<Replace Tag="LOC_CITY_NAME_BURGEO" Text="Burgeo" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_BURGEO" Text="Burgeo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BURGEO_JAPAN" Text="Burujo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CORNER_BROOK" Text="Corner Brook" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GANDER" Text="Gander" Language="en_US" />
@@ -5979,7 +6848,7 @@
 		<Replace Tag="LOC_CITY_NAME_ST_JOHNS_GREECE" Text="Agíou Ioánni" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ST_JOHNS_MACEDON" Text="Agíou Ioánni" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ST_JOHNS_BRAZIL" Text="S. João" Language="en_US" />
-		
+
 		<!-- LABRADOR -->
 		<Replace Tag="LOC_CITY_NAME_CARTWRIGHT" Text="Cartwright" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARTWRIGHT_CHINA" Text="Katelaite" Language="en_US" />
@@ -6006,7 +6875,7 @@
 		<Replace Tag="LOC_CITY_NAME_LABRADOR_CITY_MACEDON" Text="Póli tou Lamprantór" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAIN" Text="Nain" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NUTAK" Text="Nutak" Language="en_US" />
-		
+
 		<!-- QUEBEC -->
 		<Replace Tag="LOC_CITY_NAME_AKULIVIK" Text="Akulivik" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAIE_COMEAU" Text="Baie-Comeau" Language="en_US" />
@@ -6025,7 +6894,7 @@
 		<Replace Tag="LOC_CITY_NAME_HAVRE_SAINT_PIERRE" Text="Havre-Saint-Pierre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INUKJUAK" Text="Inukjuak" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KANGIQSUALUJJUAQ" Text="Kangiqsualujjuaq" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KANGIRSUK" Text="Kangirsuq" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_KANGIRSUK" Text="Kangirsuq" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUUJJUAQ" Text="Kuujjuaq" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUUJJUARAPIK" Text="Kuujjuarapik" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LA_ROMAINE" Text="La Romaine" Language="en_US" />
@@ -6041,35 +6910,35 @@
 		<Replace Tag="LOC_CITY_NAME_MONTREAL_ENGLAND" Text="Montreal" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONT_ROYAL" Text="Mont-Royal" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONT_TREMBLANT" Text="Mont-Tremblant" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY" Text="Québec City" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_CHINA" Text="Kuibeike Shi" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_JAPAN" Text="Kebekku-shi" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_ARABIA" Text="Madinat Kybik" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_RUSSIA" Text="Kvebek" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_GERMANY" Text="Québec Stadt" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_ROME" Text="Quebecum" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_GREECE" Text="Kempék" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY" Text="Québec City" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_CHINA" Text="Kuibeike Shi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_JAPAN" Text="Kebekku-shi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_ARABIA" Text="Madinat Kybik" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_RUSSIA" Text="Kvebek" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_GERMANY" Text="Québec Stadt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_ROME" Text="Quebecum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_GREECE" Text="Kempék" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_MACEDON" Text="Kempék" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_POLAND" Text="Quebec" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_NORWAY" Text="Quebec" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_SPAIN" Text="La Ciudad de Quebec" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_BRAZIL" Text="Cidade de Quebec" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_POLAND" Text="Quebec" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_NORWAY" Text="Quebec" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_SPAIN" Text="La Ciudad de Quebec" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_BRAZIL" Text="Cidade de Quebec" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_ENGLAND" Text="Quebec City" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_QUEBEC_CITY_FRANCE" Text="Ville du Québec" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PORT_MENIER" Text="Port-Menier" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_PORT_MENIER" Text="Port-Menier" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PUVIRNITUQ" Text="Puvirnituq" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RADISSON" Text="Radisson" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAGUENAY" Text="Saguenay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_AUGUSTIN" Text="Saint-Augustin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAKAMI" Text="Sakami" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SALLUIT" Text="Salluit" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_SALLUIT" Text="Salluit" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SCHEFFERVILLE" Text="Schefferville" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SEPT_ILES" Text="Sept-Iles" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHAWINIGAN" Text="Shawinigan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHERBROOKE" Text="Sherbrooke" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TASIUJAQ" Text="Tasiujaq" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TROIS_RIVIERES" Text="Trois-Rivières" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TROIS_RIVIERES_JAPAN" Text="Surebu" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_TROIS_RIVIERES_JAPAN" Text="Surebu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TROIS_RIVIERES_CHINA" Text="Sanhe Shi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TROIS_RIVIERES_RUSSIA" Text="Tri Reki" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TROIS_RIVIERES_ARABIA" Text="Thlatht 'Anhars" Language="en_US" />
@@ -6082,7 +6951,7 @@
 		<Replace Tag="LOC_CITY_NAME_TROIS_RIVIERES_ROME" Text="Tria Flumina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UMIUJAQ" Text="Umiujaq" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VAL_DOR" Text="Val-d'Or" Language="en_US" />
-		
+
 		<!-- ONTARIO -->
 		<Replace Tag="LOC_CITY_NAME_ATTAWAPISKAT" Text="Attawapiskat" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARRIE" Text="Barrie" Language="en_US" />
@@ -6097,7 +6966,7 @@
 		<Replace Tag="LOC_CITY_NAME_FORT_SEVERN" Text="Fort Severn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_YORK" Text="Fort York" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_YORK_FRANCE" Text="Fort Rouillé" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GRAND_FALLS_WINDSOR" Text="Grand Falls-Windsor" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_GRAND_FALLS_WINDSOR" Text="Grand Falls-Windsor" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PICKLE_LAKE" Text="Pickle Lake" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAN_HAMILTON" Text="Hamilton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KAPUSKASING" Text="Kapuskasing" Language="en_US" />
@@ -6105,7 +6974,7 @@
 		<Replace Tag="LOC_CITY_NAME_KENORA_FRANCE" Text="Rat Portage" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAN_KINGSTON" Text="Kingston" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAN_KINGSTON_FRANCE" Text="Fort Frontenac" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_MOOSONEE" Text="Moosonee" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_MOOSONEE" Text="Moosonee" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORTH_BAY" Text="North Bay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORTH_BAY_CHINA" Text="Bei Wan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORTH_BAY_JAPAN" Text="Hokubu-Wan" Language="en_US" />
@@ -6162,7 +7031,7 @@
 		<Replace Tag="LOC_CITY_NAME_WINDSOR_CHINA" Text="Wensha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WINDSOR_ARABIA" Text="Wanadsur" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WINDSOR_RUSSIA" Text="Vindzor" Language="en_US" />
-		
+
 		<!-- NOVA SCOTIA -->
 		<Replace Tag="LOC_CITY_NAME_CAPE_BRETON" Text="Cape Breton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAPE_BRETON_CHINA" Text="Bulei Dun Jiao" Language="en_US" />
@@ -6170,14 +7039,14 @@
 		<Replace Tag="LOC_CITY_NAME_CAPE_BRETON_RUSSIA" Text="Keyp-Breton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAPE_BRETON_ARABIA" Text="Kayb Baritun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAPE_BRETON_FRANCE" Text="Île Royale" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_HALIFAX" Text="Halifax" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HALIFAX_CHINA" Text="Huangjia Gang" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HALIFAX_JAPAN" Text="Harifakkusu" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HALIFAX_ARABIA" Text="Halifaks" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HALIFAX_RUSSIA" Text="Galifaks" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HALIFAX_ROME" Text="Halifaxia" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_HALIFAX" Text="Halifax" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HALIFAX_CHINA" Text="Huangjia Gang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HALIFAX_JAPAN" Text="Harifakkusu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HALIFAX_ARABIA" Text="Halifaks" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HALIFAX_RUSSIA" Text="Galifaks" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HALIFAX_ROME" Text="Halifaxia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HALIFAX_FRANCE" Text="Port-Royal" Language="en_US" />
-		
+
 		<!-- NEW BRUNSWICK -->
 		<Replace Tag="LOC_CITY_NAME_FREDERICTON" Text="Fredericton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FREDERICTON_CHINA" Text="Fuleidelikedun" Language="en_US" />
@@ -6200,7 +7069,7 @@
 		<Replace Tag="LOC_CITY_NAME_SAINT_JOHN_FRANCE" Text="Fort LaTour" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STE_ANNES_POINT" Text="Ste. Anne's Point" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STE_ANNES_POINT_FRANCE" Text="Pointe-Sainte-Anne" Language="en_US" />
-		
+
 		<!-- PRINCE EDWARD ISLAND -->
 		<Replace Tag="LOC_CITY_NAME_CHARLOTTETOWN" Text="Charlottetown" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHARLOTTETOWN_CHINA" Text="Xialuotedun" Language="en_US" />
@@ -6208,11 +7077,11 @@
 		<Replace Tag="LOC_CITY_NAME_CHARLOTTETOWN_ARABIA" Text="Sharlut Tawn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHARLOTTETOWN_RUSSIA" Text="Sharlottaun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHARLOTTETOWN_FRANCE" Text="Port-la-Joye" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- U.S.A. (MAINLAND, HAWAII, & ALASKA) -->
-		
+
 		<!-- HAWAII -->
 		<Replace Tag="LOC_CITY_NAME_KAPAA" Text="Kapaa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KAPAA_ARABIA" Text="Kaba" Language="en_US" />
@@ -6225,21 +7094,21 @@
 		<Replace Tag="LOC_CITY_NAME_KAHULUI_JAPAN" Text="Kafurui" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HAWI" Text="Hawi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HAWI_JAPAN" Text="Hoi" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KAILUA" Text="Kailua" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_KAILUA_CHINA" Text="Kailuwa" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_KAILUA_JAPAN" Text="Kairua" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_KAILUA_RUSSIA" Text="Kaylua" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_KAILUA_ARABIA" Text="Kilu" Language="en_US" />		
-		<Replace Tag="LOC_CITY_NAME_HILO" Text="Hilo" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HILO_CHINA" Text="Xiluo" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HILO_JAPAN" Text="Hiro" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HILO_RUSSIA" Text="Khilo" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HILO_ARABIA" Text="Hlu" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_KAILUA" Text="Kailua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAILUA_CHINA" Text="Kailuwa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAILUA_JAPAN" Text="Kairua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAILUA_RUSSIA" Text="Kaylua" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAILUA_ARABIA" Text="Kilu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HILO" Text="Hilo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HILO_CHINA" Text="Xiluo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HILO_JAPAN" Text="Hiro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HILO_RUSSIA" Text="Khilo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HILO_ARABIA" Text="Hlu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PAHALA" Text="Pahala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PAHALA_JAPAN" Text="Para" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PAHALA_RUSSIA" Text="Pakhla" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PAHALA_ARABIA" Text="Pahla" Language="en_US" />
-		
+
 		<!-- ALASKA -->
 		<Replace Tag="LOC_CITY_NAME_JUNEAU" Text="Juneau" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JUNEAU_CHINA" Text="Zhunuo" Language="en_US" />
@@ -6251,19 +7120,19 @@
 		<Replace Tag="LOC_CITY_NAME_SITKA_CHINA" Text="Xiteka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SITKA_JAPAN" Text="Shitoka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SITKA_ARABIA" Text="Sayataka" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KETCHIKAN" Text="Ketchikan" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_YAKUTAT" Text="Yakutat" Language="en_US" />				
+		<Replace Tag="LOC_CITY_NAME_KETCHIKAN" Text="Ketchikan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YAKUTAT" Text="Yakutat" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YAKUTAT_RUSSIA" Text="Slavorossiya" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ATTU_ISLAND" Text="Attu Island" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_ATTU_ISLAND_RUSSIA" Text="Saint Theodore" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_ADAK" Text="Adak" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_UNALASKA" Text="Unalaska" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_UNALASKA_AMERICA" Text="Dutch Harbor" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_UNALASKA_RUSSIA" Text="Ounalashka" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_ATTU_ISLAND" Text="Attu Island" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ATTU_ISLAND_RUSSIA" Text="Saint Theodore" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADAK" Text="Adak" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_UNALASKA" Text="Unalaska" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_UNALASKA_AMERICA" Text="Dutch Harbor" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_UNALASKA_RUSSIA" Text="Ounalashka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UNALASKA_CHINA" Text="Wunalasika" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UNALASKA_JAPAN" Text="Unarasuka Shima" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PORT_HEIDEN" Text="Port Heiden" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_NOME" Text="Nome" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_PORT_HEIDEN" Text="Port Heiden" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NOME" Text="Nome" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BETHEL" Text="Bethel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DILLINGHAM" Text="Dillingham" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KOTZEBUE" Text="Kotzebue" Language="en_US" />
@@ -6271,34 +7140,34 @@
 		<Replace Tag="LOC_CITY_NAME_KODIAK_RUSSIA" Text="Kad'yak" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KODIAK_CHINA" Text="Kediyake" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KODIAK_JAPAN" Text="Kodiakku" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KODIAK_ARABIA" Text="Kudiak" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_GALENA" Text="Galena" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_AMBLER" Text="Ambler" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_POINT_HOPE" Text="Point Hope" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_KODIAK_ARABIA" Text="Kudiak" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GALENA" Text="Galena" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AMBLER" Text="Ambler" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_POINT_HOPE" Text="Point Hope" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POINT_HOPE_RUSSIA" Text="Tiekaga" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POINT_HOPE_JAPAN" Text="Tikaga" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POINT_HOPE_CHINA" Text="Dian Xiwang" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KENAI" Text="Kenai" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_HOMER" Text="Homer" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_SEWARD" Text="Seward" Language="en_US" />			
-		<Replace Tag="LOC_CITY_NAME_ANCHORAGE" Text="Anchorage" Language="en_US" />			
-		<Replace Tag="LOC_CITY_NAME_ANCHORAGE_CHINA" Text="Ankelazhi" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_ANCHORAGE_RUSSIA" Text="Ankoridzh" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_ANCHORAGE_JAPAN" Text="Ankarejji" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_ANCHORAGE_ARABIA" Text="Ankwryj" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_WASILLA" Text="Wasilla" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_TANANA" Text="Tanana" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_GLACIER_VIEW" Text="Glacier View" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_FAIRBANKS" Text="Fairbanks" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_KENAI" Text="Kenai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOMER" Text="Homer" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEWARD" Text="Seward" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANCHORAGE" Text="Anchorage" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANCHORAGE_CHINA" Text="Ankelazhi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANCHORAGE_RUSSIA" Text="Ankoridzh" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANCHORAGE_JAPAN" Text="Ankarejji" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ANCHORAGE_ARABIA" Text="Ankwryj" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WASILLA" Text="Wasilla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TANANA" Text="Tanana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GLACIER_VIEW" Text="Glacier View" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FAIRBANKS" Text="Fairbanks" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VALDEZ" Text="Valdez" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WORTMANNS" Text="Wortmanns" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PAXSON" Text="Paxson" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_PAXSON" Text="Paxson" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DELTA_JUNCTION" Text="Delta Junction" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CORDOVA" Text="Cordova" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_CORDOVA_SPAIN" Text="Córdova" Language="en_US" />		
-		<Replace Tag="LOC_CITY_NAME_FORT_YUKON" Text="Fort Yukon" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_KATALLA" Text="Katalla" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_ALAGANIK" Text="Alaganik" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_CORDOVA_SPAIN" Text="Córdova" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FORT_YUKON" Text="Fort Yukon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KATALLA" Text="Katalla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ALAGANIK" Text="Alaganik" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOK" Text="Tok" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHICKEN" Text="Chicken" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MCCARTHY" Text="McCarthy" Language="en_US" />
@@ -6309,18 +7178,18 @@
 		<Replace Tag="LOC_CITY_NAME_ANAKTUVUK_PASS" Text="Anaktuvuk Pass" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ATQASUK" Text="Atqasuk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARROW" Text="Barrow" Language="en_US" />
-		
+
 		<!-- MAINE -->
 		<Replace Tag="LOC_CITY_NAME_BANGOR" Text="Bangor" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANGOR_ARABIA" Text="Banghur" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANGOR_CHINA" Text="Ban Ge" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BANGOR_JAPAN" Text="Bangoru" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_CARIBOU" Text="Caribou" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_CARIBOU_RUSSIA" Text="Karibu" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_CARIBOU_ARABIA" Text="Karibu" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_CARIBOU_CHINA" Text="Kalibu" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_CARIBOU_JAPAN" Text="Karibu" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_FALMOUTH" Text="Falmouth" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_CARIBOU" Text="Caribou" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARIBOU_RUSSIA" Text="Karibu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARIBOU_ARABIA" Text="Karibu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARIBOU_CHINA" Text="Kalibu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARIBOU_JAPAN" Text="Karibu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FALMOUTH" Text="Falmouth" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PENOBSCOT_BAY" Text="Penobscot Bay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ME_PORTLAND" Text="Portland" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ME_PORTLAND_RUSSIA" Text="Portland" Language="en_US" />
@@ -6328,7 +7197,7 @@
 		<Replace Tag="LOC_CITY_NAME_ME_PORTLAND_CHINA" Text="Botelan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ME_PORTLAND_JAPAN" Text="Portorando" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ME_PORTLAND_ROME" Text="Portlandia" Language="en_US" />
-		
+
 		<!-- MASSACHUSETTS -->
 		<Replace Tag="LOC_CITY_NAME_BOSTON" Text="Boston" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOSTON_GREECE" Text="Vostóni" Language="en_US" />
@@ -6336,8 +7205,8 @@
 		<Replace Tag="LOC_CITY_NAME_BOSTON_CHINA" Text="Boshidun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOSTON_JAPAN" Text="Bosuton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOSTON_ARABIA" Text="Busatun" Language="en_US" />
-		
-		<!-- DISTRICT OF COLUMBIA -->		
+
+		<!-- DISTRICT OF COLUMBIA -->
 		<Replace Tag="LOC_CITY_NAME_POINT_OF_ROCKS" Text="Point of Rocks" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POINT_OF_ROCKS_AMERICA" Text="Washington" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WASHINGTON" Text="Washington" Language="en_US" />
@@ -6350,32 +7219,32 @@
 		<Replace Tag="LOC_CITY_NAME_WASHINGTON_RUSSIA" Text="Vashington" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WASHINGTON_ROME" Text="Vasintonia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WASHINGTON_AZTEC" Text="Conoy" Language="en_US" />
-		
+
 		<!-- NEW YORK STATE -->
 		<Replace Tag="LOC_CITY_NAME_USA_ALBANY" Text="Albany" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_USA_ALBANY_CHINA" Text="Ao'erbani" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_USA_ALBANY_JAPAN" Text="Arubani" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_USA_ALBANY_ARABIA" Text="Albani" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_USA_ALBANY_NETHERLANDS" Text="Fort Orange" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BUFFALO" Text="Buffalo" Language="en_US" />		
-		<Replace Tag="LOC_CITY_NAME_BUFFALO_CHINA" Text="Shuiniu Cheng" Language="en_US" />		
-		<Replace Tag="LOC_CITY_NAME_BUFFALO_JAPAN" Text="Baffaro" Language="en_US" />		
-		<Replace Tag="LOC_CITY_NAME_BUFFALO_RUSSIA" Text="Buffalo" Language="en_US" />		
-		<Replace Tag="LOC_CITY_NAME_BUFFALO_ARABIA" Text="Bufalu" Language="en_US" />			
-		<Replace Tag="LOC_CITY_NAME_NEW_YORK" Text="New York" Language="en_US" />		
-		<Replace Tag="LOC_CITY_NAME_NEW_YORK_ROME" Text="Novum Eboracum" Language="en_US" />			
-		<Replace Tag="LOC_CITY_NAME_NEW_YORK_GREECE" Text="Néa Yórki" Language="en_US" />				
-		<Replace Tag="LOC_CITY_NAME_NEW_YORK_MACEDON" Text="Néa Yórki" Language="en_US" />				
-		<Replace Tag="LOC_CITY_NAME_NEW_YORK_CHINA" Text="Niuyue" Language="en_US" />			
-		<Replace Tag="LOC_CITY_NAME_NEW_YORK_JAPAN" Text="Nyuyoku" Language="en_US" />			
-		<Replace Tag="LOC_CITY_NAME_NEW_YORK_RUSSIA" Text="N'yu-York" Language="en_US" />			
-		<Replace Tag="LOC_CITY_NAME_NEW_YORK_ARABIA" Text="Niuyurk" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_BUFFALO" Text="Buffalo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUFFALO_CHINA" Text="Shuiniu Cheng" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUFFALO_JAPAN" Text="Baffaro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUFFALO_RUSSIA" Text="Buffalo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUFFALO_ARABIA" Text="Bufalu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEW_YORK" Text="New York" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEW_YORK_ROME" Text="Novum Eboracum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEW_YORK_GREECE" Text="Néa Yórki" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEW_YORK_MACEDON" Text="Néa Yórki" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEW_YORK_CHINA" Text="Niuyue" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEW_YORK_JAPAN" Text="Nyuyoku" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEW_YORK_RUSSIA" Text="N'yu-York" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEW_YORK_ARABIA" Text="Niuyurk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEW_YORK_NETHERLANDS" Text="Nieuw Amsterdam" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROCHESTER" Text="Rochester" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROCHESTER_CHINA" Text="Luoqiesite" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROCHESTER_JAPAN" Text="Rochesuta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROCHESTER_ARABIA" Text="Rutshstr" Language="en_US" />
-		
+
 		<!-- PENNSYLVANIA -->
 		<Replace Tag="LOC_CITY_NAME_PHILADELPHIA_USA" Text="Philadelphia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PHILADELPHIA_USA_AZTEC" Text="Lenni-Lenape" Language="en_US" />
@@ -6395,29 +7264,29 @@
 		<Replace Tag="LOC_CITY_NAME_PITTSBURGH_JAPAN" Text="Pittsubagu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PITTSBURGH_ARABIA" Text="Biatasbaragh" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PITTSBURGH_AZTEC" Text="Susquehannock" Language="en_US" />
-		
+
 		<!-- MICHIGAN -->
-		<Replace Tag="LOC_CITY_NAME_DETROIT" Text="Detroit" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_DETROIT" Text="Detroit" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DETROIT_GREECE" Text="Ntitróit" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DETROIT_MACEDON" Text="Ntitróit" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_DETROIT_CHINA" Text="Ditelu" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_DETROIT_JAPAN" Text="Detoroito" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_DETROIT_ARABIA" Text="Ditruyt" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_DETROIT_RUSSIA" Text="Detroyt" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_DETROIT_FRANCE" Text="Fort Détroit" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_FORT_DETROIT" Text="Fort Detroit" Language="en_US" />	
+		<Replace Tag="LOC_CITY_NAME_DETROIT_CHINA" Text="Ditelu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DETROIT_JAPAN" Text="Detoroito" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DETROIT_ARABIA" Text="Ditruyt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DETROIT_RUSSIA" Text="Detroyt" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DETROIT_FRANCE" Text="Fort Détroit" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FORT_DETROIT" Text="Fort Detroit" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_DETROIT_FRANCE" Text="Fort Détroit" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GRAND_RAPIDS" Text="Grand Rapids" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_GRAND_RAPIDS_FRANCE" Text="Grands Rapides" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_MARQUETTE" Text="Marquette" Language="en_US" />	
-		
+		<Replace Tag="LOC_CITY_NAME_GRAND_RAPIDS" Text="Grand Rapids" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GRAND_RAPIDS_FRANCE" Text="Grands Rapides" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARQUETTE" Text="Marquette" Language="en_US" />
+
 		<!-- VERMONT -->
 		<Replace Tag="LOC_CITY_NAME_MONTPELIER" Text="Montpelier" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTPELIER_CHINA" Text="Mengbiliai" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTPELIER_JAPAN" Text="Montopiria" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTPELIER_ARABIA" Text="Mwnblyyh" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_SAINTE_ANNE" Text="Fort Sainte Anne" Language="en_US" />
-		
+
 		<!-- MARYLAND -->
 		<Replace Tag="LOC_CITY_NAME_BALTIMORE" Text="Baltimore" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BALTIMORE_ROME" Text="Baltimora" Language="en_US" />
@@ -6429,7 +7298,7 @@
 		<Replace Tag="LOC_CITY_NAME_BALTIMORE_ARABIA" Text="Baltymwr" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BALTIMORE_SWEDEN" Text="Fort Christina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BALTIMORE_AZTEC" Text="Patapsco" Language="en_US" />
-		
+
 		<!-- VIRGINIA -->
 		<Replace Tag="LOC_CITY_NAME_JAMESTOWN" Text="Jamestown" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RICHMOND" Text="Richmond" Language="en_US" />
@@ -6439,7 +7308,7 @@
 		<Replace Tag="LOC_CITY_NAME_RICHMOND_CHINA" Text="Lishiman" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RICHMOND_JAPAN" Text="Ritchimondo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RICHMOND_ARABIA" Text="Ritshmund" Language="en_US" />
-		
+
 		<!-- NORTH CAROLINA -->
 		<Replace Tag="LOC_CITY_NAME_CHARLOTTE" Text="Charlotte" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHARLOTTE_GREECE" Text="Sarlót" Language="en_US" />
@@ -6453,7 +7322,7 @@
 		<Replace Tag="LOC_CITY_NAME_WILMINGTON_JAPAN" Text="U~iruminton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WILMINGTON_ARABIA" Text="Wayalmunjitun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WILMINGTON_AZTEC" Text="Waccamaw" Language="en_US" />
-		
+
 		<!-- SOUTH CAROLINA -->
 		<Replace Tag="LOC_CITY_NAME_CHARLESTON" Text="Charleston" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHARLESTON_GREECE" Text="Tsárleston" Language="en_US" />
@@ -6465,7 +7334,7 @@
 		<Replace Tag="LOC_CITY_NAME_CHARLESTON_ROME" Text="Carolopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHARLESTON_AZTEC" Text="Cusabo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHARLES_TOWN" Text="Charles Town" Language="en_US" />
-		
+
 		<!-- GEORGIA -->
 		<Replace Tag="LOC_CITY_NAME_ATLANTA" Text="Atlanta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ATLANTA_CHINA" Text="Yatelanda" Language="en_US" />
@@ -6475,7 +7344,7 @@
 		<Replace Tag="LOC_CITY_NAME_SAVANNAH_JAPAN" Text="Saban'na" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAVANNAH_ARABIA" Text="Safana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAVANNAH_RUSSIA" Text="Savanna" Language="en_US" />
-		
+
 		<!-- FLORIDA -->
 		<Replace Tag="LOC_CITY_NAME_FORT_DALLAS" Text="Fort Dallas" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FORT_DALLAS_SPAIN" Text="Santa Maria de Loreto" Language="en_US" />
@@ -6509,11 +7378,11 @@
 		<Replace Tag="LOC_CITY_NAME_TALLAHASSEE_ARABIA" Text="Talahasi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TALLAHASSEE_RUSSIA" Text="Tallakhassi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TALLAHASSEE_ROME" Text="Tallahassia" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TAMPA" Text="Tampa" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_TAMPA_CHINA" Text="Tanpa" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_TAMPA_JAPAN" Text="Tanpa" Language="en_US" />	
-		<Replace Tag="LOC_CITY_NAME_TAMPA_ARABIA" Text="Tamiba" Language="en_US" />		
-		
+		<Replace Tag="LOC_CITY_NAME_TAMPA" Text="Tampa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMPA_CHINA" Text="Tanpa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMPA_JAPAN" Text="Tanpa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAMPA_ARABIA" Text="Tamiba" Language="en_US" />
+
 		<!-- OHIO -->
 		<Replace Tag="LOC_CITY_NAME_AKRON" Text="Akron" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AKRON_CHINA" Text="Akelun" Language="en_US" />
@@ -6539,7 +7408,7 @@
 		<Replace Tag="LOC_CITY_NAME_COLUMBUS_RUSSIA" Text="Kolumbus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COLUMBUS_JAPAN" Text="Koronbasu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COLUMBUS_ARABIA" Text="Kulumbus" Language="en_US" />
-		
+
 		<!-- MINNESOTA -->
 		<Replace Tag="LOC_CITY_NAME_BEMIDJI" Text="Bemidji" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DULUTH" Text="Duluth" Language="en_US" />
@@ -6552,7 +7421,7 @@
 		<Replace Tag="LOC_CITY_NAME_MINNEAPOLIS_JAPAN" Text="Mineaporisu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MINNEAPOLIS_ARABIA" Text="Miniabulis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MINNEAPOLIS_FRANCE" Text="Fort Beauharnois" Language="en_US" />
-		
+
 		<!-- WISCONSIN -->
 		<Replace Tag="LOC_CITY_NAME_GREEN_BAY" Text="Green Bay" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GREEN_BAY_CHINA" Text="Gelin Bei" Language="en_US" />
@@ -6564,7 +7433,7 @@
 		<Replace Tag="LOC_CITY_NAME_MILWAUKEE_JAPAN" Text="Miruu~okī" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MILWAUKEE_RUSSIA" Text="Miluoki" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MILWAUKEE_ARABIA" Text="Milwuki" Language="en_US" />
-		
+
 		<!-- ILLINOIS -->
 		<Replace Tag="LOC_CITY_NAME_CHICAGO" Text="Chicago" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHICAGO_GREECE" Text="Sikágoo" Language="en_US" />
@@ -6578,26 +7447,26 @@
 		<Replace Tag="LOC_CITY_NAME_SPRINGFIELD_CHINA" Text="Sipulinfei'erde" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SPRINGFIELD_JAPAN" Text="Supuringufirudo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SPRINGFIELD_AZTEC" Text="Cahokia" Language="en_US" />
-		
+
 		<!-- INDIANA -->
 		<Replace Tag="LOC_CITY_NAME_INDIANAPOLIS" Text="Indianapolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INDIANAPOLIS_CHINA" Text="Yindi'annabolisi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INDIANAPOLIS_JAPAN" Text="Indianaporisu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INDIANAPOLIS_ARABIA" Text="Iindianabulis" Language="en_US" />
-		
+
 		<!-- WEST VIRGINIA -->
 		<Replace Tag="LOC_CITY_NAME_HUNTINGTON" Text="Huntington" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HUNTINGTON_CHINA" Text="Hengtingdun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HUNTINGTON_JAPAN" Text="Hantinguton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HUNTINGTON_RUSSIA" Text="Khantington" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HUNTINGTON_ARABIA" Text="Hintunghitun" Language="en_US" />
-		
+
 		<!-- KENTUCKY -->
 		<Replace Tag="LOC_CITY_NAME_LOUISVILLE" Text="Louisville" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LOUISVILLE_CHINA" Text="Luyisiwei'er" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LOUISVILLE_JAPAN" Text="Ruibiru" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LOUISVILLE_ARABIA" Text="Luayzfil" Language="en_US" />
-		
+
 		<!-- TENNESSEE -->
 		<Replace Tag="LOC_CITY_NAME_KNOXVILLE" Text="Knoxville" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KNOXVILLE_CHINA" Text="Nuokesiwei'er" Language="en_US" />
@@ -6613,7 +7482,7 @@
 		<Replace Tag="LOC_CITY_NAME_NASHVILLE_ARABIA" Text="Nashfil" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NASHVILLE_CHINA" Text="Nashiwei'er" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NASHVILLE_JAPAN" Text="Nasshubiru" Language="en_US" />
-		
+
 		<!-- ALABAMA -->
 		<Replace Tag="LOC_CITY_NAME_USA_BIRMINGHAM" Text="Birmingham" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_USA_BIRMINGHAM_RUSSIA" Text="Birmingem" Language="en_US" />
@@ -6631,14 +7500,14 @@
 		<Replace Tag="LOC_CITY_NAME_MONTGOMERY_RUSSIA" Text="Montgomeri" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTGOMERY_ARABIA" Text="Muntaghmri" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTGOMERY_FRANCE" Text="Fort Toulouse" Language="en_US" />
-		
+
 		<!-- MISSISSIPPI -->
 		<Replace Tag="LOC_CITY_NAME_JACKSON" Text="Jackson" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JACKSON_CHINA" Text="Jiekexun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JACKSON_JAPAN" Text="Jakuson" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JACKSON_RUSSIA" Text="Dzhekson" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_JACKSON_ARABIA" Text="Jakisun" Language="en_US" />
-		
+
 		<!-- WASHINGTON STATE -->
 		<Replace Tag="LOC_CITY_NAME_DUWAMPS" Text="Duwamps" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KENNEWICK" Text="Kennewick" Language="en_US" />
@@ -6664,7 +7533,7 @@
 		<Replace Tag="LOC_CITY_NAME_SPOKANE_ARABIA" Text="Sabukan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YAKIMA" Text="Yakima" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YAKIMA_CHINA" Text="Yajima" Language="en_US" />
-		
+
 		<!-- OREGON -->
 		<Replace Tag="LOC_CITY_NAME_BEND" Text="Bend" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BEND_JAPAN" Text="Bendo" Language="en_US" />
@@ -6683,7 +7552,7 @@
 		<Replace Tag="LOC_CITY_NAME_OR_PORTLAND_JAPAN" Text="Portorando" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OR_PORTLAND_AZTEC" Text="Chinook" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OR_PORTLAND_ROME" Text="Portlandia" Language="en_US" />
-		
+
 		<!-- NEW MEXICO -->
 		<Replace Tag="LOC_CITY_NAME_ALBUQUERQUE" Text="Albuquerque" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALBUQUERQUE_CHINA" Text="A'erbokeji" Language="en_US" />
@@ -6703,7 +7572,7 @@
 		<Replace Tag="LOC_CITY_NAME_SANTA_FE_RUSSIA" Text="Santa-Fe" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SANTA_FE_ARABIA" Text="Santaan Fi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SANTA_FE_AZTEC" Text="Pueblo" Language="en_US" />
-		
+
 		<!-- ARIZONA -->
 		<Replace Tag="LOC_CITY_NAME_FLAGSTAFF" Text="Flagstaff" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FLAGSTAFF_CHINA" Text="Fulagesitafu" Language="en_US" />
@@ -6726,7 +7595,7 @@
 		<Replace Tag="LOC_CITY_NAME_TUCSON_ARABIA" Text="Tukisun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TUCSON_RUSSIA" Text="Tuson" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TUCSON_AZTEC" Text="Apache" Language="en_US" />
-		
+
 		<!-- NEVADA -->
 		<Replace Tag="LOC_CITY_NAME_CARSON_CITY" Text="Carson City" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARSON_CITY_AZTEC" Text="Washo" Language="en_US" />
@@ -6758,7 +7627,7 @@
 		<Replace Tag="LOC_CITY_NAME_RENO_CHINA" Text="Linuo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RENO_JAPAN" Text="Rino" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RENO_AZTEC" Text="Washo" Language="en_US" />
-		
+
 		<!-- UTAH -->
 		<Replace Tag="LOC_CITY_NAME_BLUFF_USA" Text="Bluff" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MOAB" Text="Moab" Language="en_US" />
@@ -6783,7 +7652,7 @@
 		<Replace Tag="LOC_CITY_NAME_ST_GEORGE_SPAIN" Text="San Jorge" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ST_GEORGE_GERMANY" Text="St. Georg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ST_GEORGE_BRAZIL" Text="São Jorge" Language="en_US" />
-		
+
 		<!-- IDAHO -->
 		<Replace Tag="LOC_CITY_NAME_BOISE" Text="Boise" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOISE_ARABIA" Text="Buyz" Language="en_US" />
@@ -6795,7 +7664,7 @@
 		<Replace Tag="LOC_CITY_NAME_NAMPA_ARABIA" Text="Namaba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAMPA_CHINA" Text="Nanpa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAMPA_JAPAN" Text="Nanpa" Language="en_US" />
-		
+
 		<!-- CALIFORNIA -->
 		<Replace Tag="LOC_CITY_NAME_BAKERSFIELD" Text="Bakersfield" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAKERSFIELD_CHINA" Text="Beikesifei'erde" Language="en_US" />
@@ -6863,7 +7732,8 @@
 		<Replace Tag="LOC_CITY_NAME_STOCKTON_ARABIA" Text="Satukutun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STOCKTON_RUSSIA" Text="Stokton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STOCKTON_CHINA" Text="Situokedun" Language="en_US" />
-		
+		<Replace Tag="LOC_CITY_NAME_VICTORVILLE" Text="Victorville" Language="en_US" />
+
 		<!-- MISSOURI -->
 		<Replace Tag="LOC_CITY_NAME_KANSAS_CITY" Text="Kansas City" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KANSAS_CITY_GERMANY" Text="Kansas Stadt" Language="en_US" />
@@ -6887,7 +7757,7 @@
 		<Replace Tag="LOC_CITY_NAME_ST_LOUIS_ARABIA" Text="Sanat Luis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ST_LOUIS_RUSSIA" Text="Svyatoy Lui" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ST_LOUIS_AZTEC" Text="Cahokia" Language="en_US" />
-		
+
 		<!-- LOUISIANA -->
 		<Replace Tag="LOC_CITY_NAME_LAFAYETTE" Text="Lafayette" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LAFAYETTE_RUSSIA" Text="Lafeyyett" Language="en_US" />
@@ -6912,14 +7782,14 @@
 		<Replace Tag="LOC_CITY_NAME_SHREVEPORT_JAPAN" Text="Shuribupoto" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHREVEPORT_ARABIA" Text="Wayazyana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHREVEPORT_AZTEC" Text="Caddo" Language="en_US" />
-		
+
 		<!-- ARKANSAS -->
 		<Replace Tag="LOC_CITY_NAME_LITTLE_ROCK" Text="Little Rock" Language="en_US" />
-		
+
 		<!-- IOWA -->
 		<Replace Tag="LOC_CITY_NAME_CEDAR_RAPIDS" Text="Cedar Rapids" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DES_MOINES" Text="Des Moines" Language="en_US" />
-		
+
 		<!-- NORTH DAKOTA -->
 		<Replace Tag="LOC_CITY_NAME_BISMARCK" Text="Bismarck" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BISMARCK_CHINA" Text="Bisimai" Language="en_US" />
@@ -6932,14 +7802,14 @@
 		<Replace Tag="LOC_CITY_NAME_FARGO_CHINA" Text="Fage" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FARGO_JAPAN" Text="Fago" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FARGO_ARABIA" Text="Farju" Language="en_US" />
-		
+
 		<!-- MONTANA -->
 		<Replace Tag="LOC_CITY_NAME_BILLINGS" Text="Billings" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BILLINGS_LAKOTA" Text="Lakota" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BILLINGS_AZTEC" Text="Lakota" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GREAT_FALLS" Text="Great Falls" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MISSOULA" Text="Missoula" Language="en_US" />
-		
+
 		<!-- TEXAS -->
 		<Replace Tag="LOC_CITY_NAME_AMARILLO" Text="Amarillo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMARILLO_AZTEC" Text="Teyas" Language="en_US" />
@@ -6983,7 +7853,7 @@
 		<Replace Tag="LOC_CITY_NAME_MIDLAND_AZTEC" Text="Lipan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_USA_SAN_ANTONIO" Text="San Antonio" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_USA_SAN_ANTONIO_AZTEC" Text="Lipan" Language="en_US" />
-		
+
 		<!-- OKLAHOMA -->
 		<Replace Tag="LOC_CITY_NAME_OKLAHOMA_CITY" Text="Oklahoma City" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OKLAHOMA_CITY_GERMANY" Text="Oklahoma Stadt" Language="en_US" />
@@ -6998,7 +7868,7 @@
 		<Replace Tag="LOC_CITY_NAME_OKLAHOMA_CITY_JAPAN" Text="Okurahomashiti" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OKLAHOMA_CITY_ARABIA" Text="Uwklahuma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OKLAHOMA_CITY_AZTEC" Text="Escanjaque" Language="en_US" />
-		
+
 		<!-- COLORADO -->
 		<Replace Tag="LOC_CITY_NAME_BOULDER" Text="Boulder" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DENVER" Text="Denver" Language="en_US" />
@@ -7006,16 +7876,16 @@
 		<Replace Tag="LOC_CITY_NAME_DENVER_JAPAN" Text="Denba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRAND_JUNCTION" Text="Grand Junction" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PUEBLO" Text="Pueblo" Language="en_US" />
-		
+
 		<!-- KANSAS -->
 		<Replace Tag="LOC_CITY_NAME_TOPEKA" Text="Topeka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICHITA" Text="Wichita" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICHITA_AZTEC" Text="Kansa" Language="en_US" />
-		
+
 		<!-- SOUTH DAKOTA -->
 		<Replace Tag="LOC_CITY_NAME_SIOUX_FALLS" Text="Sioux Falls" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAPID_CITY" Text="Rapid City" Language="en_US" />
-		
+
 		<!-- NEBRASKA -->
 		<Replace Tag="LOC_CITY_NAME_USA_LINCOLN" Text="Lincoln" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_USA_LINCOLN_CHINA" Text="Línkěn" Language="en_US" />
@@ -7026,7 +7896,7 @@
 		<Replace Tag="LOC_CITY_NAME_OMAHA_CHINA" Text="Aomaha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OMAHA_RUSSIA" Text="Omakha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OMAHA_ARABIA" Text="Awmaha" Language="en_US" />
-		
+
 		<!-- WYOMING -->
 		<Replace Tag="LOC_CITY_NAME_CASPER" Text="Casper" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CASPER_SUTAIO" Text="Sutaio" Language="en_US" />
@@ -7035,11 +7905,11 @@
 		<Replace Tag="LOC_CITY_NAME_CHEYENNE_SUTAIO" Text="Sutaio" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHEYENNE_AZTEC" Text="Sutaio" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROCK_SPRINGS" Text="Rock Springs" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- MEXICO & CENTRAL AMERICA -->
-		
+
 		<!-- MEXICO -->
 		<Replace Tag="LOC_CITY_NAME_ACAPULCO" Text="Acapulco" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ACAPULCO_CHINA" Text="Akapu'erke" Language="en_US" />
@@ -7251,7 +8121,7 @@
 		<Replace Tag="LOC_CITY_NAME_MEX_LEON_TIKAL" Text="Xilotepec" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MEX_LEON_LA_VENTA" Text="Xilotepec" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MEX_LEON_PALENQUE" Text="Xilotepec" Language="en_US" />
-		
+
 		<!-- CENTRAL AMERICA -->
 		<Replace Tag="LOC_CITY_NAME_BELIZE_CITY" Text="Belize City" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BELIZE_CITY_RUSSIA" Text="Beliz Gorod" Language="en_US" />
@@ -7327,11 +8197,11 @@
 		<Replace Tag="LOC_CITY_NAME_SAN_PEDRO_SULA_LA_VENTA" Text="Nito" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAN_PEDRO_SULA_PALENQUE" Text="Nito" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TEGUCIGALPA" Text="Tegucigalpa" Language="en_US" />
-		
+
 	</LocalizedText>
-	
+
 	<LocalizedText>		<!-- SOUTH AMERICA & CARIBBEAN -->
-		
+
 		<Replace Tag="LOC_CITY_NAME_HAVANA" Text="Havana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MATANZAS" Text="Matanzas" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VARADERO" Text="Varadero" Language="en_US" />
@@ -7526,7 +8396,7 @@
 		<Replace Tag="LOC_CITY_NAME_ARAPIRACA" Text="Arapiraca" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MACEIO" Text="Maceio" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHIMBOTE" Text="Chimbote" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PUCALLPA" Text="Pucallpa" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_PUCALLPA" Text="Pucallpa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FEIJO" Text="Feijo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LABREA" Text="Labrea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COARI" Text="Coari" Language="en_US" />
@@ -7542,7 +8412,7 @@
 		<Replace Tag="LOC_CITY_NAME_CARPINA" Text="Carpina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RECIFE" Text="Recife" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TARAPOTO" Text="Tarapoto" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SANTOA" Text="Santoa" Language="en_US" />		
+		<Replace Tag="LOC_CITY_NAME_SANTOA" Text="Santoa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FOGOSO" Text="Fogoso" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARAUARI" Text="Carauari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_URUCU" Text="Urucu" Language="en_US" />
@@ -7702,5 +8572,5 @@
 		<Replace Tag="LOC_CITY_NAME_PORT_STEPHENS" Text="Port Stephens" Language="en_US" />
 
 	</LocalizedText>
-	
+
 </GameData>

--- a/Maps/GiantEarth/CityMap.xml
+++ b/Maps/GiantEarth/CityMap.xml
@@ -4,37 +4,31 @@
 	<!-- ++++++++++++++++++++++++++ -->
 	<!-- "Giant Earth Map" City Map -->
 	<!-- ++++++++++++++++++++++++++ -->
-	
-	<!-- CAPITALS -->	
-	<CityMap>	<!-- (temporary section to cover all TSL that doesn't fit the game's capitals names) -->
-		
-		<Replace MapName="GiantEarth" X="32" Y="43" CityLocaleName="LOC_CITY_NAME_LUXOR" />
-		
-	</CityMap>
-	
-	
+
+
+
 	<!-- +++++++++++++++ -->
 	<!-- Europe City Map -->
 	<!-- +++++++++++++++ -->
 
-	
+
 	<!-- CONTINENTAL WESTERN EUROPE -->
 	<CityMap>
-		
+
 		<!-- AZORES -->
 		<Replace MapName="GiantEarth" X="177" Y="55" CityLocaleName="LOC_CITY_NAME_PONTA_DELGADA" Area="0" />
 		<Replace MapName="GiantEarth" X="178" Y="57" CityLocaleName="LOC_CITY_NAME_ANGRA" Area="0" />
-		
+
 		<!-- IBERIA -->
 		<Replace MapName="GiantEarth" X="7" Y="52" CityLocaleName="LOC_CITY_NAME_GIBRALTAR" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="53" CityLocaleName="LOC_CITY_NAME_FARO" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="53" CityLocaleName="LOC_CITY_NAME_HUELVA" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="53" CityLocaleName="LOC_CITY_NAME_CADIZ" Area="0" />
 		<Replace MapName="GiantEarth" X="7" Y="53" CityLocaleName="LOC_CITY_NAME_MALAGA" Area="0" />
 		<Replace MapName="GiantEarth" X="8" Y="53" CityLocaleName="LOC_CITY_NAME_MALAGA" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="53" CityLocaleName="LOC_CITY_NAME_ALMERIA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="54" CityLocaleName="LOC_CITY_NAME_SETUBAL" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="54" CityLocaleName="LOC_CITY_NAME_SETUBAL" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="54" CityLocaleName="LOC_CITY_NAME_SEVILLA" Area="0" />
@@ -42,7 +36,7 @@
 		<Replace MapName="GiantEarth" X="8" Y="54" CityLocaleName="LOC_CITY_NAME_CORDOBA" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="54" CityLocaleName="LOC_CITY_NAME_GRANADA" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="54" CityLocaleName="LOC_CITY_NAME_CARTAGENA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="55" CityLocaleName="LOC_CITY_NAME_LISBOA" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="55" CityLocaleName="LOC_CITY_NAME_EVORA" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="55" CityLocaleName="LOC_CITY_NAME_SEVILLA" Area="0" />
@@ -50,7 +44,7 @@
 		<Replace MapName="GiantEarth" X="8" Y="55" CityLocaleName="LOC_CITY_NAME_CORDOBA" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="55" CityLocaleName="LOC_CITY_NAME_ALBACETE" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="55" CityLocaleName="LOC_CITY_NAME_VALENCIA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="56" CityLocaleName="LOC_CITY_NAME_LISBOA" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="56" CityLocaleName="LOC_CITY_NAME_EVORA" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="56" CityLocaleName="LOC_CITY_NAME_MERIDA" Area="0" />
@@ -58,7 +52,7 @@
 		<Replace MapName="GiantEarth" X="8" Y="56" CityLocaleName="LOC_CITY_NAME_TOLEDO" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="56" CityLocaleName="LOC_CITY_NAME_CUENCA" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="56" CityLocaleName="LOC_CITY_NAME_VALENCIA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="57" CityLocaleName="LOC_CITY_NAME_COIMBRA" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="57" CityLocaleName="LOC_CITY_NAME_GUARDA" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="57" CityLocaleName="LOC_CITY_NAME_AVILA" Area="0" />
@@ -66,7 +60,7 @@
 		<Replace MapName="GiantEarth" X="8" Y="57" CityLocaleName="LOC_CITY_NAME_MADRID" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="57" CityLocaleName="LOC_CITY_NAME_TERUEL" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="57" CityLocaleName="LOC_CITY_NAME_TARRAGONA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="58" CityLocaleName="LOC_CITY_NAME_PORTO" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="58" CityLocaleName="LOC_CITY_NAME_VILA_REAL" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="58" CityLocaleName="LOC_CITY_NAME_SALAMANCA" Area="0" />
@@ -75,7 +69,7 @@
 		<Replace MapName="GiantEarth" X="9" Y="58" CityLocaleName="LOC_CITY_NAME_ZARAGOZA" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="58" CityLocaleName="LOC_CITY_NAME_ZARAGOZA" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="58" CityLocaleName="LOC_CITY_NAME_BARCELONA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="3" Y="59" CityLocaleName="LOC_CITY_NAME_VIGO" Area="0" />
 		<Replace MapName="GiantEarth" X="4" Y="59" CityLocaleName="LOC_CITY_NAME_SANTIAGO_DE_COMPOSTELA" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="59" CityLocaleName="LOC_CITY_NAME_LEON" Area="0" />
@@ -86,19 +80,19 @@
 		<Replace MapName="GiantEarth" X="10" Y="59" CityLocaleName="LOC_CITY_NAME_ZARAGOZA" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="59" CityLocaleName="LOC_CITY_NAME_BARCELONA" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="59" CityLocaleName="LOC_CITY_NAME_GIRONA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="60" CityLocaleName="LOC_CITY_NAME_A_CORUNA" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="60" CityLocaleName="LOC_CITY_NAME_A_CORUNA" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="60" CityLocaleName="LOC_CITY_NAME_GIJON" Area="0" />
 		<Replace MapName="GiantEarth" X="7" Y="60" CityLocaleName="LOC_CITY_NAME_SANTANDER" Area="0" />
 		<Replace MapName="GiantEarth" X="8" Y="60" CityLocaleName="LOC_CITY_NAME_BILBAO" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="60" CityLocaleName="LOC_CITY_NAME_SAN_SEBASTIAN" Area="0" />
-		
+
 		<!-- FRANCE & SWITZERLAND -->
 		<Replace MapName="GiantEarth" X="12" Y="60" CityLocaleName="LOC_CITY_NAME_PERPIGNAN" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="60" CityLocaleName="LOC_CITY_NAME_MARSEILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="16" Y="60" CityLocaleName="LOC_CITY_NAME_NICE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="9" Y="61" CityLocaleName="LOC_CITY_NAME_BAYONNE" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="61" CityLocaleName="LOC_CITY_NAME_TOULOUSE" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="61" CityLocaleName="LOC_CITY_NAME_TOULOUSE" Area="0" />
@@ -107,21 +101,21 @@
 		<Replace MapName="GiantEarth" X="14" Y="61" CityLocaleName="LOC_CITY_NAME_MARSEILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="61" CityLocaleName="LOC_CITY_NAME_AIX_EN_PROVENCE" Area="0" />
 		<Replace MapName="GiantEarth" X="16" Y="61" CityLocaleName="LOC_CITY_NAME_NICE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="10" Y="62" CityLocaleName="LOC_CITY_NAME_BORDEAUX" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="62" CityLocaleName="LOC_CITY_NAME_BORDEAUX" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="62" CityLocaleName="LOC_CITY_NAME_MENDE" Area="0" />
 		<Replace MapName="GiantEarth" X="13" Y="62" CityLocaleName="LOC_CITY_NAME_MENDE" Area="0" />
 		<Replace MapName="GiantEarth" X="14" Y="62" CityLocaleName="LOC_CITY_NAME_AVIGNON" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="62" CityLocaleName="LOC_CITY_NAME_AVIGNON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="10" Y="63" CityLocaleName="LOC_CITY_NAME_BORDEAUX" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="63" CityLocaleName="LOC_CITY_NAME_ANGOULEME" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="63" CityLocaleName="LOC_CITY_NAME_LIMOGES" Area="0" />
 		<Replace MapName="GiantEarth" X="13" Y="63" CityLocaleName="LOC_CITY_NAME_SAINT_ETIENNE" Area="0" />
 		<Replace MapName="GiantEarth" X="14" Y="63" CityLocaleName="LOC_CITY_NAME_LYON" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="63" CityLocaleName="LOC_CITY_NAME_GENEVA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="10" Y="64" CityLocaleName="LOC_CITY_NAME_LA_ROCHELLE" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="64" CityLocaleName="LOC_CITY_NAME_POITIERS" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="64" CityLocaleName="LOC_CITY_NAME_CHATEAUROUX" Area="0" />
@@ -130,7 +124,7 @@
 		<Replace MapName="GiantEarth" X="15" Y="64" CityLocaleName="LOC_CITY_NAME_LYON" Area="0" />
 		<Replace MapName="GiantEarth" X="16" Y="64" CityLocaleName="LOC_CITY_NAME_BERN" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="64" CityLocaleName="LOC_CITY_NAME_LUGANO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="9" Y="65" CityLocaleName="LOC_CITY_NAME_NANTES" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="65" CityLocaleName="LOC_CITY_NAME_NANTES" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="65" CityLocaleName="LOC_CITY_NAME_TOURS" Area="0" />
@@ -140,7 +134,7 @@
 		<Replace MapName="GiantEarth" X="15" Y="65" CityLocaleName="LOC_CITY_NAME_DIJON" Area="0" />
 		<Replace MapName="GiantEarth" X="16" Y="65" CityLocaleName="LOC_CITY_NAME_BASEL" Area="0" />
 		<Replace MapName="GiantEarth" X="17" Y="65" CityLocaleName="LOC_CITY_NAME_ZURICH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="8" Y="66" CityLocaleName="LOC_CITY_NAME_QUIMPER" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="66" CityLocaleName="LOC_CITY_NAME_SAINT_NAZAIRE" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="66" CityLocaleName="LOC_CITY_NAME_NANTES" Area="0" />
@@ -150,7 +144,7 @@
 		<Replace MapName="GiantEarth" X="14" Y="66" CityLocaleName="LOC_CITY_NAME_TROYES" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="66" CityLocaleName="LOC_CITY_NAME_TROYES" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="66" CityLocaleName="LOC_CITY_NAME_STRASBOURG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="7" Y="67" CityLocaleName="LOC_CITY_NAME_BREST" Area="0" />
 		<Replace MapName="GiantEarth" X="8" Y="67" CityLocaleName="LOC_CITY_NAME_SAINT_BRIEUC" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="67" CityLocaleName="LOC_CITY_NAME_SAINT_BRIEUC" Area="0" />
@@ -161,278 +155,278 @@
 		<Replace MapName="GiantEarth" X="14" Y="67" CityLocaleName="LOC_CITY_NAME_REIMS" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="67" CityLocaleName="LOC_CITY_NAME_METZ" Area="0" />
 		<Replace MapName="GiantEarth" X="16" Y="67" CityLocaleName="LOC_CITY_NAME_STRASBOURG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="11" Y="68" CityLocaleName="LOC_CITY_NAME_CAEN" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="68" CityLocaleName="LOC_CITY_NAME_CAEN" Area="0" />
 		<Replace MapName="GiantEarth" X="13" Y="68" CityLocaleName="LOC_CITY_NAME_PARIS" Area="0" />
 		<Replace MapName="GiantEarth" X="14" Y="68" CityLocaleName="LOC_CITY_NAME_LILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="68" CityLocaleName="LOC_CITY_NAME_REIMS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="10" Y="69" CityLocaleName="LOC_CITY_NAME_CHERBOURG_OCTEVILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="69" CityLocaleName="LOC_CITY_NAME_ROUEN" Area="0" />
 		<Replace MapName="GiantEarth" X="13" Y="69" CityLocaleName="LOC_CITY_NAME_CALAIS" Area="0" />
-		
+
 		<!-- BENELUX -->
 		<Replace MapName="GiantEarth" X="16" Y="68" CityLocaleName="LOC_CITY_NAME_LUXEMBOURG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="14" Y="69" CityLocaleName="LOC_CITY_NAME_BRUSSELS" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="69" CityLocaleName="LOC_CITY_NAME_LIEGE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="14" Y="70" CityLocaleName="LOC_CITY_NAME_BRUGGE" Area="0" />
 		<Replace MapName="GiantEarth" X="15" Y="70" CityLocaleName="LOC_CITY_NAME_BRUSSELS" Area="0" />
 		<Replace MapName="GiantEarth" X="16" Y="70" CityLocaleName="LOC_CITY_NAME_EINDHOVEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="15" Y="71" CityLocaleName="LOC_CITY_NAME_AMSTERDAM" Area="0" />
 		<Replace MapName="GiantEarth" X="16" Y="71" CityLocaleName="LOC_CITY_NAME_ARNHEM" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="16" Y="72" CityLocaleName="LOC_CITY_NAME_GRONINGEN" Area="0" />
 		<Replace MapName="GiantEarth" X="17" Y="62" CityLocaleName="LOC_CITY_NAME_GRONINGEN" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- WESTERN MEDITERRANEAN ISLANDS -->
 	<CityMap>
-		
+
 		<!-- MAJORCA -->
 		<Replace MapName="GiantEarth" X="13" Y="56" CityLocaleName="LOC_CITY_NAME_PALMA_DE_MALLORCA" Area="0" />
-		
+
 		<!-- CORSICA -->
 		<Replace MapName="GiantEarth" X="17" Y="59" CityLocaleName="LOC_CITY_NAME_AJACCIO" Area="0" />
-		
+
 		<!-- SARDINIA -->
 		<Replace MapName="GiantEarth" X="17" Y="56" CityLocaleName="LOC_CITY_NAME_CAGLIARI" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="56" CityLocaleName="LOC_CITY_NAME_CAGLIARI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="57" CityLocaleName="LOC_CITY_NAME_OLBIA" Area="0" />
-		
+
 		<!-- SICILY -->
 		<Replace MapName="GiantEarth" X="20" Y="52" CityLocaleName="LOC_CITY_NAME_MARSALA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="52" CityLocaleName="LOC_CITY_NAME_SIRACUSA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="53" CityLocaleName="LOC_CITY_NAME_PALERMO" Area="0" />
-		
+
 		<!-- MALTA -->
 		<Replace MapName="GiantEarth" X="22" Y="51" CityLocaleName="LOC_CITY_NAME_VALLETTA" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- ITALY -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="53" CityLocaleName="LOC_CITY_NAME_REGGIO_CALABRIA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="23" Y="54" CityLocaleName="LOC_CITY_NAME_CROTONE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="55" CityLocaleName="LOC_CITY_NAME_CORIGLIANO_CALABRO" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="55" CityLocaleName="LOC_CITY_NAME_LECCE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="56" CityLocaleName="LOC_CITY_NAME_NAPOLI" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="56" CityLocaleName="LOC_CITY_NAME_BARI" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="56" CityLocaleName="LOC_CITY_NAME_BRINDISI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="57" CityLocaleName="LOC_CITY_NAME_ROMA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="57" CityLocaleName="LOC_CITY_NAME_NAPOLI" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="57" CityLocaleName="LOC_CITY_NAME_FOGGIA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="58" CityLocaleName="LOC_CITY_NAME_ROMA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="58" CityLocaleName="LOC_CITY_NAME_ROMA" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="58" CityLocaleName="LOC_CITY_NAME_PESCARA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="59" CityLocaleName="LOC_CITY_NAME_PISA" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="59" CityLocaleName="LOC_CITY_NAME_L_AQUILA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="59" CityLocaleName="LOC_CITY_NAME_SAN_BENEDETTO_DEL_TRONTO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="60" CityLocaleName="LOC_CITY_NAME_PISA" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="60" CityLocaleName="LOC_CITY_NAME_FIRENZE" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="60" CityLocaleName="LOC_CITY_NAME_RAVENNA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="61" CityLocaleName="LOC_CITY_NAME_GENOA" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="61" CityLocaleName="LOC_CITY_NAME_GENOA" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="61" CityLocaleName="LOC_CITY_NAME_BOLOGNA" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="61" CityLocaleName="LOC_CITY_NAME_RAVENNA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="62" CityLocaleName="LOC_CITY_NAME_TORINO" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="62" CityLocaleName="LOC_CITY_NAME_MILANO" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="62" CityLocaleName="LOC_CITY_NAME_CREMONA" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="62" CityLocaleName="LOC_CITY_NAME_PADOVA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="62" CityLocaleName="LOC_CITY_NAME_VENETIA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="63" CityLocaleName="LOC_CITY_NAME_TORINO" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="63" CityLocaleName="LOC_CITY_NAME_MILANO" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="63" CityLocaleName="LOC_CITY_NAME_VERONA" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="63" CityLocaleName="LOC_CITY_NAME_VICENZA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="63" CityLocaleName="LOC_CITY_NAME_VENETIA" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="63" CityLocaleName="LOC_CITY_NAME_TRIESTE" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- BRITISH ISLES -->
-	<CityMap> 
-		
+	<CityMap>
+
 		<!-- GREAT BRITAIN, SHETLAND & HEBRIDIES -->
 		<Replace MapName="GiantEarth" X="7" Y="70" CityLocaleName="LOC_CITY_NAME_PLYMOUTH" Area="0" />
 		<Replace MapName="GiantEarth" X="8" Y="70" CityLocaleName="LOC_CITY_NAME_EXETER" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="7" Y="71" CityLocaleName="LOC_CITY_NAME_LAUNCESTON" Area="0" />
 		<Replace MapName="GiantEarth" X="8" Y="71" CityLocaleName="LOC_CITY_NAME_BRISTOL" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="71" CityLocaleName="LOC_CITY_NAME_SOUTHAMPTON" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="71" CityLocaleName="LOC_CITY_NAME_PORTSMOUTH" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="71" CityLocaleName="LOC_CITY_NAME_BRIGHTON" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="71" CityLocaleName="LOC_CITY_NAME_CANTERBURY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="9" Y="72" CityLocaleName="LOC_CITY_NAME_GLOUCESTER" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="72" CityLocaleName="LOC_CITY_NAME_OXFORD" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="72" CityLocaleName="LOC_CITY_NAME_LONDON" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="72" CityLocaleName="LOC_CITY_NAME_LONDON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="7" Y="73" CityLocaleName="LOC_CITY_NAME_CARMARTHEN" Area="0" />
 		<Replace MapName="GiantEarth" X="8" Y="73" CityLocaleName="LOC_CITY_NAME_CARDIFF" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="73" CityLocaleName="LOC_CITY_NAME_WORCESTER" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="73" CityLocaleName="LOC_CITY_NAME_BIRMINGHAM" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="73" CityLocaleName="LOC_CITY_NAME_CAMBRIDGE" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="73" CityLocaleName="LOC_CITY_NAME_NORWICH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="8" Y="74" CityLocaleName="LOC_CITY_NAME_CAERNARFON" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="74" CityLocaleName="LOC_CITY_NAME_LIVERPOOL" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="74" CityLocaleName="LOC_CITY_NAME_BIRMINGHAM" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="74" CityLocaleName="LOC_CITY_NAME_NOTTINGHAM" Area="0" />
 		<Replace MapName="GiantEarth" X="12" Y="74" CityLocaleName="LOC_CITY_NAME_LINCOLN" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="9" Y="75" CityLocaleName="LOC_CITY_NAME_MANCHESTER" Area="0" />
+
+		<Replace MapName="GiantEarth" X="9" Y="75" CityLocaleName="LOC_CITY_NAME_LIVERPOOL" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="75" CityLocaleName="LOC_CITY_NAME_YORK" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="75" CityLocaleName="LOC_CITY_NAME_YORK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="10" Y="76" CityLocaleName="LOC_CITY_NAME_LANCASTER" Area="0" />
 		<Replace MapName="GiantEarth" X="11" Y="76" CityLocaleName="LOC_CITY_NAME_YORK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="9" Y="77" CityLocaleName="LOC_CITY_NAME_CARLISLE" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="77" CityLocaleName="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="8" Y="78" CityLocaleName="LOC_CITY_NAME_STRANRAER" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="78" CityLocaleName="LOC_CITY_NAME_DUMFRIES" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="78" CityLocaleName="LOC_CITY_NAME_EDINBURGH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="8" Y="79" CityLocaleName="LOC_CITY_NAME_GLASGOW" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="79" CityLocaleName="LOC_CITY_NAME_EDINBURGH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="6" Y="80" CityLocaleName="LOC_CITY_NAME_STORNOWAY" Area="0" />
 		<Replace MapName="GiantEarth" X="8" Y="80" CityLocaleName="LOC_CITY_NAME_FORT_WILLIAM" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="80" CityLocaleName="LOC_CITY_NAME_PERTH" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="80" CityLocaleName="LOC_CITY_NAME_DUNDEE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="7" Y="81" CityLocaleName="LOC_CITY_NAME_PORTREE" Area="0" />
 		<Replace MapName="GiantEarth" X="8" Y="81" CityLocaleName="LOC_CITY_NAME_FORT_AUGUSTUS" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="81" CityLocaleName="LOC_CITY_NAME_INVERNESS" Area="0" />
 		<Replace MapName="GiantEarth" X="10" Y="81" CityLocaleName="LOC_CITY_NAME_ABERDEEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="8" Y="82" CityLocaleName="LOC_CITY_NAME_ULLAPOOL" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="82" CityLocaleName="LOC_CITY_NAME_HELMSDALE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="8" Y="83" CityLocaleName="LOC_CITY_NAME_THURSO" Area="0" />
 		<Replace MapName="GiantEarth" X="9" Y="83" CityLocaleName="LOC_CITY_NAME_WICK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="12" Y="84" CityLocaleName="LOC_CITY_NAME_SCALLOWAY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="12" Y="85" CityLocaleName="LOC_CITY_NAME_LERWICK" Area="0" />
-		
+
 		<!-- IRELAND -->
 		<Replace MapName="GiantEarth" X="3" Y="73" CityLocaleName="LOC_CITY_NAME_CORK" Area="0" />
 		<Replace MapName="GiantEarth" X="4" Y="73" CityLocaleName="LOC_CITY_NAME_CORK" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="73" CityLocaleName="LOC_CITY_NAME_WATERFORD" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="74" CityLocaleName="LOC_CITY_NAME_LIMERICK" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="74" CityLocaleName="LOC_CITY_NAME_LIMERICK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="75" CityLocaleName="LOC_CITY_NAME_GALWAY" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="75" CityLocaleName="LOC_CITY_NAME_DUBLIN" />
-		
+
 		<Replace MapName="GiantEarth" X="4" Y="76" CityLocaleName="LOC_CITY_NAME_SLIGO" Area="0" />
 		<Replace MapName="GiantEarth" X="5" Y="76" CityLocaleName="LOC_CITY_NAME_DONEGAL" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="76" CityLocaleName="LOC_CITY_NAME_ARMAGH" Area="0" /> <!--OVERLAP-->
 		<Replace MapName="GiantEarth" X="7" Y="76" CityLocaleName="LOC_CITY_NAME_BELFAST" Area="0" /> <!--OVERLAP-->
-		
+
 		<Replace MapName="GiantEarth" X="5" Y="77" CityLocaleName="LOC_CITY_NAME_DERRY" Area="0" />
 		<Replace MapName="GiantEarth" X="6" Y="77" CityLocaleName="LOC_CITY_NAME_BELFAST" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- ICELAND -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="2" Y="83" CityLocaleName="LOC_CITY_NAME_HELLA" Area="0" />
 		<Replace MapName="GiantEarth" X="3" Y="83" CityLocaleName="LOC_CITY_NAME_HOFN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="1" Y="84" CityLocaleName="LOC_CITY_NAME_REYKJAVIK" />
 		<Replace MapName="GiantEarth" X="3" Y="84" CityLocaleName="LOC_CITY_NAME_AKUREYRI" Area="0" />
 		<Replace MapName="GiantEarth" X="4" Y="84" CityLocaleName="LOC_CITY_NAME_REYTHARFJORTHUR" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="2" Y="85" CityLocaleName="LOC_CITY_NAME_AKUREYRI" Area="0" />
 		<Replace MapName="GiantEarth" X="4" Y="85" CityLocaleName="LOC_CITY_NAME_THORSHOFN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="1" Y="86" CityLocaleName="LOC_CITY_NAME_ISAFJORTHUR" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- SCANDINAVIA (NORWAY, SWEDEN, FINLAND, KARELIA, & KOLA PENINSULA) -->
 	<CityMap>
-	
+
 		<Replace MapName="GiantEarth" X="22" Y="75" CityLocaleName="LOC_CITY_NAME_MALMOE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="76" CityLocaleName="LOC_CITY_NAME_HELSINGBORG" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="76" CityLocaleName="LOC_CITY_NAME_KARLSHAMN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="21" Y="77" CityLocaleName="LOC_CITY_NAME_GOETEBORG" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="77" CityLocaleName="LOC_CITY_NAME_VAEXJOE" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="77" CityLocaleName="LOC_CITY_NAME_KALMAR" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="25" Y="77" CityLocaleName="LOC_CITY_NAME_VISBY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="18" Y="78" CityLocaleName="LOC_CITY_NAME_STAVANGER" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="78" CityLocaleName="LOC_CITY_NAME_KRISTIANSAND" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="78" CityLocaleName="LOC_CITY_NAME_GOETEBORG" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="78" CityLocaleName="LOC_CITY_NAME_VAEXJOE" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="78" CityLocaleName="LOC_CITY_NAME_KALMAR" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="18" Y="79" CityLocaleName="LOC_CITY_NAME_SELJORD" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="79" CityLocaleName="LOC_CITY_NAME_TONSBERG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="21" Y="79" CityLocaleName="LOC_CITY_NAME_FREDRIKSTAD" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="79" CityLocaleName="LOC_CITY_NAME_JOENKOEPING" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="79" CityLocaleName="LOC_CITY_NAME_LINKOEPING" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="79" CityLocaleName="LOC_CITY_NAME_STOCKHOLM" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="27" Y="79" CityLocaleName="LOC_CITY_NAME_TURKU" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="79" CityLocaleName="LOC_CITY_NAME_HELSINKI" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="79" CityLocaleName="LOC_CITY_NAME_HELSINKI" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="79" CityLocaleName="LOC_CITY_NAME_VYBORG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="80" CityLocaleName="LOC_CITY_NAME_RJUKAN" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="80" CityLocaleName="LOC_CITY_NAME_OSLO" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="80" CityLocaleName="LOC_CITY_NAME_OSLO" Area="0" />
-		                                        
+
 		<Replace MapName="GiantEarth" X="23" Y="80" CityLocaleName="LOC_CITY_NAME_OEREBRO" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="80" CityLocaleName="LOC_CITY_NAME_STOCKHOLM" Area="0" />
-		                                        
+
 		<Replace MapName="GiantEarth" X="27" Y="80" CityLocaleName="LOC_CITY_NAME_TURKU" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="80" CityLocaleName="LOC_CITY_NAME_KUOVOLA" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="80" CityLocaleName="LOC_CITY_NAME_PRIOZERSK" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="80" CityLocaleName="LOC_CITY_NAME_PETROZAVODSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="81" CityLocaleName="LOC_CITY_NAME_BERGEN" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="81" CityLocaleName="LOC_CITY_NAME_BERGEN" Area="0" />
-		                                        
+
 		<Replace MapName="GiantEarth" X="20" Y="81" CityLocaleName="LOC_CITY_NAME_OSLO" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="81" CityLocaleName="LOC_CITY_NAME_KARLSTAD" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="81" CityLocaleName="LOC_CITY_NAME_VAESTERAS" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="81" CityLocaleName="LOC_CITY_NAME_UPPSALA" Area="0" />
-		                                        
+
 		<Replace MapName="GiantEarth" X="26" Y="81" CityLocaleName="LOC_CITY_NAME_RAUMA" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="81" CityLocaleName="LOC_CITY_NAME_TAMPERE" />
 		<Replace MapName="GiantEarth" X="30" Y="81" CityLocaleName="LOC_CITY_NAME_JOENSUU" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="81" CityLocaleName="LOC_CITY_NAME_JOENSUU" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="81" CityLocaleName="LOC_CITY_NAME_PETROZAVODSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="18" Y="82" CityLocaleName="LOC_CITY_NAME_BERGEN" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="82" CityLocaleName="LOC_CITY_NAME_NORDFJORDEID" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="82" CityLocaleName="LOC_CITY_NAME_NORDFJORDEID" Area="0" />
@@ -440,60 +434,60 @@
 		<Replace MapName="GiantEarth" X="22" Y="82" CityLocaleName="LOC_CITY_NAME_MORA" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="82" CityLocaleName="LOC_CITY_NAME_MORA" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="82" CityLocaleName="LOC_CITY_NAME_HUDIKSVAL" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="27" Y="82" CityLocaleName="LOC_CITY_NAME_VAASA" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="82" CityLocaleName="LOC_CITY_NAME_JOENSUU" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="82" CityLocaleName="LOC_CITY_NAME_MEDVEZHYEGORSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="18" Y="83" CityLocaleName="LOC_CITY_NAME_ALESUND" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="83" CityLocaleName="LOC_CITY_NAME_KRISTIANSUND" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="21" Y="83" CityLocaleName="LOC_CITY_NAME_LILLEHAMMER" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="83" CityLocaleName="LOC_CITY_NAME_ROEROS" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="83" CityLocaleName="LOC_CITY_NAME_OESTERSUND" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="83" CityLocaleName="LOC_CITY_NAME_SUNDSVALL" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="27" Y="83" CityLocaleName="LOC_CITY_NAME_VAASA" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="83" CityLocaleName="LOC_CITY_NAME_VIMPELI" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="83" CityLocaleName="LOC_CITY_NAME_KUOPIO" />
 		<Replace MapName="GiantEarth" X="32" Y="83" CityLocaleName="LOC_CITY_NAME_SEGEZHA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="84" CityLocaleName="LOC_CITY_NAME_TRONDHEIM" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="84" CityLocaleName="LOC_CITY_NAME_TRONDHEIM" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="23" Y="84" CityLocaleName="LOC_CITY_NAME_ARE" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="84" CityLocaleName="LOC_CITY_NAME_OESTERSUND" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="84" CityLocaleName="LOC_CITY_NAME_SUNDSVALL" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="28" Y="84" CityLocaleName="LOC_CITY_NAME_JAKOBSTAD" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="84" CityLocaleName="LOC_CITY_NAME_VIMPELI" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="84" CityLocaleName="LOC_CITY_NAME_KEM" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="84" CityLocaleName="LOC_CITY_NAME_KEM" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="21" Y="85" CityLocaleName="LOC_CITY_NAME_TRONDHEIM" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="23" Y="85" CityLocaleName="LOC_CITY_NAME_ARE" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="85" CityLocaleName="LOC_CITY_NAME_UMEA" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="85" CityLocaleName="LOC_CITY_NAME_UMEA" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="28" Y="85" CityLocaleName="LOC_CITY_NAME_OULU" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="85" CityLocaleName="LOC_CITY_NAME_KAJAANI" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="85" CityLocaleName="LOC_CITY_NAME_KOSTOMUKSHA" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="85" CityLocaleName="LOC_CITY_NAME_KOSTOMUKSHA" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="85" CityLocaleName="LOC_CITY_NAME_KEM" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="86" CityLocaleName="LOC_CITY_NAME_NAMSOS" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="24" Y="86" CityLocaleName="LOC_CITY_NAME_ARJEPLOG" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="86" CityLocaleName="LOC_CITY_NAME_BODEN" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="86" CityLocaleName="LOC_CITY_NAME_LULEA" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="28" Y="86" CityLocaleName="LOC_CITY_NAME_OULU" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="86" CityLocaleName="LOC_CITY_NAME_KUUSAMO" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="86" CityLocaleName="LOC_CITY_NAME_KUUSAMO" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="86" CityLocaleName="LOC_CITY_NAME_KOSTOMUKSHA" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="86" CityLocaleName="LOC_CITY_NAME_PLOTINA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="87" CityLocaleName="LOC_CITY_NAME_NAMSOS" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="87" CityLocaleName="LOC_CITY_NAME_KVIKKJOKK" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="87" CityLocaleName="LOC_CITY_NAME_JOKKMOKK" Area="0" />
@@ -508,10 +502,10 @@
 		<Replace MapName="GiantEarth" X="33" Y="87" CityLocaleName="LOC_CITY_NAME_KUZOMEN" Area="0" />
 		<Replace MapName="GiantEarth" X="34" Y="87" CityLocaleName="LOC_CITY_NAME_KUZOMEN" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="87" CityLocaleName="LOC_CITY_NAME_KUZOMEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="23" Y="88" CityLocaleName="LOC_CITY_NAME_NARVIK" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="88" CityLocaleName="LOC_CITY_NAME_KVIKKJOKK" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="26" Y="88" CityLocaleName="LOC_CITY_NAME_GAELLIVARE" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="88" CityLocaleName="LOC_CITY_NAME_GAELLIVARE" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="88" CityLocaleName="LOC_CITY_NAME_ROVANIEMI" Area="0" />
@@ -523,87 +517,87 @@
 		<Replace MapName="GiantEarth" X="34" Y="88" CityLocaleName="LOC_CITY_NAME_KRASNOSHCHELYE" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="88" CityLocaleName="LOC_CITY_NAME_KANEVKA" Area="0" />
 		<Replace MapName="GiantEarth" X="36" Y="88" CityLocaleName="LOC_CITY_NAME_SVYATOY_NOS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="23" Y="89" CityLocaleName="LOC_CITY_NAME_TROMSO" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="89" CityLocaleName="LOC_CITY_NAME_TROMSO" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="27" Y="89" CityLocaleName="LOC_CITY_NAME_GAELLIVARE" Area="0" />
-		                                      
+
 		<Replace MapName="GiantEarth" X="29" Y="89" CityLocaleName="LOC_CITY_NAME_KAKSLAUTTANEN" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="89" CityLocaleName="LOC_CITY_NAME_KAKSLAUTTANEN" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="89" CityLocaleName="LOC_CITY_NAME_KRASNOSHCHELYE" Area="0" />
 		<Replace MapName="GiantEarth" X="34" Y="89" CityLocaleName="LOC_CITY_NAME_SVYATOY_NOS" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="89" CityLocaleName="LOC_CITY_NAME_SVYATOY_NOS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="25" Y="90" CityLocaleName="LOC_CITY_NAME_TROMSO" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="90" CityLocaleName="LOC_CITY_NAME_KAUTOKEINO" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="90" CityLocaleName="LOC_CITY_NAME_KAUTOKEINO" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="90" CityLocaleName="LOC_CITY_NAME_KAUTOKEINO" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="90" CityLocaleName="LOC_CITY_NAME_MURMANSK" />
 		<Replace MapName="GiantEarth" X="34" Y="90" CityLocaleName="LOC_CITY_NAME_TERIBERKA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="25" Y="91" CityLocaleName="LOC_CITY_NAME_HAMMERFEST" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="91" CityLocaleName="LOC_CITY_NAME_HAMMERFEST" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="91" CityLocaleName="LOC_CITY_NAME_HAMMERFEST" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="91" CityLocaleName="LOC_CITY_NAME_KIRKENES" />
-		
+
 	</CityMap>
-	
+
 	<!-- GERMANY, AUSTRIA, CZECHIA, & DENMARK-->
-	<CityMap> 
-		
+	<CityMap>
+
 		<!-- AUSTRIA -->
 		<Replace MapName="GiantEarth" X="23" Y="64" CityLocaleName="LOC_CITY_NAME_GRAZ" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="65" CityLocaleName="LOC_CITY_NAME_BREGENZ" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="65" CityLocaleName="LOC_CITY_NAME_INNSBRUCK" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="65" CityLocaleName="LOC_CITY_NAME_SALZBURG" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="65" CityLocaleName="LOC_CITY_NAME_LINZ" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="65" CityLocaleName="LOC_CITY_NAME_WIEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="66" CityLocaleName="LOC_CITY_NAME_LINZ" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="66" CityLocaleName="LOC_CITY_NAME_WIEN" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="66" CityLocaleName="LOC_CITY_NAME_WIEN" Area="0" />
-		
+
 		<!-- CZECHIA -->
 		<Replace MapName="GiantEarth" X="22" Y="67" CityLocaleName="LOC_CITY_NAME_PLZEN" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="67" CityLocaleName="LOC_CITY_NAME_CESKY_KRUMLOV" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="67" CityLocaleName="LOC_CITY_NAME_BRNO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="68" CityLocaleName="LOC_CITY_NAME_KARLOVY_VARY" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="68" CityLocaleName="LOC_CITY_NAME_PRAHA" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="68" CityLocaleName="LOC_CITY_NAME_PRAHA" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="68" CityLocaleName="LOC_CITY_NAME_OSTRAVA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="69" CityLocaleName="LOC_CITY_NAME_USTI_NAD_LABEM" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="69" CityLocaleName="LOC_CITY_NAME_PRAHA" Area="0" />
-		
+
 		<!-- GERMANY -->
 		<Replace MapName="GiantEarth" X="17" Y="66" CityLocaleName="LOC_CITY_NAME_FREIBURG" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="66" CityLocaleName="LOC_CITY_NAME_STUTTGART" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="66" CityLocaleName="LOC_CITY_NAME_ULM" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="66" CityLocaleName="LOC_CITY_NAME_MUNICH" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="66" CityLocaleName="LOC_CITY_NAME_MUNICH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="67" CityLocaleName="LOC_CITY_NAME_FRANKFURT_AM_MAIN" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="67" CityLocaleName="LOC_CITY_NAME_STUTTGART" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="67" CityLocaleName="LOC_CITY_NAME_HEIDENHEIM" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="67" CityLocaleName="LOC_CITY_NAME_MUNICH" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="67" CityLocaleName="LOC_CITY_NAME_REGENSBURG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="68" CityLocaleName="LOC_CITY_NAME_MAINZ" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="68" CityLocaleName="LOC_CITY_NAME_FRANKFURT_AM_MAIN" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="68" CityLocaleName="LOC_CITY_NAME_FRANKFURT_AM_MAIN" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="68" CityLocaleName="LOC_CITY_NAME_NUREMBERG" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="68" CityLocaleName="LOC_CITY_NAME_ZWICKAU" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="16" Y="69" CityLocaleName="LOC_CITY_NAME_AACHEN" Area="0" />
 		<Replace MapName="GiantEarth" X="17" Y="69" CityLocaleName="LOC_CITY_NAME_COLOGNE" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="69" CityLocaleName="LOC_CITY_NAME_PADERBORN" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="69" CityLocaleName="LOC_CITY_NAME_HANOVER" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="69" CityLocaleName="LOC_CITY_NAME_LEIPZIG" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="69" CityLocaleName="LOC_CITY_NAME_DRESDEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="70" CityLocaleName="LOC_CITY_NAME_ESSEN" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="70" CityLocaleName="LOC_CITY_NAME_MUENSTER" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="70" CityLocaleName="LOC_CITY_NAME_HANOVER" Area="0" />
@@ -611,7 +605,7 @@
 		<Replace MapName="GiantEarth" X="21" Y="70" CityLocaleName="LOC_CITY_NAME_POTSDAM" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="70" CityLocaleName="LOC_CITY_NAME_COTTBUS" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="70" CityLocaleName="LOC_CITY_NAME_GORLITZ" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="17" Y="71" CityLocaleName="LOC_CITY_NAME_BREMEN" Area="0" />
 		<Replace MapName="GiantEarth" X="18" Y="71" CityLocaleName="LOC_CITY_NAME_BREMEN" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="71" CityLocaleName="LOC_CITY_NAME_HAMBURG" Area="0" />
@@ -619,63 +613,63 @@
 		<Replace MapName="GiantEarth" X="21" Y="71" CityLocaleName="LOC_CITY_NAME_BERLIN" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="71" CityLocaleName="LOC_CITY_NAME_BERLIN" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="71" CityLocaleName="LOC_CITY_NAME_FRANKFURT_AN_DER_ODER" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="18" Y="72" CityLocaleName="LOC_CITY_NAME_WILHELMSHAVEN" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="72" CityLocaleName="LOC_CITY_NAME_HAMBURG" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="72" CityLocaleName="LOC_CITY_NAME_LUBECK" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="72" CityLocaleName="LOC_CITY_NAME_ROSTOCK" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="72" CityLocaleName="LOC_CITY_NAME_STRALSUND" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="72" CityLocaleName="LOC_CITY_NAME_FRANKFURT_AN_DER_ODER" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="73" CityLocaleName="LOC_CITY_NAME_KIEL" Area="0" />
-		
+
 		<!-- DENMARK -->
 		<Replace MapName="GiantEarth" X="19" Y="74" CityLocaleName="LOC_CITY_NAME_ESBJERG" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="74" CityLocaleName="LOC_CITY_NAME_ODENSE" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="74" CityLocaleName="LOC_CITY_NAME_KOBENHAVN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="75" CityLocaleName="LOC_CITY_NAME_ESBJERG" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="75" CityLocaleName="LOC_CITY_NAME_AARHUS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="76" CityLocaleName="LOC_CITY_NAME_AALBORG" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- EASTERN EUROPE -->
-	<CityMap> 
-		
+	<CityMap>
+
 		<!-- AEGEAN ISLANDS -->
 		<Replace MapName="GiantEarth" X="29" Y="52" CityLocaleName="LOC_CITY_NAME_HERAKLION" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="52" CityLocaleName="LOC_CITY_NAME_HERAKLION" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="30" Y="54" CityLocaleName="LOC_CITY_NAME_RHODES" Area="0" />
-		
+
 		<!-- CONTINENTAL EASTERN EUROPE -->
 		<Replace MapName="GiantEarth" X="27" Y="54" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="54" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="26" Y="55" CityLocaleName="LOC_CITY_NAME_OLYMPIA" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="55" CityLocaleName="LOC_CITY_NAME_CORINTH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="26" Y="56" CityLocaleName="LOC_CITY_NAME_AGRINIO" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="56" CityLocaleName="LOC_CITY_NAME_THEBES_EURO" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="56" CityLocaleName="LOC_CITY_NAME_ATHENS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="25" Y="57" CityLocaleName="LOC_CITY_NAME_IOANNINA" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="57" CityLocaleName="LOC_CITY_NAME_IOANNINA" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="57" CityLocaleName="LOC_CITY_NAME_LARISSA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="26" Y="58" CityLocaleName="LOC_CITY_NAME_DURRES" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="58" CityLocaleName="LOC_CITY_NAME_OHRID" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="58" CityLocaleName="LOC_CITY_NAME_THESSALONIKI" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="58" CityLocaleName="LOC_CITY_NAME_THESSALONIKI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="25" Y="59" CityLocaleName="LOC_CITY_NAME_DURRES" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="59" CityLocaleName="LOC_CITY_NAME_SKOPJE" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="59" CityLocaleName="LOC_CITY_NAME_BLAGOEVGRAD" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="59" CityLocaleName="LOC_CITY_NAME_PLOVDIV" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="59" CityLocaleName="LOC_CITY_NAME_ALEXANDROUPOLI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="60" CityLocaleName="LOC_CITY_NAME_DUBROVNIK" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="60" CityLocaleName="LOC_CITY_NAME_DUBROVNIK" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="60" CityLocaleName="LOC_CITY_NAME_SKOPJE" Area="0" />
@@ -684,7 +678,7 @@
 		<Replace MapName="GiantEarth" X="29" Y="60" CityLocaleName="LOC_CITY_NAME_PLOVDIV" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="60" CityLocaleName="LOC_CITY_NAME_EDIRNE" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="60" CityLocaleName="LOC_CITY_NAME_ISTANBUL" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="61" CityLocaleName="LOC_CITY_NAME_PULA" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="61" CityLocaleName="LOC_CITY_NAME_PULA" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="61" CityLocaleName="LOC_CITY_NAME_SARAJEVO" Area="0" />
@@ -694,7 +688,7 @@
 		<Replace MapName="GiantEarth" X="28" Y="61" CityLocaleName="LOC_CITY_NAME_SOFIA" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="61" CityLocaleName="LOC_CITY_NAME_PRESLAV" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="61" CityLocaleName="LOC_CITY_NAME_BURGAS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="23" Y="62" CityLocaleName="LOC_CITY_NAME_PULA" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="62" CityLocaleName="LOC_CITY_NAME_ZAGREB" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="62" CityLocaleName="LOC_CITY_NAME_SARAJEVO" Area="0" />
@@ -705,7 +699,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="62" CityLocaleName="LOC_CITY_NAME_BUCHAREST" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="62" CityLocaleName="LOC_CITY_NAME_VARNA" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="62" CityLocaleName="LOC_CITY_NAME_CONSTANTA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="23" Y="63" CityLocaleName="LOC_CITY_NAME_ZAGREB" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="63" CityLocaleName="LOC_CITY_NAME_ZAGREB" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="63" CityLocaleName="LOC_CITY_NAME_NOVI_SAD" Area="0" />
@@ -716,7 +710,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="63" CityLocaleName="LOC_CITY_NAME_BUCHAREST" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="63" CityLocaleName="LOC_CITY_NAME_CONSTANTA" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="63" CityLocaleName="LOC_CITY_NAME_CONSTANTA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="64" CityLocaleName="LOC_CITY_NAME_SZOMBATHELY" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="64" CityLocaleName="LOC_CITY_NAME_BUDAPEST" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="64" CityLocaleName="LOC_CITY_NAME_BUDAPEST" Area="0" />
@@ -726,7 +720,7 @@
 		<Replace MapName="GiantEarth" X="31" Y="64" CityLocaleName="LOC_CITY_NAME_BUZAU" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="64" CityLocaleName="LOC_CITY_NAME_GALATI" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="64" CityLocaleName="LOC_CITY_NAME_GALATI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="65" CityLocaleName="LOC_CITY_NAME_GYOR" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="65" CityLocaleName="LOC_CITY_NAME_BUDAPEST" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="65" CityLocaleName="LOC_CITY_NAME_BUDAPEST" Area="0" />
@@ -736,7 +730,7 @@
 		<Replace MapName="GiantEarth" X="31" Y="65" CityLocaleName="LOC_CITY_NAME_IASI" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="65" CityLocaleName="LOC_CITY_NAME_CHISINAU" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="65" CityLocaleName="LOC_CITY_NAME_BILHOROD_DNISTROVSKYI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="25" Y="66" CityLocaleName="LOC_CITY_NAME_BRATISLAVA" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="66" CityLocaleName="LOC_CITY_NAME_BRATISLAVA" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="66" CityLocaleName="LOC_CITY_NAME_KOSICE" Area="0" />
@@ -745,14 +739,14 @@
 		<Replace MapName="GiantEarth" X="31" Y="66" CityLocaleName="LOC_CITY_NAME_IASI" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="66" CityLocaleName="LOC_CITY_NAME_CHISINAU" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="66" CityLocaleName="LOC_CITY_NAME_CHISINAU" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="25" Y="67" CityLocaleName="LOC_CITY_NAME_BRATISLAVA" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="67" CityLocaleName="LOC_CITY_NAME_LVIV" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="67" CityLocaleName="LOC_CITY_NAME_KOLOMYYA" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="67" CityLocaleName="LOC_CITY_NAME_CHERNIVTSI" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="67" CityLocaleName="LOC_CITY_NAME_CHISINAU" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="67" CityLocaleName="LOC_CITY_NAME_UMAN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="26" Y="68" CityLocaleName="LOC_CITY_NAME_KRAKOW" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="68" CityLocaleName="LOC_CITY_NAME_KRAKOW" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="68" CityLocaleName="LOC_CITY_NAME_RZESZOW" Area="0" />
@@ -760,7 +754,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="68" CityLocaleName="LOC_CITY_NAME_LVIV" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="68" CityLocaleName="LOC_CITY_NAME_ZHYTOMYR" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="68" CityLocaleName="LOC_CITY_NAME_ZHYTOMYR" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="69" CityLocaleName="LOC_CITY_NAME_WROCLAW" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="69" CityLocaleName="LOC_CITY_NAME_KATOWICE" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="69" CityLocaleName="LOC_CITY_NAME_KRAKOW" Area="0" />
@@ -770,7 +764,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="69" CityLocaleName="LOC_CITY_NAME_RIVNE" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="69" CityLocaleName="LOC_CITY_NAME_ZHYTOMYR" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="69" CityLocaleName="LOC_CITY_NAME_KIEV" />
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="70" CityLocaleName="LOC_CITY_NAME_WROCLAW" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="70" CityLocaleName="LOC_CITY_NAME_WROCLAW" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="70" CityLocaleName="LOC_CITY_NAME_LODZ" Area="0" />
@@ -780,7 +774,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="70" CityLocaleName="LOC_CITY_NAME_BREST_LITOVSK" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="70" CityLocaleName="LOC_CITY_NAME_PINSK" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="70" CityLocaleName="LOC_CITY_NAME_PINSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="71" CityLocaleName="LOC_CITY_NAME_GORZOW_WIELKOPOLSI" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="71" CityLocaleName="LOC_CITY_NAME_POZNAN" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="71" CityLocaleName="LOC_CITY_NAME_WARSZAWA" Area="0" />
@@ -791,7 +785,7 @@
 		<Replace MapName="GiantEarth" X="31" Y="71" CityLocaleName="LOC_CITY_NAME_PINSK" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="71" CityLocaleName="LOC_CITY_NAME_GOMEL" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="71" CityLocaleName="LOC_CITY_NAME_GOMEL" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="72" CityLocaleName="LOC_CITY_NAME_GORZOW_WIELKOPOLSI" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="72" CityLocaleName="LOC_CITY_NAME_POZNAN" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="72" CityLocaleName="LOC_CITY_NAME_BYDGOSZCZ" Area="0" />
@@ -801,7 +795,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="72" CityLocaleName="LOC_CITY_NAME_MINSK" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="72" CityLocaleName="LOC_CITY_NAME_MINSK" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="72" CityLocaleName="LOC_CITY_NAME_VITEBSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="73" CityLocaleName="LOC_CITY_NAME_SZCZECIN" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="73" CityLocaleName="LOC_CITY_NAME_SZCZECIN" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="73" CityLocaleName="LOC_CITY_NAME_KOSZALIN" Area="0" />
@@ -813,49 +807,49 @@
 		<Replace MapName="GiantEarth" X="30" Y="73" CityLocaleName="LOC_CITY_NAME_MINSK" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="73" CityLocaleName="LOC_CITY_NAME_VITEBSK" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="73" CityLocaleName="LOC_CITY_NAME_SMOLENSK" />
-		
+
 		<Replace MapName="GiantEarth" X="27" Y="74" CityLocaleName="LOC_CITY_NAME_KOENIGSBERG" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="74" CityLocaleName="LOC_CITY_NAME_KAUNAS" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="74" CityLocaleName="LOC_CITY_NAME_VILNIUS" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="74" CityLocaleName="LOC_CITY_NAME_VILNIUS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="27" Y="75" CityLocaleName="LOC_CITY_NAME_KLAIPEDA" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="75" CityLocaleName="LOC_CITY_NAME_TARTU" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="75" CityLocaleName="LOC_CITY_NAME_TARTU" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="75" CityLocaleName="LOC_CITY_NAME_VELIKY_NOVGOROD" />
 		<Replace MapName="GiantEarth" X="33" Y="75" CityLocaleName="LOC_CITY_NAME_BOROVICHI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="28" Y="76" CityLocaleName="LOC_CITY_NAME_RIGA" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="76" CityLocaleName="LOC_CITY_NAME_RIGA" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="76" CityLocaleName="LOC_CITY_NAME_PSKOV" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="76" CityLocaleName="LOC_CITY_NAME_BOROVICHI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="29" Y="77" CityLocaleName="LOC_CITY_NAME_TALLINN" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="77" CityLocaleName="LOC_CITY_NAME_ST_PETERSBURG" />
 		<Replace MapName="GiantEarth" X="33" Y="77" CityLocaleName="LOC_CITY_NAME_KIRISHI" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- EUROPEAN RUSSIA -->
-	<CityMap> 
-		
+	<CityMap>
+
 		<Replace MapName="GiantEarth" X="41" Y="61" CityLocaleName="LOC_CITY_NAME_SOCHI" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="61" CityLocaleName="LOC_CITY_NAME_BAKU" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="41" Y="62" CityLocaleName="LOC_CITY_NAME_SOCHI" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="62" CityLocaleName="LOC_CITY_NAME_MAKHACHKALA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="39" Y="63" CityLocaleName="LOC_CITY_NAME_KRASNODAR" />
 		<Replace MapName="GiantEarth" X="42" Y="63" CityLocaleName="LOC_CITY_NAME_GROZNY" />
-		
+
 		<Replace MapName="GiantEarth" X="37" Y="64" CityLocaleName="LOC_CITY_NAME_SEVASTOPOL" />
 		<Replace MapName="GiantEarth" X="41" Y="64" CityLocaleName="LOC_CITY_NAME_STAVROPOL" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="64" CityLocaleName="LOC_CITY_NAME_LAGAN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="41" Y="65" CityLocaleName="LOC_CITY_NAME_STAVROPOL" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="65" CityLocaleName="LOC_CITY_NAME_STAVROPOL" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="65" CityLocaleName="LOC_CITY_NAME_ELISTA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="34" Y="66" CityLocaleName="LOC_CITY_NAME_ODESSA" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="66" CityLocaleName="LOC_CITY_NAME_ODESSA" Area="0" />
 		<Replace MapName="GiantEarth" X="36" Y="66" CityLocaleName="LOC_CITY_NAME_KHERSON" Area="0" />
@@ -867,14 +861,14 @@
 		<Replace MapName="GiantEarth" X="45" Y="66" CityLocaleName="LOC_CITY_NAME_ASTRAKHAN" />
 		<Replace MapName="GiantEarth" X="47" Y="66" CityLocaleName="LOC_CITY_NAME_ATYRAU" Area="0" />
 		<Replace MapName="GiantEarth" X="48" Y="66" CityLocaleName="LOC_CITY_NAME_ATYRAU" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="34" Y="67" CityLocaleName="LOC_CITY_NAME_ODESSA" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="67" CityLocaleName="LOC_CITY_NAME_DONETSK" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="67" CityLocaleName="LOC_CITY_NAME_DONETSK" Area="0" />
 		<Replace MapName="GiantEarth" X="41" Y="67" CityLocaleName="LOC_CITY_NAME_VOLGODONSK" Area="0" />
 		<Replace MapName="GiantEarth" X="49" Y="67" CityLocaleName="LOC_CITY_NAME_AKTOBE" />
 		<Replace MapName="GiantEarth" X="51" Y="67" CityLocaleName="LOC_CITY_NAME_ARALSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="36" Y="68" CityLocaleName="LOC_CITY_NAME_DNIPROPETROVSK" />
 		<Replace MapName="GiantEarth" X="40" Y="68" CityLocaleName="LOC_CITY_NAME_TAMBOV" Area="0" />
 		<Replace MapName="GiantEarth" X="41" Y="68" CityLocaleName="LOC_CITY_NAME_TAMBOV" Area="0" />
@@ -882,7 +876,7 @@
 		<Replace MapName="GiantEarth" X="45" Y="68" CityLocaleName="LOC_CITY_NAME_URALSK" Area="0" />
 		<Replace MapName="GiantEarth" X="47" Y="68" CityLocaleName="LOC_CITY_NAME_ORENBURG" />
 		<Replace MapName="GiantEarth" X="51" Y="68" CityLocaleName="LOC_CITY_NAME_ARALSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="38" Y="69" CityLocaleName="LOC_CITY_NAME_VORONEZH" />
 		<Replace MapName="GiantEarth" X="40" Y="69" CityLocaleName="LOC_CITY_NAME_TAMBOV" Area="0" />
 		<Replace MapName="GiantEarth" X="41" Y="69" CityLocaleName="LOC_CITY_NAME_PENZA" Area="0" />
@@ -890,13 +884,13 @@
 		<Replace MapName="GiantEarth" X="45" Y="69" CityLocaleName="LOC_CITY_NAME_URALSK" Area="0" />
 		<Replace MapName="GiantEarth" X="50" Y="69" CityLocaleName="LOC_CITY_NAME_YASNY" Area="0" />
 		<Replace MapName="GiantEarth" X="51" Y="69" CityLocaleName="LOC_CITY_NAME_YASNY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="35" Y="70" CityLocaleName="LOC_CITY_NAME_BRYANSK" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="70" CityLocaleName="LOC_CITY_NAME_PENZA" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="70" CityLocaleName="LOC_CITY_NAME_SAMARA" />
 		<Replace MapName="GiantEarth" X="49" Y="70" CityLocaleName="LOC_CITY_NAME_STERLITAMAK" Area="0" />
 		<Replace MapName="GiantEarth" X="51" Y="70" CityLocaleName="LOC_CITY_NAME_YASNY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="34" Y="71" CityLocaleName="LOC_CITY_NAME_KALUGA" Area="0" />
 		<Replace MapName="GiantEarth" X="36" Y="71" CityLocaleName="LOC_CITY_NAME_TULA" />
 		<Replace MapName="GiantEarth" X="38" Y="71" CityLocaleName="LOC_CITY_NAME_RYAZAN" Area="0" />
@@ -904,35 +898,35 @@
 		<Replace MapName="GiantEarth" X="42" Y="71" CityLocaleName="LOC_CITY_NAME_PENZA" Area="0" />
 		<Replace MapName="GiantEarth" X="46" Y="71" CityLocaleName="LOC_CITY_NAME_UFA" />
 		<Replace MapName="GiantEarth" X="50" Y="71" CityLocaleName="LOC_CITY_NAME_MIASS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="35" Y="72" CityLocaleName="LOC_CITY_NAME_KALUGA" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="72" CityLocaleName="LOC_CITY_NAME_RYAZAN" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="72" CityLocaleName="LOC_CITY_NAME_RYAZAN" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="72" CityLocaleName="LOC_CITY_NAME_ULYANOVSK" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="72" CityLocaleName="LOC_CITY_NAME_NIZHNEKAMSK" Area="0" />
 		<Replace MapName="GiantEarth" X="48" Y="72" CityLocaleName="LOC_CITY_NAME_BELORETSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="37" Y="73" CityLocaleName="LOC_CITY_NAME_VLADIMIR" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="73" CityLocaleName="LOC_CITY_NAME_VLADIMIR" Area="0" />
 		<Replace MapName="GiantEarth" X="41" Y="73" CityLocaleName="LOC_CITY_NAME_CHEBOKSARY" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="73" CityLocaleName="LOC_CITY_NAME_KAZAN" />
 		<Replace MapName="GiantEarth" X="45" Y="73" CityLocaleName="LOC_CITY_NAME_NIZHNEKAMSK" Area="0" />
 		<Replace MapName="GiantEarth" X="49" Y="73" CityLocaleName="LOC_CITY_NAME_KUNGUR" />
-		
+
 		<Replace MapName="GiantEarth" X="36" Y="74" CityLocaleName="LOC_CITY_NAME_MOSCOW" />
 		<Replace MapName="GiantEarth" X="38" Y="74" CityLocaleName="LOC_CITY_NAME_VLADIMIR" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="74" CityLocaleName="LOC_CITY_NAME_NIZHNY_NOVGOROD" />
 		<Replace MapName="GiantEarth" X="42" Y="74" CityLocaleName="LOC_CITY_NAME_CHEBOKSARY" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="74" CityLocaleName="LOC_CITY_NAME_NIZHNEKAMSK" Area="0" />
 		<Replace MapName="GiantEarth" X="47" Y="74" CityLocaleName="LOC_CITY_NAME_PERM" />
-		
+
 		<Replace MapName="GiantEarth" X="35" Y="75" CityLocaleName="LOC_CITY_NAME_MOSCOW" Area="0" /> <!--OVERLAP-->
 		<Replace MapName="GiantEarth" X="43" Y="75" CityLocaleName="LOC_CITY_NAME_IZHEVSK" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="75" CityLocaleName="LOC_CITY_NAME_IZHEVSK" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="75" CityLocaleName="LOC_CITY_NAME_IZHEVSK" Area="0" />
 		<Replace MapName="GiantEarth" X="48" Y="75" CityLocaleName="LOC_CITY_NAME_DOBRYANKA" Area="0" />
 		<Replace MapName="GiantEarth" X="49" Y="75" CityLocaleName="LOC_CITY_NAME_DOBRYANKA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="35" Y="76" CityLocaleName="LOC_CITY_NAME_TVER" />
 		<Replace MapName="GiantEarth" X="38" Y="76" CityLocaleName="LOC_CITY_NAME_YAROSLAVL" />
 		<Replace MapName="GiantEarth" X="40" Y="76" CityLocaleName="LOC_CITY_NAME_KOSTROMA" Area="0" />
@@ -940,12 +934,12 @@
 		<Replace MapName="GiantEarth" X="46" Y="76" CityLocaleName="LOC_CITY_NAME_GLAZOV" Area="0" />
 		<Replace MapName="GiantEarth" X="47" Y="76" CityLocaleName="LOC_CITY_NAME_GLAZOV" Area="0" />
 		<Replace MapName="GiantEarth" X="41" Y="76" CityLocaleName="LOC_CITY_NAME_BEREZNIKI" />
-		
+
 		<Replace MapName="GiantEarth" X="36" Y="77" CityLocaleName="LOC_CITY_NAME_VOLOGDA" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="77" CityLocaleName="LOC_CITY_NAME_KIROV" />
 		<Replace MapName="GiantEarth" X="46" Y="77" CityLocaleName="LOC_CITY_NAME_GLAZOV" Area="0" />
 		<Replace MapName="GiantEarth" X="48" Y="77" CityLocaleName="LOC_CITY_NAME_SOLIKAMSK" />
-		
+
 		<Replace MapName="GiantEarth" X="34" Y="78" CityLocaleName="LOC_CITY_NAME_CHAGODA" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="78" CityLocaleName="LOC_CITY_NAME_VOLOGDA" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="78" CityLocaleName="LOC_CITY_NAME_VOLOGDA" Area="0" />
@@ -954,7 +948,7 @@
 		<Replace MapName="GiantEarth" X="43" Y="78" CityLocaleName="LOC_CITY_NAME_KORYAZHMA" Area="0" />
 		<Replace MapName="GiantEarth" X="50" Y="78" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
 		<Replace MapName="GiantEarth" X="51" Y="78" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="32" Y="79" CityLocaleName="LOC_CITY_NAME_VYTEGRA" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="79" CityLocaleName="LOC_CITY_NAME_VYTEGRA" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="79" CityLocaleName="LOC_CITY_NAME_CHEREPOVETS" />
@@ -963,7 +957,7 @@
 		<Replace MapName="GiantEarth" X="46" Y="79" CityLocaleName="LOC_CITY_NAME_SYKTYVKAR" />
 		<Replace MapName="GiantEarth" X="50" Y="79" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
 		<Replace MapName="GiantEarth" X="51" Y="79" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="34" Y="80" CityLocaleName="LOC_CITY_NAME_VYTEGRA" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="80" CityLocaleName="LOC_CITY_NAME_CHEREPOVETS" Area="0" /> <!--OVERLAP-->
 		<Replace MapName="GiantEarth" X="36" Y="80" CityLocaleName="LOC_CITY_NAME_CHEREPOVETS" Area="0" /> <!--OVERLAP-->
@@ -976,14 +970,14 @@
 		<Replace MapName="GiantEarth" X="47" Y="80" CityLocaleName="LOC_CITY_NAME_SYKTYVKAR" Area="0" /> <!--OVERLAP-->
 		<Replace MapName="GiantEarth" X="49" Y="80" CityLocaleName="LOC_CITY_NAME_NYROB" />
 		<Replace MapName="GiantEarth" X="51" Y="80" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="33" Y="81" CityLocaleName="LOC_CITY_NAME_PETROZAVODSK" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="81" CityLocaleName="LOC_CITY_NAME_ONEGA" />
 		<Replace MapName="GiantEarth" X="41" Y="81" CityLocaleName="LOC_CITY_NAME_USOGORSK" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="81" CityLocaleName="LOC_CITY_NAME_USOGORSK" Area="0" />
 		<Replace MapName="GiantEarth" X="46" Y="81" CityLocaleName="LOC_CITY_NAME_UST_TSILMA" />
 		<Replace MapName="GiantEarth" X="50" Y="81" CityLocaleName="LOC_CITY_NAME_USINSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="34" Y="82" CityLocaleName="LOC_CITY_NAME_SEGEZHA" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="82" CityLocaleName="LOC_CITY_NAME_PINEGRA" />
 		<Replace MapName="GiantEarth" X="42" Y="82" CityLocaleName="LOC_CITY_NAME_USOGORSK" Area="0" />
@@ -991,18 +985,18 @@
 		<Replace MapName="GiantEarth" X="48" Y="82" CityLocaleName="LOC_CITY_NAME_USTYE" Area="0" />
 		<Replace MapName="GiantEarth" X="51" Y="82" CityLocaleName="LOC_CITY_NAME_USINSK" Area="0" />
 		<Replace MapName="GiantEarth" X="52" Y="82" CityLocaleName="LOC_CITY_NAME_USINSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="33" Y="83" CityLocaleName="LOC_CITY_NAME_SEGEZHA" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="83" CityLocaleName="LOC_CITY_NAME_ARKHANGELSK" />
 		<Replace MapName="GiantEarth" X="44" Y="83" CityLocaleName="LOC_CITY_NAME_VOLOKOVAYA" />
 		<Replace MapName="GiantEarth" X="49" Y="83" CityLocaleName="LOC_CITY_NAME_KHOREY_VER" />
 		<Replace MapName="GiantEarth" X="51" Y="83" CityLocaleName="LOC_CITY_NAME_USINSK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="35" Y="84" CityLocaleName="LOC_CITY_NAME_SEVERODVINSK" />
 		<Replace MapName="GiantEarth" X="42" Y="84" CityLocaleName="LOC_CITY_NAME_YUROMA" />
 		<Replace MapName="GiantEarth" X="47" Y="84" CityLocaleName="LOC_CITY_NAME_NARYAN_MAR" />
 		<Replace MapName="GiantEarth" X="53" Y="84" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="36" Y="85" CityLocaleName="LOC_CITY_NAME_POMORYE" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="85" CityLocaleName="LOC_CITY_NAME_POMORYE" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="85" CityLocaleName="LOC_CITY_NAME_MEZEN" />
@@ -1011,83 +1005,85 @@
 		<Replace MapName="GiantEarth" X="49" Y="85" CityLocaleName="LOC_CITY_NAME_KHODOVARIKHA" Area="0" />
 		<Replace MapName="GiantEarth" X="51" Y="85" CityLocaleName="LOC_CITY_NAME_CHYORNAYA" />
 		<Replace MapName="GiantEarth" X="53" Y="85" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="38" Y="86" CityLocaleName="LOC_CITY_NAME_POMORYE" Area="0" />
 		<Replace MapName="GiantEarth" X="41" Y="86" CityLocaleName="LOC_CITY_NAME_VOLONGA" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="86" CityLocaleName="LOC_CITY_NAME_VOLONGA" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="86" CityLocaleName="LOC_CITY_NAME_FORT_POUSTOZERSKIY" />
 		<Replace MapName="GiantEarth" X="47" Y="86" CityLocaleName="LOC_CITY_NAME_INDIGA" Area="0" />
 		<Replace MapName="GiantEarth" X="53" Y="86" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="49" Y="87" CityLocaleName="LOC_CITY_NAME_VARNEK" Area="0" />
 		<Replace MapName="GiantEarth" X="50" Y="87" CityLocaleName="LOC_CITY_NAME_VARNEK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="40" Y="88" CityLocaleName="LOC_CITY_NAME_SHOYNA" />
 		<Replace MapName="GiantEarth" X="43" Y="88" CityLocaleName="LOC_CITY_NAME_BUGRINO" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="88" CityLocaleName="LOC_CITY_NAME_BUGRINO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="45" Y="89" CityLocaleName="LOC_CITY_NAME_BELUSHYA_GUBA" Area="0" />
 		<Replace MapName="GiantEarth" X="47" Y="89" CityLocaleName="LOC_CITY_NAME_KRASINO" />
-		
+
 		<Replace MapName="GiantEarth" X="47" Y="91" CityLocaleName="LOC_CITY_NAME_ROGACHYOVO" Area="0" />
 		<Replace MapName="GiantEarth" X="49" Y="91" CityLocaleName="LOC_CITY_NAME_STOLBOVOY" />
-		
+
 		<Replace MapName="GiantEarth" X="52" Y="92" CityLocaleName="LOC_CITY_NAME_SEVERNY_ISLAND" />
 		<Replace MapName="GiantEarth" X="55" Y="92" CityLocaleName="LOC_CITY_NAME_GORA_SEVERNY_NUNATAK" />
-		
+
 	</CityMap>
-	
-	
+
+
 	<!-- ++++++++++++++++++++ -->
 	<!-- Middle East City Map -->
 	<!-- ++++++++++++++++++++ -->
-	
-	
+
+
 	<!-- MIDDLE EAST -->
 	<CityMap>
-		
+
+		<Replace MapName="GiantEarth" X="38" Y="37" CityLocaleName="LOC_CITY_NAME_ADEN" Area="0" />
+		<Replace MapName="GiantEarth" X="39" Y="37" CityLocaleName="LOC_CITY_NAME_ADEN" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="37" CityLocaleName="LOC_CITY_NAME_AL_MUKALLA" />
-		
+
 		<Replace MapName="GiantEarth" X="38" Y="38" CityLocaleName="LOC_CITY_NAME_SANAA" />
-		
+
 		<Replace MapName="GiantEarth" X="42" Y="39" CityLocaleName="LOC_CITY_NAME_SALALAH" />
-		
+
 		<Replace MapName="GiantEarth" X="40" Y="40" CityLocaleName="LOC_CITY_NAME_WADI_AD_DAWASIR" />
 		<Replace MapName="GiantEarth" X="44" Y="40" CityLocaleName="LOC_CITY_NAME_MIRBAT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="36" Y="41" CityLocaleName="LOC_CITY_NAME_MECCA" />
 		<Replace MapName="GiantEarth" X="41" Y="41" CityLocaleName="LOC_CITY_NAME_ASH_SHALFA" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="41" CityLocaleName="LOC_CITY_NAME_ASH_SHALFA" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="41" CityLocaleName="LOC_CITY_NAME_MIRBAT" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="41" CityLocaleName="LOC_CITY_NAME_DUQM" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="41" CityLocaleName="LOC_CITY_NAME_DUQM" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="38" Y="42" CityLocaleName="LOC_CITY_NAME_TAIF" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="42" CityLocaleName="LOC_CITY_NAME_TAIF" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="42" CityLocaleName="LOC_CITY_NAME_ASH_SHALFA" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="42" CityLocaleName="LOC_CITY_NAME_ABU_DHABI" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="42" CityLocaleName="LOC_CITY_NAME_ABU_DHABI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="37" Y="43" CityLocaleName="LOC_CITY_NAME_TAIF" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="43" CityLocaleName="LOC_CITY_NAME_TAIF" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="43" CityLocaleName="LOC_CITY_NAME_RIYADH" />
 		<Replace MapName="GiantEarth" X="42" Y="43" CityLocaleName="LOC_CITY_NAME_ABU_DHABI" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="43" CityLocaleName="LOC_CITY_NAME_ABU_DHABI" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="43" CityLocaleName="LOC_CITY_NAME_MUSCAT" />
-		
+
 		<Replace MapName="GiantEarth" X="36" Y="44" CityLocaleName="LOC_CITY_NAME_MEDINA" />
 		<Replace MapName="GiantEarth" X="42" Y="44" CityLocaleName="LOC_CITY_NAME_DOHA" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="44" CityLocaleName="LOC_CITY_NAME_DUBAI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="38" Y="45" CityLocaleName="LOC_CITY_NAME_BURAIDAH" />
 		<Replace MapName="GiantEarth" X="40" Y="45" CityLocaleName="LOC_CITY_NAME_DAMMAM" Area="0" />
 		<Replace MapName="GiantEarth" X="41" Y="45" CityLocaleName="LOC_CITY_NAME_DOHA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="37" Y="46" CityLocaleName="LOC_CITY_NAME_HAIL" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="46" CityLocaleName="LOC_CITY_NAME_BANDAR_BUSHEHR" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="46" CityLocaleName="LOC_CITY_NAME_BANDAR_ABBAS" Area="0" />
 		<Replace MapName="GiantEarth" X="46" Y="46" CityLocaleName="LOC_CITY_NAME_BANDAR_ABBAS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="33" Y="47" CityLocaleName="LOC_CITY_NAME_SHARM_EL_SHEIKH" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="47" CityLocaleName="LOC_CITY_NAME_PETRA" />
 		<Replace MapName="GiantEarth" X="37" Y="47" CityLocaleName="LOC_CITY_NAME_HAIL" Area="0" />
@@ -1095,14 +1091,14 @@
 		<Replace MapName="GiantEarth" X="40" Y="47" CityLocaleName="LOC_CITY_NAME_KUWAIT" />
 		<Replace MapName="GiantEarth" X="43" Y="47" CityLocaleName="LOC_CITY_NAME_BANDAR_BUSHEHR" Area="0" />
 		<Replace MapName="GiantEarth" X="46" Y="47" CityLocaleName="LOC_CITY_NAME_BANDAR_ABBAS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="34" Y="48" CityLocaleName="LOC_CITY_NAME_EILAT" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="48" CityLocaleName="LOC_CITY_NAME_SAKAKA" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="48" CityLocaleName="LOC_CITY_NAME_SAKAKA" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="48" CityLocaleName="LOC_CITY_NAME_RAFHA" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="48" CityLocaleName="LOC_CITY_NAME_BANDAR_BUSHEHR" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="48" CityLocaleName="LOC_CITY_NAME_SHIRAZ" />
-		
+
 		<Replace MapName="GiantEarth" X="32" Y="49" CityLocaleName="LOC_CITY_NAME_PORT_SAID" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="49" CityLocaleName="LOC_CITY_NAME_ARISH" Area="0" />
 		<Replace MapName="GiantEarth" X="34" Y="49" CityLocaleName="LOC_CITY_NAME_GAZA" Area="0" />
@@ -1112,13 +1108,13 @@
 		<Replace MapName="GiantEarth" X="38" Y="49" CityLocaleName="LOC_CITY_NAME_SAMAWAH" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="49" CityLocaleName="LOC_CITY_NAME_UR" />
 		<Replace MapName="GiantEarth" X="42" Y="49" CityLocaleName="LOC_CITY_NAME_AHVAZ" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="38" Y="50" CityLocaleName="LOC_CITY_NAME_AMMAN" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="50" CityLocaleName="LOC_CITY_NAME_KARBALA" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="50" CityLocaleName="LOC_CITY_NAME_KARBALA" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="50" CityLocaleName="LOC_CITY_NAME_AHVAZ" Area="0" />
 		<Replace MapName="GiantEarth" X="47" Y="50" CityLocaleName="LOC_CITY_NAME_YAZD" />
-		
+
 		<Replace MapName="GiantEarth" X="36" Y="51" CityLocaleName="LOC_CITY_NAME_JERUSALEM" />
 		<Replace MapName="GiantEarth" X="38" Y="51" CityLocaleName="LOC_CITY_NAME_AMMAN" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="51" CityLocaleName="LOC_CITY_NAME_KARBALA" Area="0" />
@@ -1126,7 +1122,7 @@
 		<Replace MapName="GiantEarth" X="41" Y="51" CityLocaleName="LOC_CITY_NAME_BAGHDAD" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="51" CityLocaleName="LOC_CITY_NAME_KERMANSHAH" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="51" CityLocaleName="LOC_CITY_NAME_ISFAHAN" />
-		
+
 		<Replace MapName="GiantEarth" X="38" Y="52" CityLocaleName="LOC_CITY_NAME_DAMASCUS" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="52" CityLocaleName="LOC_CITY_NAME_DEIR_EZ_ZUR" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="52" CityLocaleName="LOC_CITY_NAME_DEIR_EZ_ZUR" Area="0" />
@@ -1134,7 +1130,9 @@
 		<Replace MapName="GiantEarth" X="42" Y="52" CityLocaleName="LOC_CITY_NAME_BAGHDAD" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="52" CityLocaleName="LOC_CITY_NAME_KERMANSHAH" Area="0" />
 		<Replace MapName="GiantEarth" X="46" Y="52" CityLocaleName="LOC_CITY_NAME_QOM" Area="0" />
-		
+
+		<Replace MapName="GiantEarth" X="33" Y="53" CityLocaleName="LOC_CITY_NAME_PAPHOS" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="53" CityLocaleName="LOC_CITY_NAME_NICOSIA" Area="0" />
 		<Replace MapName="GiantEarth" X="36" Y="53" CityLocaleName="LOC_CITY_NAME_DAMASCUS" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="53" CityLocaleName="LOC_CITY_NAME_DAMASCUS" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="53" CityLocaleName="LOC_CITY_NAME_ALEPPO" Area="0" />
@@ -1142,14 +1140,14 @@
 		<Replace MapName="GiantEarth" X="40" Y="53" CityLocaleName="LOC_CITY_NAME_DEIR_EZ_ZUR" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="53" CityLocaleName="LOC_CITY_NAME_KERMANSHAH" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="53" CityLocaleName="LOC_CITY_NAME_QOM" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="37" Y="54" CityLocaleName="LOC_CITY_NAME_ANTAKYA" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="54" CityLocaleName="LOC_CITY_NAME_ALEPPO" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="54" CityLocaleName="LOC_CITY_NAME_AR_RAQQA" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="54" CityLocaleName="LOC_CITY_NAME_AR_RAQQA" Area="0" />
 		<Replace MapName="GiantEarth" X="42" Y="54" CityLocaleName="LOC_CITY_NAME_MOSUL" />
 		<Replace MapName="GiantEarth" X="46" Y="54" CityLocaleName="LOC_CITY_NAME_TEHRAN" />
-		
+
 		<Replace MapName="GiantEarth" X="31" Y="55" CityLocaleName="LOC_CITY_NAME_BODRUM" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="55" CityLocaleName="LOC_CITY_NAME_ANTALYA" Area="0" />
 		<Replace MapName="GiantEarth" X="34" Y="55" CityLocaleName="LOC_CITY_NAME_MERSIN" />
@@ -1157,21 +1155,21 @@
 		<Replace MapName="GiantEarth" X="37" Y="55" CityLocaleName="LOC_CITY_NAME_GAZIANTEP" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="55" CityLocaleName="LOC_CITY_NAME_GAZIANTEP" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="55" CityLocaleName="LOC_CITY_NAME_TABRIZ" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="31" Y="56" CityLocaleName="LOC_CITY_NAME_BODRUM" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="56" CityLocaleName="LOC_CITY_NAME_DENIZLI" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="56" CityLocaleName="LOC_CITY_NAME_DENIZLI" Area="0" />
 		<Replace MapName="GiantEarth" X="40" Y="56" CityLocaleName="LOC_CITY_NAME_VAN" />
 		<Replace MapName="GiantEarth" X="44" Y="56" CityLocaleName="LOC_CITY_NAME_TABRIZ" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="56" CityLocaleName="LOC_CITY_NAME_RASHT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="30" Y="57" CityLocaleName="LOC_CITY_NAME_IZMIR" />
 		<Replace MapName="GiantEarth" X="32" Y="57" CityLocaleName="LOC_CITY_NAME_DENIZLI" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="57" CityLocaleName="LOC_CITY_NAME_DENIZLI" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="57" CityLocaleName="LOC_CITY_NAME_KAYSERI" />
 		<Replace MapName="GiantEarth" X="42" Y="57" CityLocaleName="LOC_CITY_NAME_YEREVAN" />
 		<Replace MapName="GiantEarth" X="44" Y="57" CityLocaleName="LOC_CITY_NAME_RASHT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="31" Y="58" CityLocaleName="LOC_CITY_NAME_BURSA" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="58" CityLocaleName="LOC_CITY_NAME_BURSA" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="58" CityLocaleName="LOC_CITY_NAME_BURSA" Area="0" />
@@ -1179,12 +1177,12 @@
 		<Replace MapName="GiantEarth" X="41" Y="58" CityLocaleName="LOC_CITY_NAME_ERZURUM" Area="0" />
 		<Replace MapName="GiantEarth" X="44" Y="58" CityLocaleName="LOC_CITY_NAME_XANXENDI" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="58" CityLocaleName="LOC_CITY_NAME_RASHT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="33" Y="59" CityLocaleName="LOC_CITY_NAME_ZONGULDAK" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="59" CityLocaleName="LOC_CITY_NAME_TRABZON" />
 		<Replace MapName="GiantEarth" X="41" Y="59" CityLocaleName="LOC_CITY_NAME_ERZURUM" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="59" CityLocaleName="LOC_CITY_NAME_XANXENDI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="34" Y="60" CityLocaleName="LOC_CITY_NAME_ZONGULDAK" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="60" CityLocaleName="LOC_CITY_NAME_ZONGULDAK" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="60" CityLocaleName="LOC_CITY_NAME_SAMSUN" />
@@ -1192,41 +1190,41 @@
 		<Replace MapName="GiantEarth" X="42" Y="60" CityLocaleName="LOC_CITY_NAME_TBILISI" Area="0" />
 		<Replace MapName="GiantEarth" X="43" Y="60" CityLocaleName="LOC_CITY_NAME_TBILISI" Area="0" />
 		<Replace MapName="GiantEarth" X="45" Y="60" CityLocaleName="LOC_CITY_NAME_BAKU" />
-		
+
 	</CityMap>
-	
-	
+
+
 	<!-- +++++++++++++++ -->
 	<!-- Africa City Map -->
 	<!-- +++++++++++++++ -->
-	
-	
+
+
 	<!-- SUB-EQUATORIAL AFRICA -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="7" CityLocaleName="LOC_CITY_NAME_CAPE_TOWN" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="7" CityLocaleName="LOC_CITY_NAME_GEORGE" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="7" CityLocaleName="LOC_CITY_NAME_PORT_ELIZABETH" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="7" CityLocaleName="LOC_CITY_NAME_PORT_ELIZABETH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="25" Y="8" CityLocaleName="LOC_CITY_NAME_CAPE_TOWN" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="8" CityLocaleName="LOC_CITY_NAME_RICHMOND" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="8" CityLocaleName="LOC_CITY_NAME_MIDDELBURG" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="8" CityLocaleName="LOC_CITY_NAME_DURBAN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="24" Y="9" CityLocaleName="LOC_CITY_NAME_ALEXANDER_BAY" Area="0" />
 		<Replace MapName="GiantEarth" X="25" Y="9" CityLocaleName="LOC_CITY_NAME_KAKAMAS" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="9" CityLocaleName="LOC_CITY_NAME_BLOEMFONTEIN" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="9" CityLocaleName="LOC_CITY_NAME_DURBAN" Area="0" />
 		<Replace MapName="GiantEarth" X="56" Y="9" CityLocaleName="LOC_CITY_NAME_KERGUELEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="23" Y="10" CityLocaleName="LOC_CITY_NAME_LUEDERITZ" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="10" CityLocaleName="LOC_CITY_NAME_ORANJEMUND" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="10" CityLocaleName="LOC_CITY_NAME_UPINGTON" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="10" CityLocaleName="LOC_CITY_NAME_JOHANNESBURG" Area="0" />
 		<Replace MapName="GiantEarth" X="28" Y="10" CityLocaleName="LOC_CITY_NAME_JOHANNESBURG" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="10" CityLocaleName="LOC_CITY_NAME_MAPUTO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="11" CityLocaleName="LOC_CITY_NAME_LUEDERITZ" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="11" CityLocaleName="LOC_CITY_NAME_BETHANIE" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="11" CityLocaleName="LOC_CITY_NAME_KEETMANSHOOP" Area="0" />
@@ -1234,7 +1232,7 @@
 		<Replace MapName="GiantEarth" X="26" Y="11" CityLocaleName="LOC_CITY_NAME_GABORONE" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="11" CityLocaleName="LOC_CITY_NAME_PRETORIA" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="11" CityLocaleName="LOC_CITY_NAME_MAPUTO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="12" CityLocaleName="LOC_CITY_NAME_WALVIS_BAY" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="12" CityLocaleName="LOC_CITY_NAME_MALTAHOEHE" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="12" CityLocaleName="LOC_CITY_NAME_MARIENTAL" Area="0" />
@@ -1244,7 +1242,7 @@
 		<Replace MapName="GiantEarth" X="28" Y="12" CityLocaleName="LOC_CITY_NAME_PRETORIA" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="12" CityLocaleName="LOC_CITY_NAME_POLOKWANE" Area="0" />
 		<Replace MapName="GiantEarth" X="30" Y="12" CityLocaleName="LOC_CITY_NAME_MAPUTO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="13" CityLocaleName="LOC_CITY_NAME_WALVIS_BAY" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="13" CityLocaleName="LOC_CITY_NAME_WINDHOEK" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="13" CityLocaleName="LOC_CITY_NAME_WINDHOEK" Area="0" />
@@ -1256,7 +1254,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="13" CityLocaleName="LOC_CITY_NAME_XAI_XAI" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="13" CityLocaleName="LOC_CITY_NAME_ANDROKA" Area="0" />
 		<Replace MapName="GiantEarth" X="36" Y="13" CityLocaleName="LOC_CITY_NAME_AMBOVOMBE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="22" Y="14" CityLocaleName="LOC_CITY_NAME_SWAKOPMUND" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="14" CityLocaleName="LOC_CITY_NAME_WINDHOEK" Area="0" />
 		<Replace MapName="GiantEarth" X="24" Y="14" CityLocaleName="LOC_CITY_NAME_WINDHOEK" Area="0" />
@@ -1270,7 +1268,7 @@
 		<Replace MapName="GiantEarth" X="35" Y="14" CityLocaleName="LOC_CITY_NAME_TOILARA" Area="0" />
 		<Replace MapName="GiantEarth" X="36" Y="14" CityLocaleName="LOC_CITY_NAME_TRANOROA" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="14" CityLocaleName="LOC_CITY_NAME_TOLNARO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="21" Y="15" CityLocaleName="LOC_CITY_NAME_SWAKOPMUND" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="15" CityLocaleName="LOC_CITY_NAME_USAKOS" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="15" CityLocaleName="LOC_CITY_NAME_WINDHOEK" Area="0" />
@@ -1284,7 +1282,7 @@
 		<Replace MapName="GiantEarth" X="31" Y="15" CityLocaleName="LOC_CITY_NAME_INHAMBANE" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="15" CityLocaleName="LOC_CITY_NAME_MOROMBE" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="15" CityLocaleName="LOC_CITY_NAME_MANAKARA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="21" Y="16" CityLocaleName="LOC_CITY_NAME_SKELETON_COAST" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="16" CityLocaleName="LOC_CITY_NAME_SESFONTEIN" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="16" CityLocaleName="LOC_CITY_NAME_OUTJO" Area="0" />
@@ -1300,7 +1298,7 @@
 		<Replace MapName="GiantEarth" X="37" Y="16" CityLocaleName="LOC_CITY_NAME_ANTSIRABE" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="16" CityLocaleName="LOC_CITY_NAME_MAHANORO" Area="0" />
 		<Replace MapName="GiantEarth" X="47" Y="16" CityLocaleName="LOC_CITY_NAME_REUNION" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="17" CityLocaleName="LOC_CITY_NAME_SKELETON_COAST" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="17" CityLocaleName="LOC_CITY_NAME_OPUWA" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="17" CityLocaleName="LOC_CITY_NAME_ONDANGWA" Area="0" />
@@ -1317,7 +1315,7 @@
 		<Replace MapName="GiantEarth" X="37" Y="17" CityLocaleName="LOC_CITY_NAME_ANTANANARIVO" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="17" CityLocaleName="LOC_CITY_NAME_TOAMASINA" Area="0" />
 		<Replace MapName="GiantEarth" X="49" Y="17" CityLocaleName="LOC_CITY_NAME_MAURITIUS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="18" CityLocaleName="LOC_CITY_NAME_TOMBWA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="18" CityLocaleName="LOC_CITY_NAME_HUMBE" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="18" CityLocaleName="LOC_CITY_NAME_XANGONGO" Area="0" />
@@ -1332,7 +1330,7 @@
 		<Replace MapName="GiantEarth" X="31" Y="18" CityLocaleName="LOC_CITY_NAME_BEIRA" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="18" CityLocaleName="LOC_CITY_NAME_MAHATSINJO" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="18" CityLocaleName="LOC_CITY_NAME_TOAMASINA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="19" CityLocaleName="LOC_CITY_NAME_NAMIBE" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="19" CityLocaleName="LOC_CITY_NAME_LUBANGO" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="19" CityLocaleName="LOC_CITY_NAME_KUVANGO" Area="0" />
@@ -1348,7 +1346,7 @@
 		<Replace MapName="GiantEarth" X="36" Y="19" CityLocaleName="LOC_CITY_NAME_MAHAJANGA" Area="0" />
 		<Replace MapName="GiantEarth" X="37" Y="19" CityLocaleName="LOC_CITY_NAME_MAHAJANGA" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="19" CityLocaleName="LOC_CITY_NAME_MANANARA_AVARATRA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="21" Y="20" CityLocaleName="LOC_CITY_NAME_BENGUELA" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="20" CityLocaleName="LOC_CITY_NAME_HUAMBO" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="20" CityLocaleName="LOC_CITY_NAME_HUAMBO" Area="0" />
@@ -1364,7 +1362,7 @@
 		<Replace MapName="GiantEarth" X="33" Y="20" CityLocaleName="LOC_CITY_NAME_NAMPULA" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="20" CityLocaleName="LOC_CITY_NAME_AMBANJA" Area="0" />
 		<Replace MapName="GiantEarth" X="39" Y="20" CityLocaleName="LOC_CITY_NAME_ANDAPA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="21" Y="21" CityLocaleName="LOC_CITY_NAME_LOBITO" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="21" CityLocaleName="LOC_CITY_NAME_KUITO" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="21" CityLocaleName="LOC_CITY_NAME_LUENA" Area="0" />
@@ -1378,7 +1376,7 @@
 		<Replace MapName="GiantEarth" X="32" Y="21" CityLocaleName="LOC_CITY_NAME_ZOMBA" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="21" CityLocaleName="LOC_CITY_NAME_NACALA" Area="0" />
 		<Replace MapName="GiantEarth" X="38" Y="21" CityLocaleName="LOC_CITY_NAME_ANTSIRANANA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="21" Y="22" CityLocaleName="LOC_CITY_NAME_PORTO_AMBOIM" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="22" CityLocaleName="LOC_CITY_NAME_QUIBALA" Area="0" />
 		<Replace MapName="GiantEarth" X="23" Y="22" CityLocaleName="LOC_CITY_NAME_CANDANGALA" Area="0" />
@@ -1389,7 +1387,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="22" CityLocaleName="LOC_CITY_NAME_CHIPATA" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="22" CityLocaleName="LOC_CITY_NAME_LILONGWE" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="22" CityLocaleName="LOC_CITY_NAME_PEMBA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="23" CityLocaleName="LOC_CITY_NAME_LUANDA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="23" CityLocaleName="LOC_CITY_NAME_DONDO" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="23" CityLocaleName="LOC_CITY_NAME_MALANJE" Area="0" />
@@ -1403,7 +1401,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="23" CityLocaleName="LOC_CITY_NAME_MZUZU" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="23" CityLocaleName="LOC_CITY_NAME_MBAMBA_BAY" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="23" CityLocaleName="LOC_CITY_NAME_MTWARA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="20" Y="24" CityLocaleName="LOC_CITY_NAME_SOYO" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="24" CityLocaleName="LOC_CITY_NAME_MBANZA_KONGO" Area="0" />
 		<Replace MapName="GiantEarth" X="22" Y="24" CityLocaleName="LOC_CITY_NAME_UIGE" Area="0" />
@@ -1417,7 +1415,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="24" CityLocaleName="LOC_CITY_NAME_PWETO" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="24" CityLocaleName="LOC_CITY_NAME_MBEYA" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="24" CityLocaleName="LOC_CITY_NAME_KILWA_MASOKO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="25" CityLocaleName="LOC_CITY_NAME_CABINDA" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="25" CityLocaleName="LOC_CITY_NAME_MATADI" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="25" CityLocaleName="LOC_CITY_NAME_MBANZA_KONGO" Area="0" />
@@ -1432,7 +1430,7 @@
 		<Replace MapName="GiantEarth" X="31" Y="25" CityLocaleName="LOC_CITY_NAME_MPANDA" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="25" CityLocaleName="LOC_CITY_NAME_DODOMA" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="25" CityLocaleName="LOC_CITY_NAME_DAR_ES_SALAAM" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="26" CityLocaleName="LOC_CITY_NAME_POINTE_NOIRE" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="26" CityLocaleName="LOC_CITY_NAME_BOMA" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="26" CityLocaleName="LOC_CITY_NAME_KINSHASA" Area="0" />
@@ -1449,7 +1447,7 @@
 		<Replace MapName="GiantEarth" X="33" Y="26" CityLocaleName="LOC_CITY_NAME_TANGA" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="26" CityLocaleName="LOC_CITY_NAME_ZANZIBAR" Area="0" />
 		<Replace MapName="GiantEarth" X="47" Y="26" CityLocaleName="LOC_CITY_NAME_SEYCHELLES" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="18" Y="27" CityLocaleName="LOC_CITY_NAME_PORT_GENTIL" Area="0" />
 		<Replace MapName="GiantEarth" X="19" Y="27" CityLocaleName="LOC_CITY_NAME_FRANCEVILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="27" CityLocaleName="LOC_CITY_NAME_BRAZZAVILLE" Area="0" />
@@ -1464,7 +1462,7 @@
 		<Replace MapName="GiantEarth" X="30" Y="27" CityLocaleName="LOC_CITY_NAME_BUJUMBURA" Area="0" />
 		<Replace MapName="GiantEarth" X="31" Y="27" CityLocaleName="LOC_CITY_NAME_MWANZA" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="27" CityLocaleName="LOC_CITY_NAME_MOMBASA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="28" CityLocaleName="LOC_CITY_NAME_LIBREVILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="28" CityLocaleName="LOC_CITY_NAME_FRANCEVILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="28" CityLocaleName="LOC_CITY_NAME_LOUKOLELA" Area="0" />
@@ -1481,7 +1479,7 @@
 		<Replace MapName="GiantEarth" X="33" Y="28" CityLocaleName="LOC_CITY_NAME_NAIROBI" Area="0" />
 		<Replace MapName="GiantEarth" X="34" Y="28" CityLocaleName="LOC_CITY_NAME_MOMBASA" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="28" CityLocaleName="LOC_CITY_NAME_MALINDI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="19" Y="29" CityLocaleName="LOC_CITY_NAME_LIBREVILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="20" Y="29" CityLocaleName="LOC_CITY_NAME_MAKOKOU" Area="0" />
 		<Replace MapName="GiantEarth" X="21" Y="29" CityLocaleName="LOC_CITY_NAME_OWANDO" Area="0" />
@@ -1491,81 +1489,714 @@
 		<Replace MapName="GiantEarth" X="25" Y="29" CityLocaleName="LOC_CITY_NAME_ISANGI" Area="0" />
 		<Replace MapName="GiantEarth" X="26" Y="29" CityLocaleName="LOC_CITY_NAME_YANGAMBI" Area="0" />
 		<Replace MapName="GiantEarth" X="27" Y="29" CityLocaleName="LOC_CITY_NAME_BAFWASENDE" Area="0" />
-		<Replace MapName="GiantEarth" X="28" Y="29" CityLocaleName="LOC_CITY_NAME_BENI" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="29" CityLocaleName="LOC_CITY_NAME_BUTEMBO" Area="0" />
 		<Replace MapName="GiantEarth" X="29" Y="29" CityLocaleName="LOC_CITY_NAME_MASAKA" Area="0" />
 		<Replace MapName="GiantEarth" X="32" Y="29" CityLocaleName="LOC_CITY_NAME_KISUMU" Area="0" />
 		<Replace MapName="GiantEarth" X="33" Y="29" CityLocaleName="LOC_CITY_NAME_NAIROBI" Area="0" />
 		<Replace MapName="GiantEarth" X="35" Y="29" CityLocaleName="LOC_CITY_NAME_KISMAYO" Area="0" />
-		
+
 	</CityMap>
-	
-	
+
+	<!-- CENTRAL & EAST AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="19" Y="30" CityLocaleName="LOC_CITY_NAME_BATA" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="30" CityLocaleName="LOC_CITY_NAME_OYEM" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="30" CityLocaleName="LOC_CITY_NAME_MAKOUA" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="30" CityLocaleName="LOC_CITY_NAME_LIRANGA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="30" CityLocaleName="LOC_CITY_NAME_MBANDAKA" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="30" CityLocaleName="LOC_CITY_NAME_BARINGA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="30" CityLocaleName="LOC_CITY_NAME_LOKUTU" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="30" CityLocaleName="LOC_CITY_NAME_BASOKO" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="30" CityLocaleName="LOC_CITY_NAME_NIA_NIA" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="30" CityLocaleName="LOC_CITY_NAME_BENI" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="30" CityLocaleName="LOC_CITY_NAME_FORT_PORTAL" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="30" CityLocaleName="LOC_CITY_NAME_ENTEBBE" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="30" CityLocaleName="LOC_CITY_NAME_KAMPALA" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="30" CityLocaleName="LOC_CITY_NAME_ELDORET" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="30" CityLocaleName="LOC_CITY_NAME_MERU" Area="0" />
+		<Replace MapName="GiantEarth" X="35" Y="30" CityLocaleName="LOC_CITY_NAME_JAMAME" Area="0" />
+		<Replace MapName="GiantEarth" X="36" Y="30" CityLocaleName="LOC_CITY_NAME_MERCA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="31" CityLocaleName="LOC_CITY_NAME_KRIBI" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="31" CityLocaleName="LOC_CITY_NAME_YAOUNDE" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="31" CityLocaleName="LOC_CITY_NAME_OUESSO" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="31" CityLocaleName="LOC_CITY_NAME_IMPFONDO" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="31" CityLocaleName="LOC_CITY_NAME_BASANKUSU" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="31" CityLocaleName="LOC_CITY_NAME_LOKUTU" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="31" CityLocaleName="LOC_CITY_NAME_BASOKO" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="31" CityLocaleName="LOC_CITY_NAME_BUTA" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="31" CityLocaleName="LOC_CITY_NAME_ISIRO" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="31" CityLocaleName="LOC_CITY_NAME_BUNIA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="31" CityLocaleName="LOC_CITY_NAME_ARUA" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="31" CityLocaleName="LOC_CITY_NAME_GULU" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="31" CityLocaleName="LOC_CITY_NAME_LODWAR" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="31" CityLocaleName="LOC_CITY_NAME_MARSABIT" Area="0" />
+		<Replace MapName="GiantEarth" X="35" Y="31" CityLocaleName="LOC_CITY_NAME_BARDERA" Area="0" />
+		<Replace MapName="GiantEarth" X="36" Y="31" CityLocaleName="LOC_CITY_NAME_MOGADISHU" Area="0" />
+		<Replace MapName="GiantEarth" X="37" Y="31" CityLocaleName="LOC_CITY_NAME_MOGADISHU" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="32" CityLocaleName="LOC_CITY_NAME_DOUALA" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="32" CityLocaleName="LOC_CITY_NAME_YAOUNDE" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="32" CityLocaleName="LOC_CITY_NAME_YAOUNDE" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="32" CityLocaleName="LOC_CITY_NAME_YOKADOUMA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="32" CityLocaleName="LOC_CITY_NAME_MAKANZA" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="32" CityLocaleName="LOC_CITY_NAME_LISALA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="32" CityLocaleName="LOC_CITY_NAME_BUMBA" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="32" CityLocaleName="LOC_CITY_NAME_AKETI" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="32" CityLocaleName="LOC_CITY_NAME_POKO" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="32" CityLocaleName="LOC_CITY_NAME_NIANGARA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="32" CityLocaleName="LOC_CITY_NAME_DUNGU" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="32" CityLocaleName="LOC_CITY_NAME_KOBOKO" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="32" CityLocaleName="LOC_CITY_NAME_KAYO_KEJI" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="32" CityLocaleName="LOC_CITY_NAME_TORIT" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="32" CityLocaleName="LOC_CITY_NAME_MAJI" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="32" CityLocaleName="LOC_CITY_NAME_JINKA" Area="0" />
+		<Replace MapName="GiantEarth" X="35" Y="32" CityLocaleName="LOC_CITY_NAME_DILA" Area="0" />
+		<Replace MapName="GiantEarth" X="36" Y="32" CityLocaleName="LOC_CITY_NAME_BAIDOA" Area="0" />
+		<Replace MapName="GiantEarth" X="37" Y="32" CityLocaleName="LOC_CITY_NAME_BELEDWEYNE" Area="0" />
+		<Replace MapName="GiantEarth" X="38" Y="32" CityLocaleName="LOC_CITY_NAME_MOGADISHU" Area="0" />
+		<Replace MapName="GiantEarth" X="39" Y="32" CityLocaleName="LOC_CITY_NAME_HOBYO" Area="0" />
+
+		<Replace MapName="GiantEarth" X="18" Y="33" CityLocaleName="LOC_CITY_NAME_PORT_HARCOURT" Area="0" />
+		<Replace MapName="GiantEarth" X="19" Y="33" CityLocaleName="LOC_CITY_NAME_KUMBA" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="33" CityLocaleName="LOC_CITY_NAME_BAFIA" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="33" CityLocaleName="LOC_CITY_NAME_NANGA_EBOKO" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="33" CityLocaleName="LOC_CITY_NAME_BERBERATI" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="33" CityLocaleName="LOC_CITY_NAME_BANGUI" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="33" CityLocaleName="LOC_CITY_NAME_GEMENA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="33" CityLocaleName="LOC_CITY_NAME_BANGASSOU" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="33" CityLocaleName="LOC_CITY_NAME_RAFAI" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="33" CityLocaleName="LOC_CITY_NAME_OBO" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="33" CityLocaleName="LOC_CITY_NAME_NZARA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="33" CityLocaleName="LOC_CITY_NAME_YAMBIO" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="33" CityLocaleName="LOC_CITY_NAME_YEI" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="33" CityLocaleName="LOC_CITY_NAME_JUBA" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="33" CityLocaleName="LOC_CITY_NAME_MONGALLA" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="33" CityLocaleName="LOC_CITY_NAME_GAMBELA" Area="0" />
+		<Replace MapName="GiantEarth" X="36" Y="33" CityLocaleName="LOC_CITY_NAME_HARAR" Area="0" />
+		<Replace MapName="GiantEarth" X="37" Y="33" CityLocaleName="LOC_CITY_NAME_GALKAYO" Area="0" />
+		<Replace MapName="GiantEarth" X="38" Y="33" CityLocaleName="LOC_CITY_NAME_GAROWE" Area="0" />
+		<Replace MapName="GiantEarth" X="39" Y="33" CityLocaleName="LOC_CITY_NAME_BAYLA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="34" CityLocaleName="LOC_CITY_NAME_ONITSHA" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="34" CityLocaleName="LOC_CITY_NAME_BAFOUSSAM" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="34" CityLocaleName="LOC_CITY_NAME_BAFOUSSAM" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="34" CityLocaleName="LOC_CITY_NAME_BERTOUA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="34" CityLocaleName="LOC_CITY_NAME_BOUAR" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="34" CityLocaleName="LOC_CITY_NAME_BAMBARI" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="34" CityLocaleName="LOC_CITY_NAME_IPPY" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="34" CityLocaleName="LOC_CITY_NAME_BRIA" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="34" CityLocaleName="LOC_CITY_NAME_YALINGA" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="34" CityLocaleName="LOC_CITY_NAME_RAGA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="34" CityLocaleName="LOC_CITY_NAME_WAU" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="34" CityLocaleName="LOC_CITY_NAME_WAU" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="34" CityLocaleName="LOC_CITY_NAME_RUMBEK" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="34" CityLocaleName="LOC_CITY_NAME_RAMCIEL" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="34" CityLocaleName="LOC_CITY_NAME_NASIR" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="34" CityLocaleName="LOC_CITY_NAME_NEKEMTE" Area="0" />
+		<Replace MapName="GiantEarth" X="35" Y="34" CityLocaleName="LOC_CITY_NAME_ADDIS_ABABA" Area="0" />
+		<Replace MapName="GiantEarth" X="36" Y="34" CityLocaleName="LOC_CITY_NAME_DIRE_DAWA" Area="0" />
+		<Replace MapName="GiantEarth" X="38" Y="34" CityLocaleName="LOC_CITY_NAME_HARGEISA" Area="0" />
+		<Replace MapName="GiantEarth" X="39" Y="34" CityLocaleName="LOC_CITY_NAME_BOSASO" Area="0" />
+		<Replace MapName="GiantEarth" X="40" Y="34" CityLocaleName="LOC_CITY_NAME_HAFUN" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="35" CityLocaleName="LOC_CITY_NAME_IDAH" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="35" CityLocaleName="LOC_CITY_NAME_BAMENDA" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="35" CityLocaleName="LOC_CITY_NAME_KUMBO" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="35" CityLocaleName="LOC_CITY_NAME_NGAOUNDERE" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="35" CityLocaleName="LOC_CITY_NAME_MOUNDOU" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="35" CityLocaleName="LOC_CITY_NAME_YAGOUA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="35" CityLocaleName="LOC_CITY_NAME_KOUMRA" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="35" CityLocaleName="LOC_CITY_NAME_SARH" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="35" CityLocaleName="LOC_CITY_NAME_AM_DAFOK" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="35" CityLocaleName="LOC_CITY_NAME_AWEIL" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="35" CityLocaleName="LOC_CITY_NAME_ABYEI" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="35" CityLocaleName="LOC_CITY_NAME_RUBKONA" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="35" CityLocaleName="LOC_CITY_NAME_FANGAK" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="35" CityLocaleName="LOC_CITY_NAME_MALAKAL" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="35" CityLocaleName="LOC_CITY_NAME_BAHIR_DAR" Area="0" />
+		<Replace MapName="GiantEarth" X="35" Y="35" CityLocaleName="LOC_CITY_NAME_AKSUM" Area="0" />
+		<Replace MapName="GiantEarth" X="36" Y="35" CityLocaleName="LOC_CITY_NAME_DJIBOUTI" Area="0" />
+		<Replace MapName="GiantEarth" X="37" Y="35" CityLocaleName="LOC_CITY_NAME_BERBERA" Area="0" />
+		<Replace MapName="GiantEarth" X="38" Y="35" CityLocaleName="LOC_CITY_NAME_HEIS" Area="0" />
+		<Replace MapName="GiantEarth" X="44" Y="35" CityLocaleName="LOC_CITY_NAME_HADIBU" Area="0" />
+
+		<Replace MapName="GiantEarth" X="20" Y="36" CityLocaleName="LOC_CITY_NAME_MAKURDI" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="36" CityLocaleName="LOC_CITY_NAME_GAROUA" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="36" CityLocaleName="LOC_CITY_NAME_MAROUA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="36" CityLocaleName="LOC_CITY_NAME_KOUSSERI" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="36" CityLocaleName="LOC_CITY_NAME_BONGOR" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="36" CityLocaleName="LOC_CITY_NAME_SARH" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="36" CityLocaleName="LOC_CITY_NAME_AM_TIMAN" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="36" CityLocaleName="LOC_CITY_NAME_GEREIDA" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="36" CityLocaleName="LOC_CITY_NAME_EL_DAEIN" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="36" CityLocaleName="LOC_CITY_NAME_KADUQLI" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="36" CityLocaleName="LOC_CITY_NAME_BIEM" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="36" CityLocaleName="LOC_CITY_NAME_KODOK" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="36" CityLocaleName="LOC_CITY_NAME_RENK" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="36" CityLocaleName="LOC_CITY_NAME_GONDAR" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="36" CityLocaleName="LOC_CITY_NAME_TADJOURA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="37" CityLocaleName="LOC_CITY_NAME_ABUJA" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="37" CityLocaleName="LOC_CITY_NAME_LAFIA" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="37" CityLocaleName="LOC_CITY_NAME_GOMBE" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="37" CityLocaleName="LOC_CITY_NAME_MAIDUGURU" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="37" CityLocaleName="LOC_CITY_NAME_BLANGOUA" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="37" CityLocaleName="LOC_CITY_NAME_NDJAMENA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="37" CityLocaleName="LOC_CITY_NAME_MELFI" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="37" CityLocaleName="LOC_CITY_NAME_MONGO" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="37" CityLocaleName="LOC_CITY_NAME_GOZ_BEIDA" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="37" CityLocaleName="LOC_CITY_NAME_NYALA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="37" CityLocaleName="LOC_CITY_NAME_BABANUSA" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="37" CityLocaleName="LOC_CITY_NAME_DILLING" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="37" CityLocaleName="LOC_CITY_NAME_UMM_RUWABA" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="37" CityLocaleName="LOC_CITY_NAME_KOSTI" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="37" CityLocaleName="LOC_CITY_NAME_RABAK" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="37" CityLocaleName="LOC_CITY_NAME_ADWA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="38" CityLocaleName="LOC_CITY_NAME_BIDA" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="38" CityLocaleName="LOC_CITY_NAME_ABUJA" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="38" CityLocaleName="LOC_CITY_NAME_DAMATURU" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="38" CityLocaleName="LOC_CITY_NAME_KUKAWA" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="38" CityLocaleName="LOC_CITY_NAME_NDJAMENA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="38" CityLocaleName="LOC_CITY_NAME_MASSAKORY" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="38" CityLocaleName="LOC_CITY_NAME_YAO" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="38" CityLocaleName="LOC_CITY_NAME_OUM_HADJER" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="38" CityLocaleName="LOC_CITY_NAME_AL_JUNAYNAH" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="38" CityLocaleName="LOC_CITY_NAME_AL_FASHIR" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="38" CityLocaleName="LOC_CITY_NAME_EN_NAHUD" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="38" CityLocaleName="LOC_CITY_NAME_EL_OBEID" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="38" CityLocaleName="LOC_CITY_NAME_ED_DUEIM" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="38" CityLocaleName="LOC_CITY_NAME_KHARTOUM" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="38" CityLocaleName="LOC_CITY_NAME_KASSALA" Area="0" />
+		<Replace MapName="GiantEarth" X="35" Y="38" CityLocaleName="LOC_CITY_NAME_MASSAWA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="39" CityLocaleName="LOC_CITY_NAME_KATSINA" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="39" CityLocaleName="LOC_CITY_NAME_KANO" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="39" CityLocaleName="LOC_CITY_NAME_GASHUA" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="39" CityLocaleName="LOC_CITY_NAME_NGUIGMI" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="39" CityLocaleName="LOC_CITY_NAME_MAO" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="39" CityLocaleName="LOC_CITY_NAME_MOUSSORO" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="39" CityLocaleName="LOC_CITY_NAME_MOUSSORO" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="39" CityLocaleName="LOC_CITY_NAME_ATI" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="39" CityLocaleName="LOC_CITY_NAME_ABECHE" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="39" CityLocaleName="LOC_CITY_NAME_KUTUM" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="39" CityLocaleName="LOC_CITY_NAME_UMM_BADR" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="39" CityLocaleName="LOC_CITY_NAME_BARAH" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="39" CityLocaleName="LOC_CITY_NAME_ELAI" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="39" CityLocaleName="LOC_CITY_NAME_OMDURMAN" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="39" CityLocaleName="LOC_CITY_NAME_ATBARA" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="39" CityLocaleName="LOC_CITY_NAME_SUAKIN" Area="0" />
+
+	</CityMap>
+
+	<!-- WEST AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="8" Y="32" CityLocaleName="LOC_CITY_NAME_SAN_PEDRO" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="32" CityLocaleName="LOC_CITY_NAME_ABIDJAN" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="32" CityLocaleName="LOC_CITY_NAME_SEKONDI_TAKORADI" Area="0" />
+
+		<Replace MapName="GiantEarth" X="7" Y="33" CityLocaleName="LOC_CITY_NAME_MONROVIA" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="33" CityLocaleName="LOC_CITY_NAME_YAMOUSSOUKRO" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="33" CityLocaleName="LOC_CITY_NAME_ABENGOROU" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="33" CityLocaleName="LOC_CITY_NAME_CAPE_COAST" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="33" CityLocaleName="LOC_CITY_NAME_ACCRA" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="33" CityLocaleName="LOC_CITY_NAME_ACCRA" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="33" CityLocaleName="LOC_CITY_NAME_LOME" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="33" CityLocaleName="LOC_CITY_NAME_LOME" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="33" CityLocaleName="LOC_CITY_NAME_BENIN" Area="0" />
+
+		<Replace MapName="GiantEarth" X="7" Y="34" CityLocaleName="LOC_CITY_NAME_MONROVIA" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="34" CityLocaleName="LOC_CITY_NAME_MAN" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="34" CityLocaleName="LOC_CITY_NAME_YAMOUSSOUKRO" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="34" CityLocaleName="LOC_CITY_NAME_KUMASI" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="34" CityLocaleName="LOC_CITY_NAME_KUMASI" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="34" CityLocaleName="LOC_CITY_NAME_NKAWKAW" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="34" CityLocaleName="LOC_CITY_NAME_KPONG" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="34" CityLocaleName="LOC_CITY_NAME_HO" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="34" CityLocaleName="LOC_CITY_NAME_COTONOU" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="34" CityLocaleName="LOC_CITY_NAME_PORTO_NOVO" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="34" CityLocaleName="LOC_CITY_NAME_LAGOS" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="34" CityLocaleName="LOC_CITY_NAME_BENIN" Area="0" />
+
+		<Replace MapName="GiantEarth" X="6" Y="35" CityLocaleName="LOC_CITY_NAME_FREETOWN" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="35" CityLocaleName="LOC_CITY_NAME_NZEREKORE" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="35" CityLocaleName="LOC_CITY_NAME_SEGUELA" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="35" CityLocaleName="LOC_CITY_NAME_BOUAKE" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="35" CityLocaleName="LOC_CITY_NAME_TECHIMAN" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="35" CityLocaleName="LOC_CITY_NAME_KUMASI" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="35" CityLocaleName="LOC_CITY_NAME_YEJI" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="35" CityLocaleName="LOC_CITY_NAME_HOHOE" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="35" CityLocaleName="LOC_CITY_NAME_ATAKPAME" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="35" CityLocaleName="LOC_CITY_NAME_BOHICON" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="35" CityLocaleName="LOC_CITY_NAME_ABEOKUTA" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="35" CityLocaleName="LOC_CITY_NAME_IBADAN" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="35" CityLocaleName="LOC_CITY_NAME_ASABA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="6" Y="36" CityLocaleName="LOC_CITY_NAME_CONAKRY" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="36" CityLocaleName="LOC_CITY_NAME_GUECKEDOU" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="36" CityLocaleName="LOC_CITY_NAME_ODIENNE" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="36" CityLocaleName="LOC_CITY_NAME_KATIOLA" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="36" CityLocaleName="LOC_CITY_NAME_BONDOUKOU" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="36" CityLocaleName="LOC_CITY_NAME_BONDOUKOU" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="36" CityLocaleName="LOC_CITY_NAME_YEJI" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="36" CityLocaleName="LOC_CITY_NAME_KETE_KRACHI" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="36" CityLocaleName="LOC_CITY_NAME_DAMBAI" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="36" CityLocaleName="LOC_CITY_NAME_ATAKPAME" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="36" CityLocaleName="LOC_CITY_NAME_OYO" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="36" CityLocaleName="LOC_CITY_NAME_IFE" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="36" CityLocaleName="LOC_CITY_NAME_OWO" Area="0" />
+		<Replace MapName="GiantEarth" X="19" Y="36" CityLocaleName="LOC_CITY_NAME_LOKOJA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="5" Y="37" CityLocaleName="LOC_CITY_NAME_CONAKRY" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="37" CityLocaleName="LOC_CITY_NAME_KINDIA" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="37" CityLocaleName="LOC_CITY_NAME_KANKAN" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="37" CityLocaleName="LOC_CITY_NAME_KORHOGO" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="37" CityLocaleName="LOC_CITY_NAME_KORHOGO" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="37" CityLocaleName="LOC_CITY_NAME_BANFORA" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="37" CityLocaleName="LOC_CITY_NAME_BOUNA" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="37" CityLocaleName="LOC_CITY_NAME_WA" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="37" CityLocaleName="LOC_CITY_NAME_TAMALE" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="37" CityLocaleName="LOC_CITY_NAME_KARA" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="37" CityLocaleName="LOC_CITY_NAME_PARAKOU" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="37" CityLocaleName="LOC_CITY_NAME_OGBOMOSHO" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="37" CityLocaleName="LOC_CITY_NAME_ILORIN" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="37" CityLocaleName="LOC_CITY_NAME_PATEGI" Area="0" />
+
+		<Replace MapName="GiantEarth" X="5" Y="38" CityLocaleName="LOC_CITY_NAME_BISSAU" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="38" CityLocaleName="LOC_CITY_NAME_LABE" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="38" CityLocaleName="LOC_CITY_NAME_BANORA" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="38" CityLocaleName="LOC_CITY_NAME_BOUGOUNI" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="38" CityLocaleName="LOC_CITY_NAME_SIKASSO" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="38" CityLocaleName="LOC_CITY_NAME_SIKASSO" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="38" CityLocaleName="LOC_CITY_NAME_BOBO_DIOULASSO" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="38" CityLocaleName="LOC_CITY_NAME_DEDOUGOU" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="38" CityLocaleName="LOC_CITY_NAME_OUAGADOUGOU" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="38" CityLocaleName="LOC_CITY_NAME_BAWKU" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="38" CityLocaleName="LOC_CITY_NAME_DJOUGOU" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="38" CityLocaleName="LOC_CITY_NAME_NIKKI" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="38" CityLocaleName="LOC_CITY_NAME_SEGBANA" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="38" CityLocaleName="LOC_CITY_NAME_MOKWA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="4" Y="39" CityLocaleName="LOC_CITY_NAME_SEREKUNDA" Area="0" />
+		<Replace MapName="GiantEarth" X="5" Y="39" CityLocaleName="LOC_CITY_NAME_KOLDA" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="39" CityLocaleName="LOC_CITY_NAME_MAHINA" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="39" CityLocaleName="LOC_CITY_NAME_BAMAKO" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="39" CityLocaleName="LOC_CITY_NAME_BAMAKO" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="39" CityLocaleName="LOC_CITY_NAME_KOUTIALA" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="39" CityLocaleName="LOC_CITY_NAME_SAN" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="39" CityLocaleName="LOC_CITY_NAME_BARANI" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="39" CityLocaleName="LOC_CITY_NAME_TOUGAN" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="39" CityLocaleName="LOC_CITY_NAME_OUAGADOUGOU" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="39" CityLocaleName="LOC_CITY_NAME_POUYTENGA" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="39" CityLocaleName="LOC_CITY_NAME_MALANVILLE" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="39" CityLocaleName="LOC_CITY_NAME_GAYA" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="39" CityLocaleName="LOC_CITY_NAME_YELWA_YAURI" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="39" CityLocaleName="LOC_CITY_NAME_KADUNA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="0" Y="40" CityLocaleName="LOC_CITY_NAME_PRAIA" Area="0" />
+		<Replace MapName="GiantEarth" X="5" Y="40" CityLocaleName="LOC_CITY_NAME_BANJUL" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="40" CityLocaleName="LOC_CITY_NAME_TAMBACOUNDA" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="40" CityLocaleName="LOC_CITY_NAME_KAYES" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="40" CityLocaleName="LOC_CITY_NAME_BAMAKO" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="40" CityLocaleName="LOC_CITY_NAME_SEGOU" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="40" CityLocaleName="LOC_CITY_NAME_SEGOU" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="40" CityLocaleName="LOC_CITY_NAME_DJENNE" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="40" CityLocaleName="LOC_CITY_NAME_KORO" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="40" CityLocaleName="LOC_CITY_NAME_OUAHIGOUYA" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="40" CityLocaleName="LOC_CITY_NAME_KAYA" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="40" CityLocaleName="LOC_CITY_NAME_NIAMEY" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="40" CityLocaleName="LOC_CITY_NAME_NIAMEY" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="40" CityLocaleName="LOC_CITY_NAME_SOKOTO" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="40" CityLocaleName="LOC_CITY_NAME_SOKOTO" Area="0" />
+
+		<Replace MapName="GiantEarth" X="4" Y="41" CityLocaleName="LOC_CITY_NAME_DAKAR" Area="0" />
+		<Replace MapName="GiantEarth" X="5" Y="41" CityLocaleName="LOC_CITY_NAME_PODOR" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="41" CityLocaleName="LOC_CITY_NAME_MATAM" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="41" CityLocaleName="LOC_CITY_NAME_SANDARE" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="41" CityLocaleName="LOC_CITY_NAME_KOULIKORO" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="41" CityLocaleName="LOC_CITY_NAME_NIONO" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="41" CityLocaleName="LOC_CITY_NAME_DIAFARABE" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="41" CityLocaleName="LOC_CITY_NAME_MOPTI" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="41" CityLocaleName="LOC_CITY_NAME_SAREYAMOU" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="41" CityLocaleName="LOC_CITY_NAME_GOSSI" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="41" CityLocaleName="LOC_CITY_NAME_TESSIT" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="41" CityLocaleName="LOC_CITY_NAME_ANSONGO" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="41" CityLocaleName="LOC_CITY_NAME_OUALLAM" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="41" CityLocaleName="LOC_CITY_NAME_FILINGUE" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="41" CityLocaleName="LOC_CITY_NAME_BIRNIN_KONNI" Area="0" />
+
+		<Replace MapName="GiantEarth" X="5" Y="42" CityLocaleName="LOC_CITY_NAME_NOUAKCHOTT" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="42" CityLocaleName="LOC_CITY_NAME_KAEDI" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="42" CityLocaleName="LOC_CITY_NAME_KAEDI" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="42" CityLocaleName="LOC_CITY_NAME_AOUDAGHOST" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="42" CityLocaleName="LOC_CITY_NAME_KUMBI_SALEH" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="42" CityLocaleName="LOC_CITY_NAME_WALATA" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="42" CityLocaleName="LOC_CITY_NAME_DIRE" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="42" CityLocaleName="LOC_CITY_NAME_TIMBUKTU" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="42" CityLocaleName="LOC_CITY_NAME_KIRCHAMBA" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="42" CityLocaleName="LOC_CITY_NAME_BOUREM" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="42" CityLocaleName="LOC_CITY_NAME_GAO" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="42" CityLocaleName="LOC_CITY_NAME_MENAKA" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="42" CityLocaleName="LOC_CITY_NAME_INEKAR" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="42" CityLocaleName="LOC_CITY_NAME_TAHOUA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="4" Y="43" CityLocaleName="LOC_CITY_NAME_NOUAKCHOTT" Area="0" />
+		<Replace MapName="GiantEarth" X="5" Y="43" CityLocaleName="LOC_CITY_NAME_BOUTILIMIT" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="43" CityLocaleName="LOC_CITY_NAME_OUADANE" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="43" CityLocaleName="LOC_CITY_NAME_OUADANE" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="43" CityLocaleName="LOC_CITY_NAME_KUMBI_SALEH" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="43" CityLocaleName="LOC_CITY_NAME_KUMBI_SALEH" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="43" CityLocaleName="LOC_CITY_NAME_WALATA" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="43" CityLocaleName="LOC_CITY_NAME_GOUNDAM" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="43" CityLocaleName="LOC_CITY_NAME_TIMBUKTU" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="43" CityLocaleName="LOC_CITY_NAME_BAMBA" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="43" CityLocaleName="LOC_CITY_NAME_BOUREM" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="43" CityLocaleName="LOC_CITY_NAME_ESSOUK" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="43" CityLocaleName="LOC_CITY_NAME_TAKEDDA" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="43" CityLocaleName="LOC_CITY_NAME_TAKEDDA" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="43" CityLocaleName="LOC_CITY_NAME_AGADEZ" Area="0" />
+
+	</CityMap>
+
+	<!-- WESTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="3" Y="44" CityLocaleName="LOC_CITY_NAME_LAS_PALMAS_DE_GRAN_CANARIA" Area="0" />
+		<Replace MapName="GiantEarth" X="5" Y="44" CityLocaleName="LOC_CITY_NAME_LAAYOUNE" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="44" CityLocaleName="LOC_CITY_NAME_TINDUF" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="44" CityLocaleName="LOC_CITY_NAME_TINDUF" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="44" CityLocaleName="LOC_CITY_NAME_TAGHAZA" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="44" CityLocaleName="LOC_CITY_NAME_TAGHAZA" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="44" CityLocaleName="LOC_CITY_NAME_TAGHAZA" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="44" CityLocaleName="LOC_CITY_NAME_ARAWAN" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="44" CityLocaleName="LOC_CITY_NAME_ARAWAN" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="44" CityLocaleName="LOC_CITY_NAME_ARAWAN" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="44" CityLocaleName="LOC_CITY_NAME_ESSOUK" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="44" CityLocaleName="LOC_CITY_NAME_ESSOUK" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="44" CityLocaleName="LOC_CITY_NAME_IDLES" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="44" CityLocaleName="LOC_CITY_NAME_ILLIZI" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="44" CityLocaleName="LOC_CITY_NAME_GHAT" Area="0" />
+
+		<Replace MapName="GiantEarth" X="1" Y="45" CityLocaleName="LOC_CITY_NAME_SANTA_CRUZ_DE_TENERIFE" Area="0" />
+		<Replace MapName="GiantEarth" X="3" Y="45" CityLocaleName="LOC_CITY_NAME_ARRECIFE" Area="0" />
+		<Replace MapName="GiantEarth" X="5" Y="45" CityLocaleName="LOC_CITY_NAME_TAN_TAN" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="45" CityLocaleName="LOC_CITY_NAME_TAMDOULT" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="45" CityLocaleName="LOC_CITY_NAME_TAGHAZA" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="45" CityLocaleName="LOC_CITY_NAME_TAGHAZA" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="45" CityLocaleName="LOC_CITY_NAME_TAOUDENNI" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="45" CityLocaleName="LOC_CITY_NAME_TAOUDENNI" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="45" CityLocaleName="LOC_CITY_NAME_TAOUDENNI" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="45" CityLocaleName="LOC_CITY_NAME_TAMENTIT" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="45" CityLocaleName="LOC_CITY_NAME_AIN_SALAH" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="45" CityLocaleName="LOC_CITY_NAME_BORDJ_OMAR_DRISS" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="45" CityLocaleName="LOC_CITY_NAME_DEBDEB" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="45" CityLocaleName="LOC_CITY_NAME_GHADAMES" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="45" CityLocaleName="LOC_CITY_NAME_AWAYNAT" Area="0" />
+
+		<Replace MapName="GiantEarth" X="6" Y="46" CityLocaleName="LOC_CITY_NAME_AGADIR" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="46" CityLocaleName="LOC_CITY_NAME_MARRAKECH" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="46" CityLocaleName="LOC_CITY_NAME_ERFOUD" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="46" CityLocaleName="LOC_CITY_NAME_SIJILMASA" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="46" CityLocaleName="LOC_CITY_NAME_BENI_ABBES" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="46" CityLocaleName="LOC_CITY_NAME_ADRAR" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="46" CityLocaleName="LOC_CITY_NAME_AIN_SALAH" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="46" CityLocaleName="LOC_CITY_NAME_BORDJ_OMAR_DRISS" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="46" CityLocaleName="LOC_CITY_NAME_MERIXEN" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="46" CityLocaleName="LOC_CITY_NAME_GHADAMES" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="46" CityLocaleName="LOC_CITY_NAME_GHADAMES" Area="0" />
+
+		<Replace MapName="GiantEarth" X="5" Y="47" CityLocaleName="LOC_CITY_NAME_SAFI" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="47" CityLocaleName="LOC_CITY_NAME_MARRAKECH" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="47" CityLocaleName="LOC_CITY_NAME_MARRAKECH" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="47" CityLocaleName="LOC_CITY_NAME_TINGHIR" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="47" CityLocaleName="LOC_CITY_NAME_ERRACHIDIA" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="47" CityLocaleName="LOC_CITY_NAME_BECHAR" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="47" CityLocaleName="LOC_CITY_NAME_FIGUIG" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="47" CityLocaleName="LOC_CITY_NAME_BENI_OUNIF" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="47" CityLocaleName="LOC_CITY_NAME_EL_MENIA" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="47" CityLocaleName="LOC_CITY_NAME_OUARGLA" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="47" CityLocaleName="LOC_CITY_NAME_HASSI_MESSAOUD" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="47" CityLocaleName="LOC_CITY_NAME_EL_BORMA" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="47" CityLocaleName="LOC_CITY_NAME_BORJ_EL_KHADRA" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="47" CityLocaleName="LOC_CITY_NAME_NALUT" Area="0" />
+
+		<Replace MapName="GiantEarth" X="6" Y="48" CityLocaleName="LOC_CITY_NAME_CASABLANCA" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="48" CityLocaleName="LOC_CITY_NAME_FEZ" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="48" CityLocaleName="LOC_CITY_NAME_TENDRARA" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="48" CityLocaleName="LOC_CITY_NAME_BREZINA" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="48" CityLocaleName="LOC_CITY_NAME_GHARDAIA" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="48" CityLocaleName="LOC_CITY_NAME_EL_GUERRARA" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="48" CityLocaleName="LOC_CITY_NAME_OUARGLA" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="48" CityLocaleName="LOC_CITY_NAME_TAIBET" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="48" CityLocaleName="LOC_CITY_NAME_DOUAR_EL_MA" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="48" CityLocaleName="LOC_CITY_NAME_TATAOUINE" Area="0" />
+
+		<Replace MapName="GiantEarth" X="2" Y="49" CityLocaleName="LOC_CITY_NAME_FUNCHAL" Area="0" />
+		<Replace MapName="GiantEarth" X="6" Y="49" CityLocaleName="LOC_CITY_NAME_RABAT" Area="0" />
+		<Replace MapName="GiantEarth" X="7" Y="49" CityLocaleName="LOC_CITY_NAME_FEZ" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="49" CityLocaleName="LOC_CITY_NAME_TAZA" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="49" CityLocaleName="LOC_CITY_NAME_MECHERIA" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="49" CityLocaleName="LOC_CITY_NAME_EL_BAYADH" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="49" CityLocaleName="LOC_CITY_NAME_LAGHOUAT" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="49" CityLocaleName="LOC_CITY_NAME_DJELFA" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="49" CityLocaleName="LOC_CITY_NAME_MESSAAD" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="49" CityLocaleName="LOC_CITY_NAME_TOUGGOURT" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="49" CityLocaleName="LOC_CITY_NAME_EL_OUED" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="49" CityLocaleName="LOC_CITY_NAME_KEBILI" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="49" CityLocaleName="LOC_CITY_NAME_ZUWARA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="7" Y="50" CityLocaleName="LOC_CITY_NAME_TANGIER" Area="0" />
+		<Replace MapName="GiantEarth" X="8" Y="50" CityLocaleName="LOC_CITY_NAME_HOCEIMA" Area="0" />
+		<Replace MapName="GiantEarth" X="9" Y="50" CityLocaleName="LOC_CITY_NAME_NADOR" Area="0" />
+		<Replace MapName="GiantEarth" X="10" Y="50" CityLocaleName="LOC_CITY_NAME_ORAN" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="50" CityLocaleName="LOC_CITY_NAME_BISKRA" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="50" CityLocaleName="LOC_CITY_NAME_NEGRINE" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="50" CityLocaleName="LOC_CITY_NAME_GAFSA" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="50" CityLocaleName="LOC_CITY_NAME_GABES" Area="0" />
+
+		<Replace MapName="GiantEarth" X="10" Y="51" CityLocaleName="LOC_CITY_NAME_ORAN" Area="0" />
+		<Replace MapName="GiantEarth" X="11" Y="51" CityLocaleName="LOC_CITY_NAME_TENES" Area="0" />
+		<Replace MapName="GiantEarth" X="12" Y="51" CityLocaleName="LOC_CITY_NAME_CHERCHELL" Area="0" />
+		<Replace MapName="GiantEarth" X="13" Y="51" CityLocaleName="LOC_CITY_NAME_BLIDA" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="51" CityLocaleName="LOC_CITY_NAME_CONSTANTINE" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="51" CityLocaleName="LOC_CITY_NAME_KHENCHELA" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="51" CityLocaleName="LOC_CITY_NAME_TEBESSA" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="51" CityLocaleName="LOC_CITY_NAME_SFAX" Area="0" />
+
+		<Replace MapName="GiantEarth" X="13" Y="52" CityLocaleName="LOC_CITY_NAME_ALGIERS" Area="0" />
+		<Replace MapName="GiantEarth" X="14" Y="52" CityLocaleName="LOC_CITY_NAME_TAMENTFOUST" Area="0" />
+		<Replace MapName="GiantEarth" X="15" Y="52" CityLocaleName="LOC_CITY_NAME_BEJAIA" Area="0" />
+		<Replace MapName="GiantEarth" X="16" Y="52" CityLocaleName="LOC_CITY_NAME_SKIKDA" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="52" CityLocaleName="LOC_CITY_NAME_SOUK_AHRAS" Area="0" />
+		<Replace MapName="GiantEarth" X="18" Y="52" CityLocaleName="LOC_CITY_NAME_TUNIS" Area="0" />
+
+		<Replace MapName="GiantEarth" X="16" Y="53" CityLocaleName="LOC_CITY_NAME_ANNABA" Area="0" />
+		<Replace MapName="GiantEarth" X="17" Y="53" CityLocaleName="LOC_CITY_NAME_BIZERTA" Area="0" />
+
+	</CityMap>
+
+	<!-- EASTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="19" Y="40" CityLocaleName="LOC_CITY_NAME_MARADI" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="40" CityLocaleName="LOC_CITY_NAME_ZINDER" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="40" CityLocaleName="LOC_CITY_NAME_GOURE" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="40" CityLocaleName="LOC_CITY_NAME_ADDIA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="40" CityLocaleName="LOC_CITY_NAME_NGOURTI" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="40" CityLocaleName="LOC_CITY_NAME_SALAL" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="40" CityLocaleName="LOC_CITY_NAME_SALAL" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="40" CityLocaleName="LOC_CITY_NAME_KORO_TORO" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="40" CityLocaleName="LOC_CITY_NAME_BILTINE" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="40" CityLocaleName="LOC_CITY_NAME_GUEREDA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="40" CityLocaleName="LOC_CITY_NAME_UMM_BADR" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="40" CityLocaleName="LOC_CITY_NAME_BIR_NATRUN" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="40" CityLocaleName="LOC_CITY_NAME_AL_DABBAH" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="40" CityLocaleName="LOC_CITY_NAME_KORTI" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="40" CityLocaleName="LOC_CITY_NAME_BERBER" Area="0" />
+		<Replace MapName="GiantEarth" X="34" Y="40" CityLocaleName="LOC_CITY_NAME_PORT_SUDAN" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="41" CityLocaleName="LOC_CITY_NAME_ZINDER" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="41" CityLocaleName="LOC_CITY_NAME_ZINDER" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="41" CityLocaleName="LOC_CITY_NAME_FACHI" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="41" CityLocaleName="LOC_CITY_NAME_AGADEM" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="41" CityLocaleName="LOC_CITY_NAME_AGADEM" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="41" CityLocaleName="LOC_CITY_NAME_FAYA_LARGEAU" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="41" CityLocaleName="LOC_CITY_NAME_FAYA_LARGEAU" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="41" CityLocaleName="LOC_CITY_NAME_FADA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="41" CityLocaleName="LOC_CITY_NAME_SALIMA_OASIS" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="41" CityLocaleName="LOC_CITY_NAME_DONGOLA" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="41" CityLocaleName="LOC_CITY_NAME_KARIMA" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="41" CityLocaleName="LOC_CITY_NAME_NURI" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="41" CityLocaleName="LOC_CITY_NAME_PORT_SUDAN" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="42" CityLocaleName="LOC_CITY_NAME_AGADEZ" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="42" CityLocaleName="LOC_CITY_NAME_TABELOT" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="42" CityLocaleName="LOC_CITY_NAME_FACHI" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="42" CityLocaleName="LOC_CITY_NAME_BILMA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="42" CityLocaleName="LOC_CITY_NAME_BILMA" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="42" CityLocaleName="LOC_CITY_NAME_ZOUAR" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="42" CityLocaleName="LOC_CITY_NAME_BOURO" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="42" CityLocaleName="LOC_CITY_NAME_OUNIANGA_KEBIR" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="42" CityLocaleName="LOC_CITY_NAME_KUFRA" />
+		<Replace MapName="GiantEarth" X="30" Y="42" CityLocaleName="LOC_CITY_NAME_BARIS" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="42" CityLocaleName="LOC_CITY_NAME_FARAS" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="42" CityLocaleName="LOC_CITY_NAME_WADI_HALFA" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="42" CityLocaleName="LOC_CITY_NAME_ABU_HAMAD" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="43" CityLocaleName="LOC_CITY_NAME_ARLIT" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="43" CityLocaleName="LOC_CITY_NAME_DJADO" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="43" CityLocaleName="LOC_CITY_NAME_DJADO" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="43" CityLocaleName="LOC_CITY_NAME_MADAMA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="43" CityLocaleName="LOC_CITY_NAME_DIRKOU" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="43" CityLocaleName="LOC_CITY_NAME_BARDAI" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="43" CityLocaleName="LOC_CITY_NAME_AOUZOU" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="43" CityLocaleName="LOC_CITY_NAME_REBIANA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="43" CityLocaleName="LOC_CITY_NAME_ISMANT_EL_KHARAB" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="43" CityLocaleName="LOC_CITY_NAME_KHARGA" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="43" CityLocaleName="LOC_CITY_NAME_EDFU" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="43" CityLocaleName="LOC_CITY_NAME_LUXOR" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="43" CityLocaleName="LOC_CITY_NAME_BARANIS" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="44" CityLocaleName="LOC_CITY_NAME_GHAT" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="44" CityLocaleName="LOC_CITY_NAME_GERMA" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="44" CityLocaleName="LOC_CITY_NAME_GERMA" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="44" CityLocaleName="LOC_CITY_NAME_QATRUN" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="44" CityLocaleName="LOC_CITY_NAME_QATRUN" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="44" CityLocaleName="LOC_CITY_NAME_TMASSA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="44" CityLocaleName="LOC_CITY_NAME_AOUZOU" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="44" CityLocaleName="LOC_CITY_NAME_BUZEMA" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="44" CityLocaleName="LOC_CITY_NAME_EL_TAG" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="44" CityLocaleName="LOC_CITY_NAME_EL_QASR" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="44" CityLocaleName="LOC_CITY_NAME_MUT_EL_KHARAB" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="44" CityLocaleName="LOC_CITY_NAME_KHARGA" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="44" CityLocaleName="LOC_CITY_NAME_SOHAG" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="44" CityLocaleName="LOC_CITY_NAME_DENDERA" Area="0" />
+		<Replace MapName="GiantEarth" X="33" Y="44" CityLocaleName="LOC_CITY_NAME_QUS" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="45" CityLocaleName="LOC_CITY_NAME_UBARI" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="45" CityLocaleName="LOC_CITY_NAME_UBARI" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="45" CityLocaleName="LOC_CITY_NAME_SABHA" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="45" CityLocaleName="LOC_CITY_NAME_SABHA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="45" CityLocaleName="LOC_CITY_NAME_AL_FUQAHA" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="45" CityLocaleName="LOC_CITY_NAME_ZELLA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="45" CityLocaleName="LOC_CITY_NAME_TAZIRBU" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="45" CityLocaleName="LOC_CITY_NAME_JALU" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="45" CityLocaleName="LOC_CITY_NAME_ABU_MINQAR" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="45" CityLocaleName="LOC_CITY_NAME_FARAFRA" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="45" CityLocaleName="LOC_CITY_NAME_FARAFRA" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="45" CityLocaleName="LOC_CITY_NAME_ASYUT" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="45" CityLocaleName="LOC_CITY_NAME_DISHNA" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="45" CityLocaleName="LOC_CITY_NAME_QENA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="46" CityLocaleName="LOC_CITY_NAME_DIRJ" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="46" CityLocaleName="LOC_CITY_NAME_ADIRI" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="46" CityLocaleName="LOC_CITY_NAME_SABHA" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="46" CityLocaleName="LOC_CITY_NAME_SABHA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="46" CityLocaleName="LOC_CITY_NAME_AL_FUQAHA" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="46" CityLocaleName="LOC_CITY_NAME_ZELLA" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="46" CityLocaleName="LOC_CITY_NAME_MARADA" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="46" CityLocaleName="LOC_CITY_NAME_AWJILA" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="46" CityLocaleName="LOC_CITY_NAME_SIWA_OASIS" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="46" CityLocaleName="LOC_CITY_NAME_SIWA_OASIS" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="46" CityLocaleName="LOC_CITY_NAME_BAHARIYA_OASIS" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="46" CityLocaleName="LOC_CITY_NAME_BENI_SUEF" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="46" CityLocaleName="LOC_CITY_NAME_ATFIH" Area="0" />
+		<Replace MapName="GiantEarth" X="32" Y="46" CityLocaleName="LOC_CITY_NAME_HURGHADA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="47" CityLocaleName="LOC_CITY_NAME_ZINTAN" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="47" CityLocaleName="LOC_CITY_NAME_TABAQA" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="47" CityLocaleName="LOC_CITY_NAME_ASH_SHWAYRIF" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="47" CityLocaleName="LOC_CITY_NAME_SOKNA" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="47" CityLocaleName="LOC_CITY_NAME_WADDAN" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="47" CityLocaleName="LOC_CITY_NAME_RAS_LANUF" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="47" CityLocaleName="LOC_CITY_NAME_MARADA" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="47" CityLocaleName="LOC_CITY_NAME_AWJILA" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="47" CityLocaleName="LOC_CITY_NAME_SIWA_OASIS" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="47" CityLocaleName="LOC_CITY_NAME_BAHARIYA_OASIS" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="47" CityLocaleName="LOC_CITY_NAME_GIZA" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="47" CityLocaleName="LOC_CITY_NAME_CAIRO" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="47" CityLocaleName="LOC_CITY_NAME_RAS_GHARIB" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="48" CityLocaleName="LOC_CITY_NAME_YEFREN" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="48" CityLocaleName="LOC_CITY_NAME_GHARYAN" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="48" CityLocaleName="LOC_CITY_NAME_BANI_WALID" Area="0" />
+		<Replace MapName="GiantEarth" X="22" Y="48" CityLocaleName="LOC_CITY_NAME_SIRTE" Area="0" />
+		<Replace MapName="GiantEarth" X="23" Y="48" CityLocaleName="LOC_CITY_NAME_SIRTE" Area="0" />
+		<Replace MapName="GiantEarth" X="24" Y="48" CityLocaleName="LOC_CITY_NAME_BIN_JAWAD" Area="0" />
+		<Replace MapName="GiantEarth" X="25" Y="48" CityLocaleName="LOC_CITY_NAME_EL_AGHEILA" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="48" CityLocaleName="LOC_CITY_NAME_BREGA" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="48" CityLocaleName="LOC_CITY_NAME_AJDABIYA" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="48" CityLocaleName="LOC_CITY_NAME_QARA_OASIS" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="48" CityLocaleName="LOC_CITY_NAME_DAMANHUR" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="48" CityLocaleName="LOC_CITY_NAME_EL_MAHALLAH_EL_KUBRA" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="48" CityLocaleName="LOC_CITY_NAME_ISMAILIA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="19" Y="49" CityLocaleName="LOC_CITY_NAME_TRIPOLI" Area="0" />
+		<Replace MapName="GiantEarth" X="20" Y="49" CityLocaleName="LOC_CITY_NAME_TRIPOLI" Area="0" />
+		<Replace MapName="GiantEarth" X="21" Y="49" CityLocaleName="LOC_CITY_NAME_MISRATA" Area="0" />
+		<Replace MapName="GiantEarth" X="26" Y="49" CityLocaleName="LOC_CITY_NAME_QAMINIS" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="49" CityLocaleName="LOC_CITY_NAME_MECHILI" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="49" CityLocaleName="LOC_CITY_NAME_MARINA_EL_ALAMEIN" Area="0" />
+		<Replace MapName="GiantEarth" X="29" Y="49" CityLocaleName="LOC_CITY_NAME_ALEXANDRIA" Area="0" />
+		<Replace MapName="GiantEarth" X="30" Y="49" CityLocaleName="LOC_CITY_NAME_DAMIETTA" Area="0" />
+		<Replace MapName="GiantEarth" X="31" Y="49" CityLocaleName="LOC_CITY_NAME_PORT_SAID" Area="0" />
+
+		<Replace MapName="GiantEarth" X="26" Y="50" CityLocaleName="LOC_CITY_NAME_BENGHAZI" Area="0" />
+		<Replace MapName="GiantEarth" X="27" Y="50" CityLocaleName="LOC_CITY_NAME_BAYDA" Area="0" />
+		<Replace MapName="GiantEarth" X="28" Y="50" CityLocaleName="LOC_CITY_NAME_TOBRUK" Area="0" />
+
+	</CityMap>
+
+
 	<!-- +++++++++++++++++++++ -->
 	<!-- Asia-Pacific City Map -->
 	<!-- +++++++++++++++++++++ -->
-	
-	
+
+
 	<!-- AOTEAROA/NEW ZEALAND -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="107" Y="2" CityLocaleName="LOC_CITY_NAME_TE_ANAU" Area="0" />
 		<Replace MapName="GiantEarth" X="108" Y="2" CityLocaleName="LOC_CITY_NAME_BLUFF" Area="0" />
 		<Replace MapName="GiantEarth" X="109" Y="2" CityLocaleName="LOC_CITY_NAME_INVERCARGILL" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="109" Y="3" CityLocaleName="LOC_CITY_NAME_DUNEDIN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="109" Y="4" CityLocaleName="LOC_CITY_NAME_QUEENSTOWN" Area="0" />
 		<Replace MapName="GiantEarth" X="110" Y="4" CityLocaleName="LOC_CITY_NAME_TIMARU" Area="0" />
 		<Replace MapName="GiantEarth" X="111" Y="4" CityLocaleName="LOC_CITY_NAME_CHRISTCHURCH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="109" Y="5" CityLocaleName="LOC_CITY_NAME_GREYMOUTH" Area="0" />
 		<Replace MapName="GiantEarth" X="110" Y="5" CityLocaleName="LOC_CITY_NAME_CHRISTCHURCH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="110" Y="6" CityLocaleName="LOC_CITY_NAME_WESTPORT" Area="0" />
 		<Replace MapName="GiantEarth" X="111" Y="6" CityLocaleName="LOC_CITY_NAME_KAIKOURA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="110" Y="7" CityLocaleName="LOC_CITY_NAME_NELSON" Area="0" />
 		<Replace MapName="GiantEarth" X="111" Y="7" CityLocaleName="LOC_CITY_NAME_BLENHEIM" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="113" Y="8" CityLocaleName="LOC_CITY_NAME_WELLINGTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="111" Y="9" CityLocaleName="LOC_CITY_NAME_NEW_PLYMOUTH" Area="0" />
 		<Replace MapName="GiantEarth" X="112" Y="9" CityLocaleName="LOC_CITY_NAME_WHANGANUI" Area="0" />
 		<Replace MapName="GiantEarth" X="113" Y="9" CityLocaleName="LOC_CITY_NAME_NAPIER_HASTINGS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="112" Y="10" CityLocaleName="LOC_CITY_NAME_TE_KUITI" Area="0" />
 		<Replace MapName="GiantEarth" X="113" Y="10" CityLocaleName="LOC_CITY_NAME_TAUPO" Area="0" />
 		<Replace MapName="GiantEarth" X="114" Y="10" CityLocaleName="LOC_CITY_NAME_GISBORNE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="112" Y="11" CityLocaleName="LOC_CITY_NAME_HAMILTON" Area="0" />
 		<Replace MapName="GiantEarth" X="113" Y="11" CityLocaleName="LOC_CITY_NAME_TAURANGA" Area="0" />
 		<Replace MapName="GiantEarth" X="114" Y="11" CityLocaleName="LOC_CITY_NAME_TE_ARAROA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="112" Y="12" CityLocaleName="LOC_CITY_NAME_AUCKLAND" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="111" Y="13" CityLocaleName="LOC_CITY_NAME_WHANGAREI" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- AUSTRALIA -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="100" Y="4" CityLocaleName="LOC_CITY_NAME_HOBART" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="99" Y="5" CityLocaleName="LOC_CITY_NAME_DEVONPORT" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="5" CityLocaleName="LOC_CITY_NAME_LAUNCESTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="99" Y="7" CityLocaleName="LOC_CITY_NAME_GEELONG" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="7" CityLocaleName="LOC_CITY_NAME_MELBOURNE" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="7" CityLocaleName="LOC_CITY_NAME_ORBOST" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="96" Y="8" CityLocaleName="LOC_CITY_NAME_KINGSCOTE" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="8" CityLocaleName="LOC_CITY_NAME_MOUNT_GAMBIER" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="8" CityLocaleName="LOC_CITY_NAME_PORTLAND" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="8" CityLocaleName="LOC_CITY_NAME_BALLARAT" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="8" CityLocaleName="LOC_CITY_NAME_BRIGHT" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="8" CityLocaleName="LOC_CITY_NAME_BEGA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="86" Y="9" CityLocaleName="LOC_CITY_NAME_BUSSELTON" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="9" CityLocaleName="LOC_CITY_NAME_ALBANY" Area="0" />
 		<Replace MapName="GiantEarth" X="97" Y="9" CityLocaleName="LOC_CITY_NAME_MURRAY_BRIDGE" Area="0" />
@@ -1574,7 +2205,7 @@
 		<Replace MapName="GiantEarth" X="100" Y="9" CityLocaleName="LOC_CITY_NAME_ALBURY_WODONGA" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="9" CityLocaleName="LOC_CITY_NAME_CANBERRA" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="9" CityLocaleName="LOC_CITY_NAME_NOWRA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="87" Y="10" CityLocaleName="LOC_CITY_NAME_BUNBURY" Area="0" />
 		<Replace MapName="GiantEarth" X="88" Y="10" CityLocaleName="LOC_CITY_NAME_RAVENSTHORPE" Area="0" />
 		<Replace MapName="GiantEarth" X="89" Y="10" CityLocaleName="LOC_CITY_NAME_ESPERANCE" Area="0" />
@@ -1585,7 +2216,7 @@
 		<Replace MapName="GiantEarth" X="100" Y="10" CityLocaleName="LOC_CITY_NAME_GRIFFITH" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="10" CityLocaleName="LOC_CITY_NAME_WAGGA_WAGGA" Area="0" />
 		<Replace MapName="GiantEarth" X="103" Y="10" CityLocaleName="LOC_CITY_NAME_SYDNEY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="87" Y="11" CityLocaleName="LOC_CITY_NAME_KONDININ" Area="0" />
 		<Replace MapName="GiantEarth" X="88" Y="11" CityLocaleName="LOC_CITY_NAME_NORSEMAN" Area="0" />
 		<Replace MapName="GiantEarth" X="89" Y="11" CityLocaleName="LOC_CITY_NAME_BALLADONIA" Area="0" />
@@ -1600,7 +2231,7 @@
 		<Replace MapName="GiantEarth" X="101" Y="11" CityLocaleName="LOC_CITY_NAME_ORANGE" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="11" CityLocaleName="LOC_CITY_NAME_MAITLAND" Area="0" />
 		<Replace MapName="GiantEarth" X="103" Y="11" CityLocaleName="LOC_CITY_NAME_NEWCASTLE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="86" Y="12" CityLocaleName="LOC_CITY_NAME_PERTH" />
 		<Replace MapName="GiantEarth" X="88" Y="12" CityLocaleName="LOC_CITY_NAME_MERREDIN" Area="0" />
 		<Replace MapName="GiantEarth" X="89" Y="12" CityLocaleName="LOC_CITY_NAME_NORSEMAN" Area="0" />
@@ -1617,7 +2248,7 @@
 		<Replace MapName="GiantEarth" X="102" Y="12" CityLocaleName="LOC_CITY_NAME_DUBBO" Area="0" />
 		<Replace MapName="GiantEarth" X="103" Y="12" CityLocaleName="LOC_CITY_NAME_TAMWORTH" Area="0" />
 		<Replace MapName="GiantEarth" X="104" Y="12" CityLocaleName="LOC_CITY_NAME_COFFS_HARBOUR" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="85" Y="13" CityLocaleName="LOC_CITY_NAME_GERALDTON" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="13" CityLocaleName="LOC_CITY_NAME_MOORA" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="13" CityLocaleName="LOC_CITY_NAME_MERREDIN" Area="0" />
@@ -1636,7 +2267,7 @@
 		<Replace MapName="GiantEarth" X="102" Y="13" CityLocaleName="LOC_CITY_NAME_ARMIDALE" Area="0" />
 		<Replace MapName="GiantEarth" X="103" Y="13" CityLocaleName="LOC_CITY_NAME_GRAFTON" Area="0" />
 		<Replace MapName="GiantEarth" X="104" Y="13" CityLocaleName="LOC_CITY_NAME_GOLD_COAST" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="85" Y="14" CityLocaleName="LOC_CITY_NAME_GERALDTON" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="14" CityLocaleName="LOC_CITY_NAME_MULLEWA" Area="0" />
 		<Replace MapName="GiantEarth" X="88" Y="14" CityLocaleName="LOC_CITY_NAME_MENZIES" Area="0" />
@@ -1647,14 +2278,14 @@
 		<Replace MapName="GiantEarth" X="93" Y="14" CityLocaleName="LOC_CITY_NAME_MABEL_CREEK" Area="0" />
 		<Replace MapName="GiantEarth" X="94" Y="14" CityLocaleName="LOC_CITY_NAME_MARLA" Area="0" />
 		<Replace MapName="GiantEarth" X="95" Y="14" CityLocaleName="LOC_CITY_NAME_COOBER_PEDY" Area="0" />
-		<Replace MapName="GiantEarth" X="96" Y="14" CityLocaleName="LOC_CITY_NAME_OODNADATTA" Area="0" />
+		<Replace MapName="GiantEarth" X="96" Y="14" CityLocaleName="LOC_CITY_NAME_OODNADATTA" />
 		<Replace MapName="GiantEarth" X="98" Y="14" CityLocaleName="LOC_CITY_NAME_MUNGERANIE" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="14" CityLocaleName="LOC_CITY_NAME_INNAMINKA" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="14" CityLocaleName="LOC_CITY_NAME_BOURKE" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="14" CityLocaleName="LOC_CITY_NAME_WALGETT" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="14" CityLocaleName="LOC_CITY_NAME_GOONDIWINDI" Area="0" />
 		<Replace MapName="GiantEarth" X="104" Y="14" CityLocaleName="LOC_CITY_NAME_BRISBANE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="84" Y="15" CityLocaleName="LOC_CITY_NAME_DENHAM" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="15" CityLocaleName="LOC_CITY_NAME_NORTHAMPTON" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="15" CityLocaleName="LOC_CITY_NAME_MOUNT_MAGNET" />
@@ -1671,7 +2302,7 @@
 		<Replace MapName="GiantEarth" X="101" Y="15" CityLocaleName="LOC_CITY_NAME_MOONIE" Area="0" />
 		<Replace MapName="GiantEarth" X="103" Y="15" CityLocaleName="LOC_CITY_NAME_KINGAROY" Area="0" />
 		<Replace MapName="GiantEarth" X="104" Y="15" CityLocaleName="LOC_CITY_NAME_SUNSHINE_COAST" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="85" Y="16" CityLocaleName="LOC_CITY_NAME_CARNAVON" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="16" CityLocaleName="LOC_CITY_NAME_GASCOYNE_JUNCTION" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="16" CityLocaleName="LOC_CITY_NAME_CUE" Area="0" />
@@ -1690,7 +2321,7 @@
 		<Replace MapName="GiantEarth" X="102" Y="16" CityLocaleName="LOC_CITY_NAME_ROMA_QLD" Area="0" />
 		<Replace MapName="GiantEarth" X="103" Y="16" CityLocaleName="LOC_CITY_NAME_KINGAROY" Area="0" />
 		<Replace MapName="GiantEarth" X="104" Y="16" CityLocaleName="LOC_CITY_NAME_BUNDABERG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="84" Y="17" CityLocaleName="LOC_CITY_NAME_MACLEOD" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="17" CityLocaleName="LOC_CITY_NAME_MINILYA" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="17" CityLocaleName="LOC_CITY_NAME_MOUNT_AUGUSTUS" Area="0" />
@@ -1710,7 +2341,7 @@
 		<Replace MapName="GiantEarth" X="101" Y="17" CityLocaleName="LOC_CITY_NAME_EMERALD" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="17" CityLocaleName="LOC_CITY_NAME_BLACKWATER" Area="0" />
 		<Replace MapName="GiantEarth" X="103" Y="17" CityLocaleName="LOC_CITY_NAME_ROCKHAMPTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="85" Y="18" CityLocaleName="LOC_CITY_NAME_MINILYA" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="18" CityLocaleName="LOC_CITY_NAME_TOM_PRICE" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="18" CityLocaleName="LOC_CITY_NAME_PARABURDOO" Area="0" />
@@ -1730,7 +2361,7 @@
 		<Replace MapName="GiantEarth" X="101" Y="18" CityLocaleName="LOC_CITY_NAME_BLAIR_ATHOL" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="18" CityLocaleName="LOC_CITY_NAME_CLERMONT" Area="0" />
 		<Replace MapName="GiantEarth" X="103" Y="18" CityLocaleName="LOC_CITY_NAME_ROCKHAMPTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="85" Y="19" CityLocaleName="LOC_CITY_NAME_ONSLOW" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="19" CityLocaleName="LOC_CITY_NAME_DAMPIER" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="19" CityLocaleName="LOC_CITY_NAME_WITTENOON" Area="0" />
@@ -1749,7 +2380,7 @@
 		<Replace MapName="GiantEarth" X="100" Y="19" CityLocaleName="LOC_CITY_NAME_CHARTERS_TOWERS" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="19" CityLocaleName="LOC_CITY_NAME_CHARTERS_TOWERS" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="19" CityLocaleName="LOC_CITY_NAME_MACKAY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="87" Y="20" CityLocaleName="LOC_CITY_NAME_PORT_HEDLAND" />
 		<Replace MapName="GiantEarth" X="89" Y="20" CityLocaleName="LOC_CITY_NAME_LIVERINGA" Area="0" />
 		<Replace MapName="GiantEarth" X="90" Y="20" CityLocaleName="LOC_CITY_NAME_FITZROY_CROSSING" Area="0" />
@@ -1765,7 +2396,7 @@
 		<Replace MapName="GiantEarth" X="100" Y="20" CityLocaleName="LOC_CITY_NAME_GREENVALE" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="20" CityLocaleName="LOC_CITY_NAME_INGHAM" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="20" CityLocaleName="LOC_CITY_NAME_TOWNSVILLE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="88" Y="21" CityLocaleName="LOC_CITY_NAME_BROOME" Area="0" />
 		<Replace MapName="GiantEarth" X="89" Y="21" CityLocaleName="LOC_CITY_NAME_DERBY" Area="0" />
 		<Replace MapName="GiantEarth" X="90" Y="21" CityLocaleName="LOC_CITY_NAME_WYNDHAM" Area="0" />
@@ -1779,7 +2410,7 @@
 		<Replace MapName="GiantEarth" X="98" Y="21" CityLocaleName="LOC_CITY_NAME_NORMANTON" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="21" CityLocaleName="LOC_CITY_NAME_MOUNT_SURPRISE" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="21" CityLocaleName="LOC_CITY_NAME_CAIRNS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="91" Y="22" CityLocaleName="LOC_CITY_NAME_TIMBER_CREEK" Area="0" />
 		<Replace MapName="GiantEarth" X="92" Y="22" CityLocaleName="LOC_CITY_NAME_KATHERINE" Area="0" />
 		<Replace MapName="GiantEarth" X="93" Y="22" CityLocaleName="LOC_CITY_NAME_KATHERINE" Area="0" />
@@ -1787,60 +2418,60 @@
 		<Replace MapName="GiantEarth" X="98" Y="22" CityLocaleName="LOC_CITY_NAME_KARUMBA" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="22" CityLocaleName="LOC_CITY_NAME_MUNGANA" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="22" CityLocaleName="LOC_CITY_NAME_CAIRNS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="91" Y="23" CityLocaleName="LOC_CITY_NAME_BATCHELOR" Area="0" />
 		<Replace MapName="GiantEarth" X="92" Y="23" CityLocaleName="LOC_CITY_NAME_KATHERINE" Area="0" />
 		<Replace MapName="GiantEarth" X="93" Y="23" CityLocaleName="LOC_CITY_NAME_ROPER_BAR" Area="0" />
 		<Replace MapName="GiantEarth" X="94" Y="23" CityLocaleName="LOC_CITY_NAME_NUMBULWAR" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="23" CityLocaleName="LOC_CITY_NAME_KOWANYAMA" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="23" CityLocaleName="LOC_CITY_NAME_COOKTOWN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="92" Y="24" CityLocaleName="LOC_CITY_NAME_DARWIN" Area="0" />
 		<Replace MapName="GiantEarth" X="93" Y="24" CityLocaleName="LOC_CITY_NAME_DARWIN" Area="0" />
 		<Replace MapName="GiantEarth" X="94" Y="24" CityLocaleName="LOC_CITY_NAME_JABIRU" Area="0" />
 		<Replace MapName="GiantEarth" X="95" Y="24" CityLocaleName="LOC_CITY_NAME_NHULUNBUY" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="24" CityLocaleName="LOC_CITY_NAME_WEIPA" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="24" CityLocaleName="LOC_CITY_NAME_COEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="97" Y="25" CityLocaleName="LOC_CITY_NAME_BAMAGA" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="25" CityLocaleName="LOC_CITY_NAME_CAPE_YORK" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- PAPUA -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="98" Y="28" CityLocaleName="LOC_CITY_NAME_MERAUKE" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="28" CityLocaleName="LOC_CITY_NAME_DARU" Area="0" />
 		<Replace MapName="GiantEarth" X="102" Y="28" CityLocaleName="LOC_CITY_NAME_PORT_MORESBY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="97" Y="29" CityLocaleName="LOC_CITY_NAME_PIRIMAPUN" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="29" CityLocaleName="LOC_CITY_NAME_KIUNGA" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="29" CityLocaleName="LOC_CITY_NAME_BAIMURU" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="29" CityLocaleName="LOC_CITY_NAME_PORT_MORESBY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="96" Y="30" CityLocaleName="LOC_CITY_NAME_KOKENAU" Area="0" />
 		<Replace MapName="GiantEarth" X="97" Y="30" CityLocaleName="LOC_CITY_NAME_AGATS" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="30" CityLocaleName="LOC_CITY_NAME_TELEFOMIN" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="30" CityLocaleName="LOC_CITY_NAME_MADANG" Area="0" />
 		<Replace MapName="GiantEarth" X="101" Y="30" CityLocaleName="LOC_CITY_NAME_LAE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="93" Y="31" CityLocaleName="LOC_CITY_NAME_KONOKA" Area="0" />
 		<Replace MapName="GiantEarth" X="95" Y="31" CityLocaleName="LOC_CITY_NAME_NABIRE" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="31" CityLocaleName="LOC_CITY_NAME_WEWAK" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="31" CityLocaleName="LOC_CITY_NAME_WEWAK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="93" Y="32" CityLocaleName="LOC_CITY_NAME_SORONG" Area="0" />
 		<Replace MapName="GiantEarth" X="94" Y="32" CityLocaleName="LOC_CITY_NAME_MANOKWARI" Area="0" />
 		<Replace MapName="GiantEarth" X="96" Y="32" CityLocaleName="LOC_CITY_NAME_MATABOOR" Area="0" />
 		<Replace MapName="GiantEarth" X="97" Y="32" CityLocaleName="LOC_CITY_NAME_JAYAPURA" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="32" CityLocaleName="LOC_CITY_NAME_VANIMO" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- SOUTH EAST ASIA -->
 	<CityMap>
-		
+
 		<!-- VIETNAM, LAOS, MYANMAR, THAILAND & CAMBODIA -->
 		<Replace MapName="GiantEarth" X="73" Y="51" CityLocaleName="LOC_CITY_NAME_NUJIANG" Area="0" />
 		<Replace MapName="GiantEarth" X="71" Y="49" CityLocaleName="LOC_CITY_NAME_MONYWA" Area="0" />
@@ -1852,7 +2483,7 @@
 		<Replace MapName="GiantEarth" X="74" Y="47" CityLocaleName="LOC_CITY_NAME_LUANG_NAMTHA" Area="0" />
 		<Replace MapName="GiantEarth" X="75" Y="47" CityLocaleName="LOC_CITY_NAME_LUANG_NAMTHA" Area="0" />
 		<Replace MapName="GiantEarth" X="76" Y="47" CityLocaleName="LOC_CITY_NAME_HANOI" />
-		
+
 		<Replace MapName="GiantEarth" X="77" Y="46" CityLocaleName="LOC_CITY_NAME_HANOI" Area="0" />
 		<Replace MapName="GiantEarth" X="70" Y="46" CityLocaleName="LOC_CITY_NAME_CHITTAGONG" />
 		<Replace MapName="GiantEarth" X="73" Y="46" CityLocaleName="LOC_CITY_NAME_TAUNGGYI" Area="0" />
@@ -1866,7 +2497,7 @@
 		<Replace MapName="GiantEarth" X="72" Y="44" CityLocaleName="LOC_CITY_NAME_NAYPYIDAW" />
 		<Replace MapName="GiantEarth" X="73" Y="44" CityLocaleName="LOC_CITY_NAME_TAK" Area="0" />
 		<Replace MapName="GiantEarth" X="75" Y="44" CityLocaleName="LOC_CITY_NAME_PHITSANULOK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="72" Y="43" CityLocaleName="LOC_CITY_NAME_BAGO" Area="0" />
 		<Replace MapName="GiantEarth" X="74" Y="43" CityLocaleName="LOC_CITY_NAME_NAKHON_SAWAN" Area="0" />
 		<Replace MapName="GiantEarth" X="75" Y="43" CityLocaleName="LOC_CITY_NAME_PETCHABURI" Area="0" />
@@ -1886,7 +2517,7 @@
 		<Replace MapName="GiantEarth" X="78" Y="41" CityLocaleName="LOC_CITY_NAME_PAKXE" Area="0" />
 		<Replace MapName="GiantEarth" X="79" Y="41" CityLocaleName="LOC_CITY_NAME_BOUN_MA_THOUT" Area="0" />
 		<Replace MapName="GiantEarth" X="80" Y="41" CityLocaleName="LOC_CITY_NAME_BOUN_MA_THOUT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="75" Y="40" CityLocaleName="LOC_CITY_NAME_BANGKOK" />
 		<Replace MapName="GiantEarth" X="76" Y="40" CityLocaleName="LOC_CITY_NAME_SEREI_SAOPHOAN" Area="0" />
 		<Replace MapName="GiantEarth" X="77" Y="40" CityLocaleName="LOC_CITY_NAME_SIEM_REAP" Area="0" />
@@ -1899,7 +2530,7 @@
 		<Replace MapName="GiantEarth" X="80" Y="39" CityLocaleName="LOC_CITY_NAME_NHA_TRANG" />
 		<Replace MapName="GiantEarth" X="69" Y="38" CityLocaleName="LOC_CITY_NAME_ANDAMAN_ISLANDS" />
 		<Replace MapName="GiantEarth" X="74" Y="38" CityLocaleName="LOC_CITY_NAME_PRACHUAP_KIRI_KHAN"/>
-		
+
 		<Replace MapName="GiantEarth" X="73" Y="37" CityLocaleName="LOC_CITY_NAME_SURAT_THANI" Area="0" />
 		<Replace MapName="GiantEarth" X="78" Y="38" CityLocaleName="LOC_CITY_NAME_HO_CHI_MINH_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="78" Y="37" CityLocaleName="LOC_CITY_NAME_HO_CHI_MINH_CITY" />
@@ -1907,9 +2538,9 @@
 		<Replace MapName="GiantEarth" X="69" Y="35" CityLocaleName="LOC_CITY_NAME_NICOBAR_ISLANDS" />
 		<Replace MapName="GiantEarth" X="74" Y="35" CityLocaleName="LOC_CITY_NAME_HAT_YAI" Area="0" />
 		<Replace MapName="GiantEarth" X="75" Y="35" CityLocaleName="LOC_CITY_NAME_NARATHIWAT" Area="0" />
-		
+
 		<!-- PHILIPPINES, MALAYSIA & INDONESIA  -->
-		
+
 		<Replace MapName="GiantEarth" X="87" Y="44" CityLocaleName="LOC_CITY_NAME_LAOAG" />
 		<Replace MapName="GiantEarth" X="89" Y="44" CityLocaleName="LOC_CITY_NAME_TUGUEGARAO" />
 		<Replace MapName="GiantEarth" X="90" Y="42" CityLocaleName="LOC_CITY_NAME_MUNOZ" />
@@ -1918,7 +2549,7 @@
 		<Replace MapName="GiantEarth" X="91" Y="38" CityLocaleName="LOC_CITY_NAME_TACLOBAN" />
 		<Replace MapName="GiantEarth" X="86" Y="37" CityLocaleName="LOC_CITY_NAME_PUERTO_PRINCESA" />
 		<Replace MapName="GiantEarth" X="88" Y="36" CityLocaleName="LOC_CITY_NAME_ZAMBOANGA" />
-		
+
 		<Replace MapName="GiantEarth" X="84" Y="35" CityLocaleName="LOC_CITY_NAME_KOTA_KINABALU" />
 		<Replace MapName="GiantEarth" X="90" Y="35" CityLocaleName="LOC_CITY_NAME_DAVAO" />
 		<Replace MapName="GiantEarth" X="72" Y="34" CityLocaleName="LOC_CITY_NAME_BANDA_ACEH" Area="0" />
@@ -1932,7 +2563,7 @@
 		<Replace MapName="GiantEarth" X="77" Y="33" CityLocaleName="LOC_CITY_NAME_KUANTAN" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="33" CityLocaleName="LOC_CITY_NAME_LAHAD_DATU" Area="0" />
 		<Replace MapName="GiantEarth" X="91" Y="33" CityLocaleName="LOC_CITY_NAME_NORTH_MALUKU" />
-		
+
 		<Replace MapName="GiantEarth" X="73" Y="32" CityLocaleName="LOC_CITY_NAME_PADANG_SIDEMPUAN" Area="0" />
 		<Replace MapName="GiantEarth" X="76" Y="32" CityLocaleName="LOC_CITY_NAME_KUALA_LUMPUR" />
 		<Replace MapName="GiantEarth" X="77" Y="32" CityLocaleName="LOC_CITY_NAME_JOHOR_BAHRU" Area="0" />
@@ -1941,7 +2572,7 @@
 		<Replace MapName="GiantEarth" X="83" Y="32" CityLocaleName="LOC_CITY_NAME_BINTULU" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="32" CityLocaleName="LOC_CITY_NAME_TARAKAN" Area="0" />
 		<Replace MapName="GiantEarth" X="88" Y="32" CityLocaleName="LOC_CITY_NAME_GORONTALO" />
-		
+
 		<Replace MapName="GiantEarth" X="74" Y="31" CityLocaleName="LOC_CITY_NAME_DUMAI" Area="0" />
 		<Replace MapName="GiantEarth" X="82" Y="31" CityLocaleName="LOC_CITY_NAME_SIBU" Area="0" />
 		<Replace MapName="GiantEarth" X="83" Y="31" CityLocaleName="LOC_CITY_NAME_KALIMANTAN" />
@@ -1958,7 +2589,7 @@
 		<Replace MapName="GiantEarth" X="85" Y="30" CityLocaleName="LOC_CITY_NAME_BALIKPAPAN" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="30" CityLocaleName="LOC_CITY_NAME_PALU" Area="0" />
 		<Replace MapName="GiantEarth" X="91" Y="30" CityLocaleName="LOC_CITY_NAME_BANGGAI_REGENCY" />
-		
+
 		<Replace MapName="GiantEarth" X="72" Y="29" CityLocaleName="LOC_CITY_NAME_PULAU_NIAS" />
 		<Replace MapName="GiantEarth" X="77" Y="29" CityLocaleName="LOC_CITY_NAME_PALEMBANG" />
 		<Replace MapName="GiantEarth" X="79" Y="29" CityLocaleName="LOC_CITY_NAME_BANGKA_BELITUNG_ISLANDS" />
@@ -1969,7 +2600,7 @@
 		<Replace MapName="GiantEarth" X="88" Y="29" CityLocaleName="LOC_CITY_NAME_PALOPO" Area="0" />
 		<Replace MapName="GiantEarth" X="76" Y="28" CityLocaleName="LOC_CITY_NAME_BENGKULU" Area="0" />
 		<Replace MapName="GiantEarth" X="93" Y="28" CityLocaleName="LOC_CITY_NAME_PALAU_JAMDENA" />
-		
+
 		<Replace MapName="GiantEarth" X="74" Y="27" CityLocaleName="LOC_CITY_NAME_PULUA_SIBERUT" />
 		<Replace MapName="GiantEarth" X="82" Y="27" CityLocaleName="LOC_CITY_NAME_SAMPIT" />
 		<Replace MapName="GiantEarth" X="84" Y="27" CityLocaleName="LOC_CITY_NAME_BANJARMASIN" />
@@ -1983,213 +2614,213 @@
 		<Replace MapName="GiantEarth" X="84" Y="25" CityLocaleName="LOC_CITY_NAME_SURABAYA" />
 		<Replace MapName="GiantEarth" X="87" Y="25" CityLocaleName="LOC_CITY_NAME_BALI" />
 		<Replace MapName="GiantEarth" X="89" Y="25" CityLocaleName="LOC_CITY_NAME_NUSA_TENGGARA" />
-		
+
 		<Replace MapName="GiantEarth" X="85" Y="24" CityLocaleName="LOC_CITY_NAME_PROBOLINGGO" Area="0" />
 		<Replace MapName="GiantEarth" X="78" Y="23" CityLocaleName="LOC_CITY_NAME_CHRISTMAS_ISLANDS" />
 		<Replace MapName="GiantEarth" X="82" Y="23" CityLocaleName="LOC_CITY_NAME_YOGYAKARTA" />
-		
+
 	</CityMap>
-	
+
 	<!-- INDIAN SUBCONTINENT -->
 	<CityMap>
-		
+
 		<!-- INDIA, PAKISTAN, BANGLADESH, SRI LANKA -->
 		<Replace MapName="GiantEarth" X="58" Y="58" CityLocaleName="LOC_CITY_NAME_MALAKAND" Area="0" />
 		<Replace MapName="GiantEarth" X="59" Y="58" CityLocaleName="LOC_CITY_NAME_ABBOTTABAD" Area="0" />
-		<Replace MapName="GiantEarth" X="62" Y="58" CityLocaleName="LOC_CITY_NAME_CHAMBA" Area="0" />		
+		<Replace MapName="GiantEarth" X="62" Y="58" CityLocaleName="LOC_CITY_NAME_CHAMBA" Area="0" />
 		<Replace MapName="GiantEarth" X="56" Y="57" CityLocaleName="LOC_CITY_NAME_PESHAWAR" Area="0" />
 		<Replace MapName="GiantEarth" X="57" Y="57" CityLocaleName="LOC_CITY_NAME_ISLAMABAD" Area="0" />
 		<Replace MapName="GiantEarth" X="58" Y="57" CityLocaleName="LOC_CITY_NAME_ISLAMABAD" Area="0" />
-		<Replace MapName="GiantEarth" X="60" Y="57" CityLocaleName="LOC_CITY_NAME_SRINAGAR" />		
-		<Replace MapName="GiantEarth" X="62" Y="57" CityLocaleName="LOC_CITY_NAME_PALAMPUR" Area="0" />		
+		<Replace MapName="GiantEarth" X="60" Y="57" CityLocaleName="LOC_CITY_NAME_SRINAGAR" />
+		<Replace MapName="GiantEarth" X="62" Y="57" CityLocaleName="LOC_CITY_NAME_PALAMPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="63" Y="57" CityLocaleName="LOC_CITY_NAME_MANALI" Area="0" />
 		<Replace MapName="GiantEarth" X="55" Y="56" CityLocaleName="LOC_CITY_NAME_PARACHINAR" Area="0" />
-		<Replace MapName="GiantEarth" X="57" Y="56" CityLocaleName="LOC_CITY_NAME_KOHAT" Area="0" />		
-		<Replace MapName="GiantEarth" X="58" Y="56" CityLocaleName="LOC_CITY_NAME_RAWALPINDI" />		
+		<Replace MapName="GiantEarth" X="57" Y="56" CityLocaleName="LOC_CITY_NAME_KOHAT" Area="0" />
+		<Replace MapName="GiantEarth" X="58" Y="56" CityLocaleName="LOC_CITY_NAME_RAWALPINDI" />
 		<Replace MapName="GiantEarth" X="63" Y="56" CityLocaleName="LOC_CITY_NAME_MANDI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="55" Y="55" CityLocaleName="LOC_CITY_NAME_DERA_ISMAIL_KHAN" Area="0" />
-		<Replace MapName="GiantEarth" X="56" Y="55" CityLocaleName="LOC_CITY_NAME_DERA_ISMAIL_KHAN" Area="0" />		
-		<Replace MapName="GiantEarth" X="57" Y="55" CityLocaleName="LOC_CITY_NAME_SARGODHA" Area="0" />		
+		<Replace MapName="GiantEarth" X="56" Y="55" CityLocaleName="LOC_CITY_NAME_DERA_ISMAIL_KHAN" Area="0" />
+		<Replace MapName="GiantEarth" X="57" Y="55" CityLocaleName="LOC_CITY_NAME_SARGODHA" Area="0" />
 		<Replace MapName="GiantEarth" X="57" Y="54" CityLocaleName="LOC_CITY_NAME_SARGODHA" Area="0" />
 		<Replace MapName="GiantEarth" X="58" Y="55" CityLocaleName="LOC_CITY_NAME_GUJRANWALA" Area="0" />
 		<Replace MapName="GiantEarth" X="58" Y="54" CityLocaleName="LOC_CITY_NAME_GUJRANWALA" Area="0" />
 		<Replace MapName="GiantEarth" X="61" Y="55" CityLocaleName="LOC_CITY_NAME_CHANDIGARH" />
-		<Replace MapName="GiantEarth" X="62" Y="55" CityLocaleName="LOC_CITY_NAME_SHIMLA" Area="0" />		
+		<Replace MapName="GiantEarth" X="62" Y="55" CityLocaleName="LOC_CITY_NAME_SHIMLA" Area="0" />
 		<Replace MapName="GiantEarth" X="63" Y="55" CityLocaleName="LOC_CITY_NAME_SHIMLA" Area="0" />
 		<Replace MapName="GiantEarth" X="64" Y="55" CityLocaleName="LOC_CITY_NAME_SURKHET" Area="0" />
 		<Replace MapName="GiantEarth" X="55" Y="54" CityLocaleName="LOC_CITY_NAME_QUETTA" />
-		<Replace MapName="GiantEarth" X="56" Y="54" CityLocaleName="LOC_CITY_NAME_BHAKKAR" Area="0" />		
+		<Replace MapName="GiantEarth" X="56" Y="54" CityLocaleName="LOC_CITY_NAME_BHAKKAR" Area="0" />
 		<Replace MapName="GiantEarth" X="59" Y="54" CityLocaleName="LOC_CITY_NAME_LAHORE" />
 		<Replace MapName="GiantEarth" X="60" Y="54" CityLocaleName="LOC_CITY_NAME_LUDHIANA" Area="0" />
 		<Replace MapName="GiantEarth" X="62" Y="54" CityLocaleName="LOC_CITY_NAME_DEHRADUN" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="55" Y="53" CityLocaleName="LOC_CITY_NAME_DERA_GHAZI_KHAN" Area="0" />		
-		<Replace MapName="GiantEarth" X="56" Y="53" CityLocaleName="LOC_CITY_NAME_DERA_GHAZI_KHAN" Area="0" />		
+
+		<Replace MapName="GiantEarth" X="55" Y="53" CityLocaleName="LOC_CITY_NAME_DERA_GHAZI_KHAN" Area="0" />
+		<Replace MapName="GiantEarth" X="56" Y="53" CityLocaleName="LOC_CITY_NAME_DERA_GHAZI_KHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="57" Y="53" CityLocaleName="LOC_CITY_NAME_FAISALABAD" Area="0" />
 		<Replace MapName="GiantEarth" X="58" Y="52" CityLocaleName="LOC_CITY_NAME_FAISALABAD" Area="0" />
 		<Replace MapName="GiantEarth" X="61" Y="53" CityLocaleName="LOC_CITY_NAME_MEERUT" Area="0" />
-		<Replace MapName="GiantEarth" X="62" Y="53" CityLocaleName="LOC_CITY_NAME_GONDA" Area="0" />		
-		<Replace MapName="GiantEarth" X="63" Y="53" CityLocaleName="LOC_CITY_NAME_BHARATPUR" Area="0" />		
+		<Replace MapName="GiantEarth" X="62" Y="53" CityLocaleName="LOC_CITY_NAME_GONDA" Area="0" />
+		<Replace MapName="GiantEarth" X="63" Y="53" CityLocaleName="LOC_CITY_NAME_BHARATPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="71" Y="53" CityLocaleName="LOC_CITY_NAME_DIBRUGARH" Area="0" />
 		<Replace MapName="GiantEarth" X="72" Y="53" CityLocaleName="LOC_CITY_NAME_DIBRUGARH" Area="0" />
-		<Replace MapName="GiantEarth" X="53" Y="52" CityLocaleName="LOC_CITY_NAME_KHUZDAR" Area="0" />		
-		<Replace MapName="GiantEarth" X="53" Y="51" CityLocaleName="LOC_CITY_NAME_KHUZDAR" Area="0" />				
+		<Replace MapName="GiantEarth" X="53" Y="52" CityLocaleName="LOC_CITY_NAME_KHUZDAR" Area="0" />
+		<Replace MapName="GiantEarth" X="53" Y="51" CityLocaleName="LOC_CITY_NAME_KHUZDAR" Area="0" />
 		<Replace MapName="GiantEarth" X="56" Y="52" CityLocaleName="LOC_CITY_NAME_SHIKARPU" Area="0" />
 		<Replace MapName="GiantEarth" X="57" Y="52" CityLocaleName="LOC_CITY_NAME_MULTAN" Area="0" />
 		<Replace MapName="GiantEarth" X="56" Y="51" CityLocaleName="LOC_CITY_NAME_MULTAN" Area="0" />
-		<Replace MapName="GiantEarth" X="60" Y="52" CityLocaleName="LOC_CITY_NAME_NEW_DELHI" />		
+		<Replace MapName="GiantEarth" X="60" Y="52" CityLocaleName="LOC_CITY_NAME_NEW_DELHI" />
 		<Replace MapName="GiantEarth" X="62" Y="52" CityLocaleName="LOC_CITY_NAME_FAIZABAD" Area="0" />
 		<Replace MapName="GiantEarth" X="63" Y="52" CityLocaleName="LOC_CITY_NAME_GIRAKHPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="64" Y="52" CityLocaleName="LOC_CITY_NAME_BETTIAH" Area="0" />
-		<Replace MapName="GiantEarth" X="66" Y="52" CityLocaleName="LOC_CITY_NAME_KATHMANDU" />		
+		<Replace MapName="GiantEarth" X="66" Y="52" CityLocaleName="LOC_CITY_NAME_KATHMANDU" />
 		<Replace MapName="GiantEarth" X="67" Y="52" CityLocaleName="LOC_CITY_NAME_DARJEELING" Area="0" />
 		<Replace MapName="GiantEarth" X="68" Y="52" CityLocaleName="LOC_CITY_NAME_THIMPHU" Area="0" />
 		<Replace MapName="GiantEarth" X="69" Y="52" CityLocaleName="LOC_CITY_NAME_THIMPHU" Area="0" />
-		<Replace MapName="GiantEarth" X="70" Y="52" CityLocaleName="LOC_CITY_NAME_ITANAGAR" Area="0" />		
-		<Replace MapName="GiantEarth" X="71" Y="52" CityLocaleName="LOC_CITY_NAME_ITANAGAR" Area="0" />		
-		
+		<Replace MapName="GiantEarth" X="70" Y="52" CityLocaleName="LOC_CITY_NAME_ITANAGAR" Area="0" />
+		<Replace MapName="GiantEarth" X="71" Y="52" CityLocaleName="LOC_CITY_NAME_ITANAGAR" Area="0" />
+
 		<Replace MapName="GiantEarth" X="54" Y="51" CityLocaleName="LOC_CITY_NAME_LARKANA" />
-		<Replace MapName="GiantEarth" X="55" Y="51" CityLocaleName="LOC_CITY_NAME_SUKKUR" Area="0" />		
-		<Replace MapName="GiantEarth" X="56" Y="51" CityLocaleName="LOC_CITY_NAME_SUKKUR" Area="0" />		
-		<Replace MapName="GiantEarth" X="57" Y="51" CityLocaleName="LOC_CITY_NAME_BAHAWALPUR" Area="0" />		
+		<Replace MapName="GiantEarth" X="55" Y="51" CityLocaleName="LOC_CITY_NAME_SUKKUR" Area="0" />
+		<Replace MapName="GiantEarth" X="56" Y="51" CityLocaleName="LOC_CITY_NAME_SUKKUR" Area="0" />
+		<Replace MapName="GiantEarth" X="57" Y="51" CityLocaleName="LOC_CITY_NAME_BAHAWALPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="58" Y="51" CityLocaleName="LOC_CITY_NAME_SRI_GANGANAGAR" Area="0" />
 		<Replace MapName="GiantEarth" X="61" Y="51" CityLocaleName="LOC_CITY_NAME_LUCKNOW" Area="0" />
 		<Replace MapName="GiantEarth" X="62" Y="50" CityLocaleName="LOC_CITY_NAME_LUCKNOW" Area="0" />
-		<Replace MapName="GiantEarth" X="62" Y="51" CityLocaleName="LOC_CITY_NAME_ALLAHABAD" Area="0" />		
-		<Replace MapName="GiantEarth" X="63" Y="51" CityLocaleName="LOC_CITY_NAME_VARANASI"  />		
+		<Replace MapName="GiantEarth" X="62" Y="51" CityLocaleName="LOC_CITY_NAME_ALLAHABAD" Area="0" />
+		<Replace MapName="GiantEarth" X="63" Y="51" CityLocaleName="LOC_CITY_NAME_VARANASI"  />
 		<Replace MapName="GiantEarth" X="65" Y="51" CityLocaleName="LOC_CITY_NAME_BIRGUNJ" Area="0" />
 		<Replace MapName="GiantEarth" X="66" Y="51" CityLocaleName="LOC_CITY_NAME_JANAKPUR" Area="0" />
-		<Replace MapName="GiantEarth" X="67" Y="51" CityLocaleName="LOC_CITY_NAME_BOGRA" Area="0" />		
+		<Replace MapName="GiantEarth" X="67" Y="51" CityLocaleName="LOC_CITY_NAME_BOGRA" Area="0" />
 		<Replace MapName="GiantEarth" X="68" Y="51" CityLocaleName="LOC_CITY_NAME_GUWAHATI" Area="0" />
 		<Replace MapName="GiantEarth" X="69" Y="51" CityLocaleName="LOC_CITY_NAME_DIMAPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="70" Y="51" CityLocaleName="LOC_CITY_NAME_DIMAPUR" Area="0" />
-		<Replace MapName="GiantEarth" X="71" Y="51" CityLocaleName="LOC_CITY_NAME_KOHIMA" Area="0" />		
-		
+		<Replace MapName="GiantEarth" X="71" Y="51" CityLocaleName="LOC_CITY_NAME_KOHIMA" Area="0" />
+
 		<Replace MapName="GiantEarth" X="54" Y="50" CityLocaleName="LOC_CITY_NAME_DADU" Area="0" />
 		<Replace MapName="GiantEarth" X="55" Y="50" CityLocaleName="LOC_CITY_NAME_NAWABSHAH" Area="0" />
 		<Replace MapName="GiantEarth" X="54" Y="49" CityLocaleName="LOC_CITY_NAME_NAWABSHAH" Area="0" />
-		<Replace MapName="GiantEarth" X="57" Y="50" CityLocaleName="LOC_CITY_NAME_JAISALMER" Area="0" />		
-		<Replace MapName="GiantEarth" X="58" Y="50" CityLocaleName="LOC_CITY_NAME_BIKANER" Area="0" />		
+		<Replace MapName="GiantEarth" X="57" Y="50" CityLocaleName="LOC_CITY_NAME_JAISALMER" Area="0" />
+		<Replace MapName="GiantEarth" X="58" Y="50" CityLocaleName="LOC_CITY_NAME_BIKANER" Area="0" />
 		<Replace MapName="GiantEarth" X="60" Y="50" CityLocaleName="LOC_CITY_NAME_AGRA" Area="0" />
 		<Replace MapName="GiantEarth" X="61" Y="50" CityLocaleName="LOC_CITY_NAME_AGRA" Area="0" />
-		<Replace MapName="GiantEarth" X="66" Y="50" CityLocaleName="LOC_CITY_NAME_BEGUSARAI" Area="0" />		
-		<Replace MapName="GiantEarth" X="67" Y="50" CityLocaleName="LOC_CITY_NAME_RAJSHAHI" Area="0" />		
+		<Replace MapName="GiantEarth" X="66" Y="50" CityLocaleName="LOC_CITY_NAME_BEGUSARAI" Area="0" />
+		<Replace MapName="GiantEarth" X="67" Y="50" CityLocaleName="LOC_CITY_NAME_RAJSHAHI" Area="0" />
 		<Replace MapName="GiantEarth" X="68" Y="50" CityLocaleName="LOC_CITY_NAME_RANGPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="69" Y="50" CityLocaleName="LOC_CITY_NAME_SYLHET" Area="0" />
-		<Replace MapName="GiantEarth" X="70" Y="50" CityLocaleName="LOC_CITY_NAME_AIZAWL" Area="0" />		
-		<Replace MapName="GiantEarth" X="71" Y="50" CityLocaleName="LOC_CITY_NAME_IMPHAL" Area="0" />		
-		
+		<Replace MapName="GiantEarth" X="70" Y="50" CityLocaleName="LOC_CITY_NAME_AIZAWL" Area="0" />
+		<Replace MapName="GiantEarth" X="71" Y="50" CityLocaleName="LOC_CITY_NAME_IMPHAL" Area="0" />
+
 		<Replace MapName="GiantEarth" X="53" Y="49" CityLocaleName="LOC_CITY_NAME_WINDER" Area="0" />
 		<Replace MapName="GiantEarth" X="53" Y="48" CityLocaleName="LOC_CITY_NAME_WINDER" Area="0" />
-		<Replace MapName="GiantEarth" X="56" Y="49" CityLocaleName="LOC_CITY_NAME_HYDERABAD_SINDH" />		
+		<Replace MapName="GiantEarth" X="56" Y="49" CityLocaleName="LOC_CITY_NAME_HYDERABAD_SINDH" />
 		<Replace MapName="GiantEarth" X="57" Y="49" CityLocaleName="LOC_CITY_NAME_JODHPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="59" Y="49" CityLocaleName="LOC_CITY_NAME_JAIPUR" />
 		<Replace MapName="GiantEarth" X="60" Y="49" CityLocaleName="LOC_CITY_NAME_GWALIOR" Area="0" />
-		<Replace MapName="GiantEarth" X="61" Y="49" CityLocaleName="LOC_CITY_NAME_KANPUR" />		
+		<Replace MapName="GiantEarth" X="61" Y="49" CityLocaleName="LOC_CITY_NAME_KANPUR" />
 		<Replace MapName="GiantEarth" X="63" Y="49" CityLocaleName="LOC_CITY_NAME_GAYA" Area="0" />
 		<Replace MapName="GiantEarth" X="65" Y="49" CityLocaleName="LOC_CITY_NAME_PATNA" />
 		<Replace MapName="GiantEarth" X="66" Y="49" CityLocaleName="LOC_CITY_NAME_BHAGALPUR" Area="0" />
-		<Replace MapName="GiantEarth" X="67" Y="49" CityLocaleName="LOC_CITY_NAME_KHULNA" Area="0" />		
-		
-		<Replace MapName="GiantEarth" X="58" Y="48" CityLocaleName="LOC_CITY_NAME_UDAIPUR" Area="0" />		
+		<Replace MapName="GiantEarth" X="67" Y="49" CityLocaleName="LOC_CITY_NAME_KHULNA" Area="0" />
+
+		<Replace MapName="GiantEarth" X="58" Y="48" CityLocaleName="LOC_CITY_NAME_UDAIPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="60" Y="48" CityLocaleName="LOC_CITY_NAME_KOTA" Area="0" />
 		<Replace MapName="GiantEarth" X="61" Y="48" CityLocaleName="LOC_CITY_NAME_ASHOKNAGAR" Area="0" />
-		<Replace MapName="GiantEarth" X="62" Y="48" CityLocaleName="LOC_CITY_NAME_SAGAR" Area="0" />		
-		<Replace MapName="GiantEarth" X="63" Y="48" CityLocaleName="LOC_CITY_NAME_DALTONGANJ" Area="0" />		
+		<Replace MapName="GiantEarth" X="62" Y="48" CityLocaleName="LOC_CITY_NAME_SAGAR" Area="0" />
+		<Replace MapName="GiantEarth" X="63" Y="48" CityLocaleName="LOC_CITY_NAME_DALTONGANJ" Area="0" />
 		<Replace MapName="GiantEarth" X="64" Y="48" CityLocaleName="LOC_CITY_NAME_GAYA" Area="0" />
 		<Replace MapName="GiantEarth" X="65" Y="48" CityLocaleName="LOC_CITY_NAME_RANCHI" Area="0" />
 		<Replace MapName="GiantEarth" X="64" Y="47" CityLocaleName="LOC_CITY_NAME_RANCHI" Area="0" />
-		<Replace MapName="GiantEarth" X="66" Y="48" CityLocaleName="LOC_CITY_NAME_JAMSHEDPUR" Area="0" />		
-		<Replace MapName="GiantEarth" X="65" Y="47" CityLocaleName="LOC_CITY_NAME_JAMSHEDPUR" Area="0" />		
-		<Replace MapName="GiantEarth" X="68" Y="48" CityLocaleName="LOC_CITY_NAME_KOLKATA" Area="0" />		
+		<Replace MapName="GiantEarth" X="66" Y="48" CityLocaleName="LOC_CITY_NAME_JAMSHEDPUR" Area="0" />
+		<Replace MapName="GiantEarth" X="65" Y="47" CityLocaleName="LOC_CITY_NAME_JAMSHEDPUR" Area="0" />
+		<Replace MapName="GiantEarth" X="68" Y="48" CityLocaleName="LOC_CITY_NAME_KOLKATA" Area="0" />
 		<Replace MapName="GiantEarth" X="69" Y="48" CityLocaleName="LOC_CITY_NAME_DHAKA" />
-		
+
 		<Replace MapName="GiantEarth" X="54" Y="47" CityLocaleName="LOC_CITY_NAME_KARACHI" />
-		<Replace MapName="GiantEarth" X="56" Y="47" CityLocaleName="LOC_CITY_NAME_JALANPUR" Area="0" />		
+		<Replace MapName="GiantEarth" X="56" Y="47" CityLocaleName="LOC_CITY_NAME_JALANPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="59" Y="47" CityLocaleName="LOC_CITY_NAME_INDORE" Area="0" />
 		<Replace MapName="GiantEarth" X="59" Y="46" CityLocaleName="LOC_CITY_NAME_INDORE" Area="0" />
 		<Replace MapName="GiantEarth" X="60" Y="46" CityLocaleName="LOC_CITY_NAME_INDORE" Area="0" />
-		<Replace MapName="GiantEarth" X="61" Y="47" CityLocaleName="LOC_CITY_NAME_BHOPAL" Area="0" />		
+		<Replace MapName="GiantEarth" X="61" Y="47" CityLocaleName="LOC_CITY_NAME_BHOPAL" Area="0" />
 		<Replace MapName="GiantEarth" X="62" Y="47" CityLocaleName="LOC_CITY_NAME_JABALPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="63" Y="47" CityLocaleName="LOC_CITY_NAME_AMBIKAPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="67" Y="47" CityLocaleName="LOC_CITY_NAME_KOLKATA" />
-		<Replace MapName="GiantEarth" X="56" Y="46" CityLocaleName="LOC_CITY_NAME_BHUJ" />		
-		<Replace MapName="GiantEarth" X="58" Y="46" CityLocaleName="LOC_CITY_NAME_AHMEDABAD" />		
+		<Replace MapName="GiantEarth" X="56" Y="46" CityLocaleName="LOC_CITY_NAME_BHUJ" />
+		<Replace MapName="GiantEarth" X="58" Y="46" CityLocaleName="LOC_CITY_NAME_AHMEDABAD" />
 		<Replace MapName="GiantEarth" X="62" Y="46" CityLocaleName="LOC_CITY_NAME_CHHINDWARA" Area="0" />
 		<Replace MapName="GiantEarth" X="63" Y="46" CityLocaleName="LOC_CITY_NAME_BILASPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="64" Y="46" CityLocaleName="LOC_CITY_NAME_KORBA" Area="0" />
-		<Replace MapName="GiantEarth" X="65" Y="46" CityLocaleName="LOC_CITY_NAME_ROURKELA" Area="0" />		
-		<Replace MapName="GiantEarth" X="66" Y="46" CityLocaleName="LOC_CITY_NAME_KHARAGPUR" Area="0" />		
+		<Replace MapName="GiantEarth" X="65" Y="46" CityLocaleName="LOC_CITY_NAME_ROURKELA" Area="0" />
+		<Replace MapName="GiantEarth" X="66" Y="46" CityLocaleName="LOC_CITY_NAME_KHARAGPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="66" Y="46" CityLocaleName="LOC_CITY_NAME_BALASORE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="55" Y="45" CityLocaleName="LOC_CITY_NAME_RAJKOT" Area="0" />
-		<Replace MapName="GiantEarth" X="55" Y="44" CityLocaleName="LOC_CITY_NAME_RAJKOT" Area="0" />		
-		<Replace MapName="GiantEarth" X="56" Y="45" CityLocaleName="LOC_CITY_NAME_BHAVNAGAR" Area="0" />		
+		<Replace MapName="GiantEarth" X="55" Y="44" CityLocaleName="LOC_CITY_NAME_RAJKOT" Area="0" />
+		<Replace MapName="GiantEarth" X="56" Y="45" CityLocaleName="LOC_CITY_NAME_BHAVNAGAR" Area="0" />
 		<Replace MapName="GiantEarth" X="56" Y="44" CityLocaleName="LOC_CITY_NAME_BHAVNAGAR" Area="0" />
 		<Replace MapName="GiantEarth" X="57" Y="45" CityLocaleName="LOC_CITY_NAME_VADODARA" Area="0" />
-		<Replace MapName="GiantEarth" X="58" Y="45" CityLocaleName="LOC_CITY_NAME_VADODARA" Area="0" />		
-		<Replace MapName="GiantEarth" X="59" Y="45" CityLocaleName="LOC_CITY_NAME_KHANDWA" Area="0" />		
+		<Replace MapName="GiantEarth" X="58" Y="45" CityLocaleName="LOC_CITY_NAME_VADODARA" Area="0" />
+		<Replace MapName="GiantEarth" X="59" Y="45" CityLocaleName="LOC_CITY_NAME_KHANDWA" Area="0" />
 		<Replace MapName="GiantEarth" X="60" Y="45" CityLocaleName="LOC_CITY_NAME_HOSHANGABAD" Area="0" />
 		<Replace MapName="GiantEarth" X="62" Y="45" CityLocaleName="LOC_CITY_NAME_RAJNANDGAON" Area="0" />
-		<Replace MapName="GiantEarth" X="63" Y="45" CityLocaleName="LOC_CITY_NAME_RAIPUR" />		
-		<Replace MapName="GiantEarth" X="64" Y="45" CityLocaleName="LOC_CITY_NAME_SAMBALPUR" Area="0" />		
+		<Replace MapName="GiantEarth" X="63" Y="45" CityLocaleName="LOC_CITY_NAME_RAIPUR" />
+		<Replace MapName="GiantEarth" X="64" Y="45" CityLocaleName="LOC_CITY_NAME_SAMBALPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="66" Y="45" CityLocaleName="LOC_CITY_NAME_CUTTACK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="57" Y="44" CityLocaleName="LOC_CITY_NAME_SURAT" />
-		<Replace MapName="GiantEarth" X="59" Y="44" CityLocaleName="LOC_CITY_NAME_DHULE" Area="0" />		
+		<Replace MapName="GiantEarth" X="59" Y="44" CityLocaleName="LOC_CITY_NAME_DHULE" Area="0" />
 		<Replace MapName="GiantEarth" X="60" Y="44" CityLocaleName="LOC_CITY_NAME_AMRAVATI" Area="0" />
 		<Replace MapName="GiantEarth" X="62" Y="44" CityLocaleName="LOC_CITY_NAME_NAGPUR" />
 		<Replace MapName="GiantEarth" X="66" Y="44" CityLocaleName="LOC_CITY_NAME_BRAHMAPUR" Area="0" />
-		<Replace MapName="GiantEarth" X="58" Y="43" CityLocaleName="LOC_CITY_NAME_NASHIK" Area="0" />		
-		<Replace MapName="GiantEarth" X="59" Y="42" CityLocaleName="LOC_CITY_NAME_NASHIK" Area="0" />		
+		<Replace MapName="GiantEarth" X="58" Y="43" CityLocaleName="LOC_CITY_NAME_NASHIK" Area="0" />
+		<Replace MapName="GiantEarth" X="59" Y="42" CityLocaleName="LOC_CITY_NAME_NASHIK" Area="0" />
 		<Replace MapName="GiantEarth" X="59" Y="43" CityLocaleName="LOC_CITY_NAME_AURANGABAD" Area="0" />
 		<Replace MapName="GiantEarth" X="60" Y="43" CityLocaleName="LOC_CITY_NAME_NANDED" Area="0" />
 		<Replace MapName="GiantEarth" X="61" Y="43" CityLocaleName="LOC_CITY_NAME_KARIMNAGAR" Area="0" />
-		<Replace MapName="GiantEarth" X="62" Y="43" CityLocaleName="LOC_CITY_NAME_RAJAHMUNDRY" Area="0" />		
+		<Replace MapName="GiantEarth" X="62" Y="43" CityLocaleName="LOC_CITY_NAME_RAJAHMUNDRY" Area="0" />
 		<Replace MapName="GiantEarth" X="63" Y="42" CityLocaleName="LOC_CITY_NAME_RAJAHMUNDRY" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="60" Y="42" CityLocaleName="LOC_CITY_NAME_SOLAPUR" Area="0" />		
+
+		<Replace MapName="GiantEarth" X="60" Y="42" CityLocaleName="LOC_CITY_NAME_SOLAPUR" Area="0" />
 		<Replace MapName="GiantEarth" X="61" Y="42" CityLocaleName="LOC_CITY_NAME_NIZAMABAD" Area="0" />
 		<Replace MapName="GiantEarth" X="62" Y="42" CityLocaleName="LOC_CITY_NAME_VIJAYAWADA" Area="0" />
-		<Replace MapName="GiantEarth" X="62" Y="41" CityLocaleName="LOC_CITY_NAME_VIJAYAWADA" Area="0" />		
-		<Replace MapName="GiantEarth" X="65" Y="42" CityLocaleName="LOC_CITY_NAME_VISAKHAPATNAM" />		
+		<Replace MapName="GiantEarth" X="62" Y="41" CityLocaleName="LOC_CITY_NAME_VIJAYAWADA" Area="0" />
+		<Replace MapName="GiantEarth" X="65" Y="42" CityLocaleName="LOC_CITY_NAME_VISAKHAPATNAM" />
 		<Replace MapName="GiantEarth" X="57" Y="41" CityLocaleName="LOC_CITY_NAME_MUMBAI" />
 		<Replace MapName="GiantEarth" X="59" Y="41" CityLocaleName="LOC_CITY_NAME_PUNE" Area="0" />
 		<Replace MapName="GiantEarth" X="59" Y="40" CityLocaleName="LOC_CITY_NAME_PUNE" Area="0" />
-		<Replace MapName="GiantEarth" X="60" Y="41" CityLocaleName="LOC_CITY_NAME_HYDERABAD" />	
-		
-		<Replace MapName="GiantEarth" X="62" Y="40" CityLocaleName="LOC_CITY_NAME_ONGOLE" Area="0" />		
+		<Replace MapName="GiantEarth" X="60" Y="41" CityLocaleName="LOC_CITY_NAME_HYDERABAD" />
+
+		<Replace MapName="GiantEarth" X="62" Y="40" CityLocaleName="LOC_CITY_NAME_ONGOLE" Area="0" />
 		<Replace MapName="GiantEarth" X="58" Y="38" CityLocaleName="LOC_CITY_NAME_PANAJI" />
 		<Replace MapName="GiantEarth" X="60" Y="38" CityLocaleName="LOC_CITY_NAME_BENGALURU" />
-		<Replace MapName="GiantEarth" X="62" Y="38" CityLocaleName="LOC_CITY_NAME_CHENNAI" />		
-		<Replace MapName="GiantEarth" X="59" Y="37" CityLocaleName="LOC_CITY_NAME_MANGALURU" Area="0" />	
+		<Replace MapName="GiantEarth" X="62" Y="38" CityLocaleName="LOC_CITY_NAME_CHENNAI" />
+		<Replace MapName="GiantEarth" X="59" Y="37" CityLocaleName="LOC_CITY_NAME_MANGALURU" Area="0" />
 		<Replace MapName="GiantEarth" X="60" Y="36" CityLocaleName="LOC_CITY_NAME_COIMBATORE" Area="0" />
-		<Replace MapName="GiantEarth" X="61" Y="36" CityLocaleName="LOC_CITY_NAME_MADURAI" Area="0" />		
-		<Replace MapName="GiantEarth" X="62" Y="36" CityLocaleName="LOC_CITY_NAME_MADURAI" Area="0" />	
+		<Replace MapName="GiantEarth" X="61" Y="36" CityLocaleName="LOC_CITY_NAME_MADURAI" Area="0" />
+		<Replace MapName="GiantEarth" X="62" Y="36" CityLocaleName="LOC_CITY_NAME_MADURAI" Area="0" />
 		<Replace MapName="GiantEarth" X="60" Y="35" CityLocaleName="LOC_CITY_NAME_THIRUVANANTHAPURAM" Area="0" />
-		<Replace MapName="GiantEarth" X="61" Y="35" CityLocaleName="LOC_CITY_NAME_THOOTHUKUDI" Area="0" />		
-		<Replace MapName="GiantEarth" X="61" Y="34" CityLocaleName="LOC_CITY_NAME_NAGERCOIL" Area="0" />	
+		<Replace MapName="GiantEarth" X="61" Y="35" CityLocaleName="LOC_CITY_NAME_THOOTHUKUDI" Area="0" />
+		<Replace MapName="GiantEarth" X="61" Y="34" CityLocaleName="LOC_CITY_NAME_NAGERCOIL" Area="0" />
 		<Replace MapName="GiantEarth" X="63" Y="34" CityLocaleName="LOC_CITY_NAME_JAFFNA" Area="0" />
-		<Replace MapName="GiantEarth" X="62" Y="32" CityLocaleName="LOC_CITY_NAME_COLOMBO" />		
-		<Replace MapName="GiantEarth" X="64" Y="32" CityLocaleName="LOC_CITY_NAME_BATTICOLOA" Area="0" />	
+		<Replace MapName="GiantEarth" X="62" Y="32" CityLocaleName="LOC_CITY_NAME_COLOMBO" />
+		<Replace MapName="GiantEarth" X="64" Y="32" CityLocaleName="LOC_CITY_NAME_BATTICOLOA" Area="0" />
 		<Replace MapName="GiantEarth" X="58" Y="31" CityLocaleName="LOC_CITY_NAME_MALDIVES" />
-		
+
 	</CityMap>
-	
+
 	<!-- CHINA -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="81" Y="44" CityLocaleName="LOC_CITY_NAME_HAINAN" />
 		<Replace MapName="GiantEarth" X="81" Y="46" CityLocaleName="LOC_CITY_NAME_HAINAN" Area="0" />
 		<Replace MapName="GiantEarth" X="84" Y="46" CityLocaleName="LOC_CITY_NAME_PRATAS_ISLAND" />
 		<Replace MapName="GiantEarth" X="80" Y="47" CityLocaleName="LOC_CITY_NAME_ZHANJIANG" />
-		
+
 		<Replace MapName="GiantEarth" X="82" Y="48" CityLocaleName="LOC_CITY_NAME_YANGJIANG" Area="0" />
 		<Replace MapName="GiantEarth" X="83" Y="48" CityLocaleName="LOC_CITY_NAME_MACAU" Area="0" />
 		<Replace MapName="GiantEarth" X="84" Y="48" CityLocaleName="LOC_CITY_NAME_HONG_KONG" Area="0" />
 		<Replace MapName="GiantEarth" X="88" Y="48" CityLocaleName="LOC_CITY_NAME_KAOHSIUNG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="76" Y="49" CityLocaleName="LOC_CITY_NAME_WENSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="77" Y="50" CityLocaleName="LOC_CITY_NAME_WENSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="78" Y="49" CityLocaleName="LOC_CITY_NAME_CHONGZUO" />
@@ -2199,7 +2830,7 @@
 		<Replace MapName="GiantEarth" X="80" Y="49" CityLocaleName="LOC_CITY_NAME_GUIGANG" Area="0" />
 		<Replace MapName="GiantEarth" X="82" Y="49" CityLocaleName="LOC_CITY_NAME_ZHONGSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="84" Y="49" CityLocaleName="LOC_CITY_NAME_SHENZHEN" />
-		
+
 		<Replace MapName="GiantEarth" X="74" Y="50" CityLocaleName="LOC_CITY_NAME_DALI" Area="0" />
 		<Replace MapName="GiantEarth" X="75" Y="50" CityLocaleName="LOC_CITY_NAME_KUNMING" />
 		<Replace MapName="GiantEarth" X="78" Y="50" CityLocaleName="LOC_CITY_NAME_GUIYANG" Area="0" />
@@ -2208,7 +2839,7 @@
 		<Replace MapName="GiantEarth" X="82" Y="50" CityLocaleName="LOC_CITY_NAME_FOSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="81" Y="51" CityLocaleName="LOC_CITY_NAME_FOSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="88" Y="50" CityLocaleName="LOC_CITY_NAME_TAIPEI" />
-		
+
 		<Replace MapName="GiantEarth" X="74" Y="51" CityLocaleName="LOC_CITY_NAME_LIJIANG" Area="0" />
 		<Replace MapName="GiantEarth" X="76" Y="51" CityLocaleName="LOC_CITY_NAME_QUJING" Area="0" />
 		<Replace MapName="GiantEarth" X="79" Y="51" CityLocaleName="LOC_CITY_NAME_LIUZHOU" Area="0" />
@@ -2216,7 +2847,7 @@
 		<Replace MapName="GiantEarth" X="83" Y="51" CityLocaleName="LOC_CITY_NAME_GUANGZHOU" />
 		<Replace MapName="GiantEarth" X="85" Y="51" CityLocaleName="LOC_CITY_NAME_XIAMEN" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="52" CityLocaleName="LOC_CITY_NAME_XIAMEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="75" Y="52" CityLocaleName="LOC_CITY_NAME_LIANGSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="76" Y="52" CityLocaleName="LOC_CITY_NAME_LIANGSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="77" Y="52" CityLocaleName="LOC_CITY_NAME_ZHAOTONG" Area="0" />
@@ -2224,7 +2855,7 @@
 		<Replace MapName="GiantEarth" X="80" Y="52" CityLocaleName="LOC_CITY_NAME_GUILIN" Area="0" />
 		<Replace MapName="GiantEarth" X="81" Y="52" CityLocaleName="LOC_CITY_NAME_CHENZHOU" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="52" CityLocaleName="LOC_CITY_NAME_WENZHOU" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="73" Y="53" CityLocaleName="LOC_CITY_NAME_DEQEN" />
 		<Replace MapName="GiantEarth" X="76" Y="53" CityLocaleName="LOC_CITY_NAME_NEIJIANG" Area="0" />
 		<Replace MapName="GiantEarth" X="77" Y="53" CityLocaleName="LOC_CITY_NAME_LUZHOU" Area="0" />
@@ -2232,7 +2863,7 @@
 		<Replace MapName="GiantEarth" X="84" Y="53" CityLocaleName="LOC_CITY_NAME_NANCHANG" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="53" CityLocaleName="LOC_CITY_NAME_JINHUA" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="53" CityLocaleName="LOC_CITY_NAME_TAIZHOU" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="70" Y="54" CityLocaleName="LOC_CITY_NAME_LHASA" />
 		<Replace MapName="GiantEarth" X="74" Y="54" CityLocaleName="LOC_CITY_NAME_YAAN" Area="0" />
 		<Replace MapName="GiantEarth" X="73" Y="55" CityLocaleName="LOC_CITY_NAME_YAAN" Area="0" />
@@ -2243,14 +2874,14 @@
 		<Replace MapName="GiantEarth" X="84" Y="54" CityLocaleName="LOC_CITY_NAME_HUANGSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="54" CityLocaleName="LOC_CITY_NAME_HANGZHOU" />
 		<Replace MapName="GiantEarth" X="87" Y="54" CityLocaleName="LOC_CITY_NAME_NINGBO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="66" Y="55" CityLocaleName="LOC_CITY_NAME_XIGAZE" />
 		<Replace MapName="GiantEarth" X="67" Y="55" CityLocaleName="LOC_CITY_NAME_XIGAZE" />
 		<Replace MapName="GiantEarth" X="72" Y="55" CityLocaleName="LOC_CITY_NAME_QAMDO" Area="0" />
 		<Replace MapName="GiantEarth" X="75" Y="55" CityLocaleName="LOC_CITY_NAME_CHENGDU" />
 		<Replace MapName="GiantEarth" X="77" Y="55" CityLocaleName="LOC_CITY_NAME_SUINING" Area="0" />
 		<Replace MapName="GiantEarth" X="80" Y="55" CityLocaleName="LOC_CITY_NAME_YICHANG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="71" Y="56" CityLocaleName="LOC_CITY_NAME_QAMDO" />
 		<Replace MapName="GiantEarth" X="77" Y="56" CityLocaleName="LOC_CITY_NAME_NANCHONG" Area="0" />
 		<Replace MapName="GiantEarth" X="80" Y="56" CityLocaleName="LOC_CITY_NAME_SHIYAN" Area="0" />
@@ -2262,19 +2893,19 @@
 		<Replace MapName="GiantEarth" X="84" Y="57" CityLocaleName="LOC_CITY_NAME_NANJING" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="57" CityLocaleName="LOC_CITY_NAME_NANJING" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="56" CityLocaleName="LOC_CITY_NAME_SHANGHAI" />
-		
+
 		<Replace MapName="GiantEarth" X="64" Y="57" CityLocaleName="LOC_CITY_NAME_NGARI" Area="0" />
 		<Replace MapName="GiantEarth" X="64" Y="58" CityLocaleName="LOC_CITY_NAME_NGARI" Area="0" />
 		<Replace MapName="GiantEarth" X="66" Y="57" CityLocaleName="LOC_CITY_NAME_NAGQU" Area="0" />
 		<Replace MapName="GiantEarth" X="75" Y="57" CityLocaleName="LOC_CITY_NAME_MIANYANG" Area="0" />
 		<Replace MapName="GiantEarth" X="78" Y="57" CityLocaleName="LOC_CITY_NAME_ANKANG" Area="0" />
 		<Replace MapName="GiantEarth" X="79" Y="57" CityLocaleName="LOC_CITY_NAME_ANKANG" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="69" Y="58" CityLocaleName="LOC_CITY_NAME_NAGQU" />
 		<Replace MapName="GiantEarth" X="73" Y="58" CityLocaleName="LOC_CITY_NAME_GARZE" />
 		<Replace MapName="GiantEarth" X="79" Y="58" CityLocaleName="LOC_CITY_NAME_SHANGLUO" />
 		<Replace MapName="GiantEarth" X="81" Y="58" CityLocaleName="LOC_CITY_NAME_NANYANG" />
-		
+
 		<Replace MapName="GiantEarth" X="66" Y="59" CityLocaleName="LOC_CITY_NAME_NAGQU" />
 		<Replace MapName="GiantEarth" X="75" Y="59" CityLocaleName="LOC_CITY_NAME_ABA" />
 		<Replace MapName="GiantEarth" X="79" Y="59" CityLocaleName="LOC_CITY_NAME_LUOYANG" Area="0" />
@@ -2285,7 +2916,7 @@
 		<Replace MapName="GiantEarth" X="83" Y="59" CityLocaleName="LOC_CITY_NAME_XUZHOU" />
 		<Replace MapName="GiantEarth" X="84" Y="59" CityLocaleName="LOC_CITY_NAME_LINYI" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="59" CityLocaleName="LOC_CITY_NAME_YANCHENG" />
-		
+
 		<Replace MapName="GiantEarth" X="61" Y="60" CityLocaleName="LOC_CITY_NAME_KASHGAR" />
 		<Replace MapName="GiantEarth" X="64" Y="60" CityLocaleName="LOC_CITY_NAME_HOTAN" />
 		<Replace MapName="GiantEarth" X="71" Y="60" CityLocaleName="LOC_CITY_NAME_HAIXI_TIBETAN" />
@@ -2295,7 +2926,7 @@
 		<Replace MapName="GiantEarth" X="83" Y="61" CityLocaleName="LOC_CITY_NAME_JINAN" Area="0" />
 		<Replace MapName="GiantEarth" X="84" Y="60" CityLocaleName="LOC_CITY_NAME_QINGDAO" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="60" CityLocaleName="LOC_CITY_NAME_QINGDAO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="69" Y="61" CityLocaleName="LOC_CITY_NAME_HAIXI_TIBETAN" />
 		<Replace MapName="GiantEarth" X="74" Y="61" CityLocaleName="LOC_CITY_NAME_GOLOG" />
 		<Replace MapName="GiantEarth" X="76" Y="61" CityLocaleName="LOC_CITY_NAME_LANZHOU" Area="0" />
@@ -2304,14 +2935,14 @@
 		<Replace MapName="GiantEarth" X="82" Y="61" CityLocaleName="LOC_CITY_NAME_KAIFENG" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="61" CityLocaleName="LOC_CITY_NAME_WEIFANG" />
 		<Replace MapName="GiantEarth" X="86" Y="61" CityLocaleName="LOC_CITY_NAME_YANTAI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="66" Y="62" CityLocaleName="LOC_CITY_NAME_BAYINGOL" />
 		<Replace MapName="GiantEarth" X="72" Y="62" CityLocaleName="LOC_CITY_NAME_YUSHU" Area="2" />
 		<Replace MapName="GiantEarth" X="78" Y="62" CityLocaleName="LOC_CITY_NAME_YANAN" Area="0" />
 		<Replace MapName="GiantEarth" X="79" Y="62" CityLocaleName="LOC_CITY_NAME_YANAN" Area="0" />
 		<Replace MapName="GiantEarth" X="81" Y="62" CityLocaleName="LOC_CITY_NAME_CHANGZHI" Area="0" />
 		<Replace MapName="GiantEarth" X="82" Y="62" CityLocaleName="LOC_CITY_NAME_HANDAN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="59" Y="63" CityLocaleName="LOC_CITY_NAME_KIZILSU" />
 		<Replace MapName="GiantEarth" X="75" Y="63" CityLocaleName="LOC_CITY_NAME_ZHONGWEI" Area="0" />
 		<Replace MapName="GiantEarth" X="76" Y="63" CityLocaleName="LOC_CITY_NAME_ZHONGWEI" Area="0" />
@@ -2320,7 +2951,7 @@
 		<Replace MapName="GiantEarth" X="82" Y="64" CityLocaleName="LOC_CITY_NAME_BAODING" Area="0" />
 		<Replace MapName="GiantEarth" X="81" Y="65" CityLocaleName="LOC_CITY_NAME_BAODING" Area="0" />
 		<Replace MapName="GiantEarth" X="83" Y="63" CityLocaleName="LOC_CITY_NAME_TIANJIN" />
-		
+
 		<Replace MapName="GiantEarth" X="61" Y="64" CityLocaleName="LOC_CITY_NAME_KARAKOL" Area="0" />
 		<Replace MapName="GiantEarth" X="61" Y="65" CityLocaleName="LOC_CITY_NAME_KARAKOL" Area="0" />
 		<Replace MapName="GiantEarth" X="63" Y="64" CityLocaleName="LOC_CITY_NAME_AKSU" Area="2" />
@@ -2330,7 +2961,7 @@
 		<Replace MapName="GiantEarth" X="76" Y="65" CityLocaleName="LOC_CITY_NAME_YINCHUAN" Area="0" />
 		<Replace MapName="GiantEarth" X="78" Y="64" CityLocaleName="LOC_CITY_NAME_YULIN" />
 		<Replace MapName="GiantEarth" X="80" Y="64" CityLocaleName="LOC_CITY_NAME_SHIJIAZHUANG" />
-		
+
 		<Replace MapName="GiantEarth" X="65" Y="65" CityLocaleName="LOC_CITY_NAME_YANQI" Area="0" />
 		<Replace MapName="GiantEarth" X="66" Y="65" CityLocaleName="LOC_CITY_NAME_YANQI" Area="0" />
 		<Replace MapName="GiantEarth" X="68" Y="65" CityLocaleName="LOC_CITY_NAME_XINJIANG" Area="2" />
@@ -2344,7 +2975,7 @@
 		<Replace MapName="GiantEarth" X="86" Y="66" CityLocaleName="LOC_CITY_NAME_TANGSHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="65" CityLocaleName="LOC_CITY_NAME_DALIAN" />
 		<Replace MapName="GiantEarth" X="87" Y="66" CityLocaleName="LOC_CITY_NAME_DALIAN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="66" Y="66" CityLocaleName="LOC_CITY_NAME_URUMQI" Area="0" />
 		<Replace MapName="GiantEarth" X="67" Y="66" CityLocaleName="LOC_CITY_NAME_URUMQI" Area="0" />
 		<Replace MapName="GiantEarth" X="73" Y="66" CityLocaleName="LOC_CITY_NAME_JIAQUAN" Area="0" />
@@ -2354,7 +2985,7 @@
 		<Replace MapName="GiantEarth" X="78" Y="67" CityLocaleName="LOC_CITY_NAME_BAOTOU" Area="0" />
 		<Replace MapName="GiantEarth" X="79" Y="68" CityLocaleName="LOC_CITY_NAME_BAOTOU" Area="0" />
 		<Replace MapName="GiantEarth" X="83" Y="66" CityLocaleName="LOC_CITY_NAME_BEIJING" />
-		
+
 		<Replace MapName="GiantEarth" X="64" Y="67" CityLocaleName="LOC_CITY_NAME_ILI" />
 		<Replace MapName="GiantEarth" X="67" Y="67" CityLocaleName="LOC_CITY_NAME_URUMQI" />
 		<Replace MapName="GiantEarth" X="68" Y="67" CityLocaleName="LOC_CITY_NAME_URUMQI" Area="0" />
@@ -2366,7 +2997,7 @@
 		<Replace MapName="GiantEarth" X="85" Y="67" CityLocaleName="LOC_CITY_NAME_CHIFENG" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="68" CityLocaleName="LOC_CITY_NAME_CHIFENG" Area="0" />
 		<Replace MapName="GiantEarth" X="87" Y="67" CityLocaleName="LOC_CITY_NAME_SHENYANG" />
-		
+
 		<Replace MapName="GiantEarth" X="66" Y="68" CityLocaleName="LOC_CITY_NAME_BORTALA" />
 		<Replace MapName="GiantEarth" X="70" Y="68" CityLocaleName="LOC_CITY_NAME_TURPAN" />
 		<Replace MapName="GiantEarth" X="73" Y="68" CityLocaleName="LOC_CITY_NAME_JIAQUAN" />
@@ -2379,14 +3010,14 @@
 		<Replace MapName="GiantEarth" X="91" Y="68" CityLocaleName="LOC_CITY_NAME_YANBIAN" Area="0" />
 		<Replace MapName="GiantEarth" X="91" Y="69" CityLocaleName="LOC_CITY_NAME_YANBIAN" Area="0" />
 		<Replace MapName="GiantEarth" X="92" Y="69" CityLocaleName="LOC_CITY_NAME_YANBIAN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="67" Y="69" CityLocaleName="LOC_CITY_NAME_KARAMAY" Area="0" />
 		<Replace MapName="GiantEarth" X="68" Y="69" CityLocaleName="LOC_CITY_NAME_KARAMAY" Area="0" />
 		<Replace MapName="GiantEarth" X="68" Y="70" CityLocaleName="LOC_CITY_NAME_KARAMAY" Area="0" />
 		<Replace MapName="GiantEarth" X="70" Y="69" CityLocaleName="LOC_CITY_NAME_KAMUL" />
 		<Replace MapName="GiantEarth" X="82" Y="69" CityLocaleName="LOC_CITY_NAME_XILIN_GOL"  />
 		<Replace MapName="GiantEarth" X="86" Y="69" CityLocaleName="LOC_CITY_NAME_TONGLIAO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="66" Y="70" CityLocaleName="LOC_CITY_NAME_QOQEK" />
 		<Replace MapName="GiantEarth" X="85" Y="70" CityLocaleName="LOC_CITY_NAME_HINGGAN" />
 		<Replace MapName="GiantEarth" X="87" Y="70" CityLocaleName="LOC_CITY_NAME_SONGYUAN" Area="0" />
@@ -2394,7 +3025,7 @@
 		<Replace MapName="GiantEarth" X="89" Y="70" CityLocaleName="LOC_CITY_NAME_HARBIN" />
 		<Replace MapName="GiantEarth" X="91" Y="70" CityLocaleName="LOC_CITY_NAME_JIAMUSI" Area="0" />
 		<Replace MapName="GiantEarth" X="92" Y="70" CityLocaleName="LOC_CITY_NAME_MUDANJIANG" />
-		
+
 		<Replace MapName="GiantEarth" X="67" Y="71" CityLocaleName="LOC_CITY_NAME_ALTAY" />
 		<Replace MapName="GiantEarth" X="83" Y="71" CityLocaleName="LOC_CITY_NAME_XILIN_GOL" Area="0" />
 		<Replace MapName="GiantEarth" X="86" Y="71" CityLocaleName="LOC_CITY_NAME_BAICHENG" Area="0" />
@@ -2403,7 +3034,7 @@
 		<Replace MapName="GiantEarth" X="91" Y="71" CityLocaleName="LOC_CITY_NAME_HEGANG" Area="0" />
 		<Replace MapName="GiantEarth" X="92" Y="71" CityLocaleName="LOC_CITY_NAME_SHUANGYASHAN" Area="0" />
 		<Replace MapName="GiantEarth" X="93" Y="71" CityLocaleName="LOC_CITY_NAME_JIXI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="84" Y="72" CityLocaleName="LOC_CITY_NAME_HULUN_BUIR" Area="0" />
 		<Replace MapName="GiantEarth" X="83" Y="73" CityLocaleName="LOC_CITY_NAME_HULUN_BUIR" Area="0" />
 		<Replace MapName="GiantEarth" X="85" Y="74" CityLocaleName="LOC_CITY_NAME_HULUN_BUIR" />
@@ -2412,17 +3043,17 @@
 		<Replace MapName="GiantEarth" X="88" Y="72" CityLocaleName="LOC_CITY_NAME_DAQING" Area="0" />
 		<Replace MapName="GiantEarth" X="89" Y="72" CityLocaleName="LOC_CITY_NAME_SUIHUA" Area="0" />
 		<Replace MapName="GiantEarth" X="89" Y="73" CityLocaleName="LOC_CITY_NAME_SUIHUA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="88" Y="74" CityLocaleName="LOC_CITY_NAME_DAXINGANLING" />
 		<Replace MapName="GiantEarth" X="88" Y="75" CityLocaleName="LOC_CITY_NAME_MAGDAGACHI" Area="0" />
 		<Replace MapName="GiantEarth" X="89" Y="75" CityLocaleName="LOC_CITY_NAME_MAGDAGACHI" Area="0" />
 		<Replace MapName="GiantEarth" X="88" Y="76" CityLocaleName="LOC_CITY_NAME_MAGDAGACHI" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- JAPAN & KOREA -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="91" Y="50" CityLocaleName="LOC_CITY_NAME_OKINAWA" />
 		<Replace MapName="GiantEarth" X="90" Y="52" CityLocaleName="LOC_CITY_NAME_KUMAMOTO" />
 		<Replace MapName="GiantEarth" X="90" Y="53" CityLocaleName="LOC_CITY_NAME_KUMAMOTO" Area="0" />
@@ -2430,21 +3061,21 @@
 		<Replace MapName="GiantEarth" X="99" Y="52" CityLocaleName="LOC_CITY_NAME_OSHIMA" />
 		<Replace MapName="GiantEarth" X="91" Y="53" CityLocaleName="LOC_CITY_NAME_MIYAZAKI" Area="0" />
 		<Replace MapName="GiantEarth" X="93" Y="53" CityLocaleName="LOC_CITY_NAME_MATSUYAMA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="91" Y="54" CityLocaleName="LOC_CITY_NAME_FUKUOKA" />
 		<Replace MapName="GiantEarth" X="93" Y="54" CityLocaleName="LOC_CITY_NAME_MATSUYAMA" Area="0" />
 		<Replace MapName="GiantEarth" X="95" Y="54" CityLocaleName="LOC_CITY_NAME_KOCHI" Area="0"/>
-		
+
 		<Replace MapName="GiantEarth" X="90" Y="55" CityLocaleName="LOC_CITY_NAME_KITAKYUSHU" Area="0" />
 		<Replace MapName="GiantEarth" X="91" Y="56" CityLocaleName="LOC_CITY_NAME_KITAKYUSHU" Area="0" />
 		<Replace MapName="GiantEarth" X="93" Y="55" CityLocaleName="LOC_CITY_NAME_TAKAMATSU" />
 		<Replace MapName="GiantEarth" X="96" Y="55" CityLocaleName="LOC_CITY_NAME_SAKAI" Area="0" />
 		<Replace MapName="GiantEarth" X="97" Y="55" CityLocaleName="LOC_CITY_NAME_WAKAYAMA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="93" Y="56" CityLocaleName="LOC_CITY_NAME_HIROSHIMA" />
 		<Replace MapName="GiantEarth" X="97" Y="56" CityLocaleName="LOC_CITY_NAME_OSAKA" />
 		<Replace MapName="GiantEarth" X="98" Y="56" CityLocaleName="LOC_CITY_NAME_NARA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="89" Y="57" CityLocaleName="LOC_CITY_NAME_JEJU" />
 		<Replace MapName="GiantEarth" X="91" Y="57" CityLocaleName="LOC_CITY_NAME_YAMAGUSHI" Area="0" />
 		<Replace MapName="GiantEarth" X="93" Y="57" CityLocaleName="LOC_CITY_NAME_OKAYAMA" Area="0" />
@@ -2455,12 +3086,12 @@
 		<Replace MapName="GiantEarth" X="97" Y="58" CityLocaleName="LOC_CITY_NAME_OTSU" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="56" CityLocaleName="LOC_CITY_NAME_NAGOYA" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="57" CityLocaleName="LOC_CITY_NAME_NAGOYA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="93" Y="58" CityLocaleName="LOC_CITY_NAME_MATSUE" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="58" CityLocaleName="LOC_CITY_NAME_YOKOHAMA" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="58" CityLocaleName="LOC_CITY_NAME_CHIBA" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="59" CityLocaleName="LOC_CITY_NAME_CHIBA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="89" Y="59" CityLocaleName="LOC_CITY_NAME_GWANGJU" Area="0" />
 		<Replace MapName="GiantEarth" X="90" Y="59" CityLocaleName="LOC_CITY_NAME_BUSAN" />
 		<Replace MapName="GiantEarth" X="93" Y="59" CityLocaleName="LOC_CITY_NAME_TOTTORI" />
@@ -2468,10 +3099,10 @@
 		<Replace MapName="GiantEarth" X="96" Y="59" CityLocaleName="LOC_CITY_NAME_KYOTO" />
 		<Replace MapName="GiantEarth" X="97" Y="59" CityLocaleName="LOC_CITY_NAME_MATSUMOTO" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="59" CityLocaleName="LOC_CITY_NAME_TOKYO" />
-		
+
 		<Replace MapName="GiantEarth" X="90" Y="60" CityLocaleName="LOC_CITY_NAME_JEONJU" Area="0" />
 		<Replace MapName="GiantEarth" X="97" Y="60" CityLocaleName="LOC_CITY_NAME_TOYAMA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="89" Y="62" CityLocaleName="LOC_CITY_NAME_INCHEON" />
 		<Replace MapName="GiantEarth" X="90" Y="61" CityLocaleName="LOC_CITY_NAME_DAEGU" Area="0" />
 		<Replace MapName="GiantEarth" X="91" Y="61" CityLocaleName="LOC_CITY_NAME_ULSAN" Area="0" />
@@ -2482,12 +3113,12 @@
 		<Replace MapName="GiantEarth" X="90" Y="62" CityLocaleName="LOC_CITY_NAME_DAEJEON" Area="0" />
 		<Replace MapName="GiantEarth" X="91" Y="62" CityLocaleName="LOC_CITY_NAME_POHANG" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="62" CityLocaleName="LOC_CITY_NAME_NAGAOKA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="89" Y="61" CityLocaleName="LOC_CITY_NAME_SEOUL"  />
 		<Replace MapName="GiantEarth" X="90" Y="63" CityLocaleName="LOC_CITY_NAME_GANGNEUNG" Area="0" />
 		<Replace MapName="GiantEarth" X="98" Y="63" CityLocaleName="LOC_CITY_NAME_YAMAGATA" Area="0" />
 		<Replace MapName="GiantEarth" X="99" Y="63" CityLocaleName="LOC_CITY_NAME_SENDAI" />
-		
+
 		<Replace MapName="GiantEarth" X="89" Y="64" CityLocaleName="LOC_CITY_NAME_PYONGYANG" Area="0" />
 		<Replace MapName="GiantEarth" X="88" Y="65" CityLocaleName="LOC_CITY_NAME_PYONGYANG" />
 		<Replace MapName="GiantEarth" X="97" Y="64" CityLocaleName="LOC_CITY_NAME_NIIGATA" />
@@ -2502,29 +3133,29 @@
 
 		<Replace MapName="GiantEarth" X="90" Y="66" CityLocaleName="LOC_CITY_NAME_KANGYE" />
 		<Replace MapName="GiantEarth" X="100" Y="66" CityLocaleName="LOC_CITY_NAME_HACHINOHE" />
-		
+
 		<Replace MapName="GiantEarth" X="93" Y="67" CityLocaleName="LOC_CITY_NAME_CHONGJIN" />
 		<Replace MapName="GiantEarth" X="97" Y="67" CityLocaleName="LOC_CITY_NAME_AOMORI" />
-		
+
 		<Replace MapName="GiantEarth" X="97" Y="69" CityLocaleName="LOC_CITY_NAME_HAKODATE" />
 		<Replace MapName="GiantEarth" X="98" Y="70" CityLocaleName="LOC_CITY_NAME_SAPPORO" />
 		<Replace MapName="GiantEarth" X="99" Y="70" CityLocaleName="LOC_CITY_NAME_TOMAKOMAI" Area="0" />
 		<Replace MapName="GiantEarth" X="100" Y="70" CityLocaleName="LOC_CITY_NAME_OBIHIRO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="99" Y="73" CityLocaleName="LOC_CITY_NAME_ASAHIKAWA" />
 		<Replace MapName="GiantEarth" X="101" Y="71" CityLocaleName="LOC_CITY_NAME_KUSHIRO" />
-		
+
 	</CityMap>
-	
-	
+
+
 	<!-- +++++++++++++++++++++ -->
 	<!-- The Americas City Map -->
 	<!-- +++++++++++++++++++++ -->
-	
-	
+
+
 	<!-- GREENLAND -->
 	<CityMap>
-		
+
 		<Replace MapName="GiantEarth" X="178" Y="92" CityLocaleName="LOC_CITY_NAME_MYGGBUKTA" Area="2" />
 		<Replace MapName="GiantEarth" X="175" Y="88" CityLocaleName="LOC_CITY_NAME_TASIILAQ" Area="2" />
 		<Replace MapName="GiantEarth" X="174" Y="92" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_EAST" Area="2" />
@@ -2535,9 +3166,9 @@
 		<Replace MapName="GiantEarth" X="170" Y="86" CityLocaleName="LOC_CITY_NAME_NARSARSUAQ" Area="2" />
 		<Replace MapName="GiantEarth" X="170" Y="82" CityLocaleName="LOC_CITY_NAME_NANORTALIK" Area="2" />
 		<Replace MapName="GiantEarth" X="168" Y="89" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_CENTER" Area="2" />
-		<Replace MapName="GiantEarth" X="168" Y="84" CityLocaleName="LOC_CITY_NAME_QAQORTOQ" Area="2" />	
+		<Replace MapName="GiantEarth" X="168" Y="84" CityLocaleName="LOC_CITY_NAME_QAQORTOQ" Area="2" />
 		<Replace MapName="GiantEarth" X="170" Y="84" CityLocaleName="LOC_CITY_NAME_NANORTALIK" Area="0" />
-		<Replace MapName="GiantEarth" X="171" Y="84" CityLocaleName="LOC_CITY_NAME_NANORTALIK" Area="0" />	
+		<Replace MapName="GiantEarth" X="171" Y="84" CityLocaleName="LOC_CITY_NAME_NANORTALIK" Area="0" />
 		<Replace MapName="GiantEarth" X="164" Y="91" CityLocaleName="LOC_CITY_NAME_KANGERLUSSAQ" Area="0" />
 		<Replace MapName="GiantEarth" X="166" Y="91" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_WEST" Area="2" />
 		<Replace MapName="GiantEarth" X="168" Y="91" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_NORTH" Area="0" />
@@ -2557,55 +3188,55 @@
 		<Replace MapName="GiantEarth" X="167" Y="86" CityLocaleName="LOC_CITY_NAME_QAQORTOQ" Area="0" />
 		<Replace MapName="GiantEarth" X="168" Y="86" CityLocaleName="LOC_CITY_NAME_QAQORTOQ" Area="0" />
 		<Replace MapName="GiantEarth" X="172" Y="86" CityLocaleName="LOC_CITY_NAME_NARSARSUAQ" Area="0" />
-		<Replace MapName="GiantEarth" X="162" Y="88" CityLocaleName="LOC_CITY_NAME_SISIMIUT" Area="0" />	
-		<Replace MapName="GiantEarth" X="161" Y="90" CityLocaleName="LOC_CITY_NAME_ILULISSAT" Area="1" />	
-		<Replace MapName="GiantEarth" X="163" Y="90" CityLocaleName="LOC_CITY_NAME_MANIITSOQ" Area="0" />	
-		<Replace MapName="GiantEarth" X="164" Y="90" CityLocaleName="LOC_CITY_NAME_MANIITSOQ" Area="0" />	
-		<Replace MapName="GiantEarth" X="165" Y="90" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_WEST" Area="0" />	
-		<Replace MapName="GiantEarth" X="170" Y="90" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_CENTER" Area="0" />	
-		<Replace MapName="GiantEarth" X="173" Y="90" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_SOUTH" Area="0" />	
-		<Replace MapName="GiantEarth" X="174" Y="90" CityLocaleName="LOC_CITY_NAME_TASIILAQ" Area="0" />	
-		<Replace MapName="GiantEarth" X="175" Y="90" CityLocaleName="LOC_CITY_NAME_TASIILAQ" Area="0" />			
-		<Replace MapName="GiantEarth" X="161" Y="89" CityLocaleName="LOC_CITY_NAME_AASIAAT" Area="0" />				
-		<Replace MapName="GiantEarth" X="164" Y="89" CityLocaleName="LOC_CITY_NAME_MANIITSOQ" Area="0" />				
-		<Replace MapName="GiantEarth" X="173" Y="89" CityLocaleName="LOC_CITY_NAME_TASIILAQ" Area="0" />			
-		<Replace MapName="GiantEarth" X="164" Y="87" CityLocaleName="LOC_CITY_NAME_KAPISILLIT" Area="0" />			
-		<Replace MapName="GiantEarth" X="167" Y="87" CityLocaleName="LOC_CITY_NAME_KAPISILLIT" Area="0" />			
-		<Replace MapName="GiantEarth" X="168" Y="87" CityLocaleName="LOC_CITY_NAME_NARSARSUAQ" Area="0" />			
-		<Replace MapName="GiantEarth" X="171" Y="87" CityLocaleName="LOC_CITY_NAME_NARSARSUAQ" Area="0" />				
-		<Replace MapName="GiantEarth" X="171" Y="85" CityLocaleName="LOC_CITY_NAME_PRINS_CHRISTIANS_SUND" Area="0" />		
+		<Replace MapName="GiantEarth" X="162" Y="88" CityLocaleName="LOC_CITY_NAME_SISIMIUT" Area="0" />
+		<Replace MapName="GiantEarth" X="161" Y="90" CityLocaleName="LOC_CITY_NAME_ILULISSAT" Area="1" />
+		<Replace MapName="GiantEarth" X="163" Y="90" CityLocaleName="LOC_CITY_NAME_MANIITSOQ" Area="0" />
+		<Replace MapName="GiantEarth" X="164" Y="90" CityLocaleName="LOC_CITY_NAME_MANIITSOQ" Area="0" />
+		<Replace MapName="GiantEarth" X="165" Y="90" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_WEST" Area="0" />
+		<Replace MapName="GiantEarth" X="170" Y="90" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_CENTER" Area="0" />
+		<Replace MapName="GiantEarth" X="173" Y="90" CityLocaleName="LOC_CITY_NAME_GREENLAND_GLACIER_SOUTH" Area="0" />
+		<Replace MapName="GiantEarth" X="174" Y="90" CityLocaleName="LOC_CITY_NAME_TASIILAQ" Area="0" />
+		<Replace MapName="GiantEarth" X="175" Y="90" CityLocaleName="LOC_CITY_NAME_TASIILAQ" Area="0" />
+		<Replace MapName="GiantEarth" X="161" Y="89" CityLocaleName="LOC_CITY_NAME_AASIAAT" Area="0" />
+		<Replace MapName="GiantEarth" X="164" Y="89" CityLocaleName="LOC_CITY_NAME_MANIITSOQ" Area="0" />
+		<Replace MapName="GiantEarth" X="173" Y="89" CityLocaleName="LOC_CITY_NAME_TASIILAQ" Area="0" />
+		<Replace MapName="GiantEarth" X="164" Y="87" CityLocaleName="LOC_CITY_NAME_KAPISILLIT" Area="0" />
+		<Replace MapName="GiantEarth" X="167" Y="87" CityLocaleName="LOC_CITY_NAME_KAPISILLIT" Area="0" />
+		<Replace MapName="GiantEarth" X="168" Y="87" CityLocaleName="LOC_CITY_NAME_NARSARSUAQ" Area="0" />
+		<Replace MapName="GiantEarth" X="171" Y="87" CityLocaleName="LOC_CITY_NAME_NARSARSUAQ" Area="0" />
+		<Replace MapName="GiantEarth" X="171" Y="85" CityLocaleName="LOC_CITY_NAME_PRINS_CHRISTIANS_SUND" Area="0" />
 		<Replace MapName="GiantEarth" X="171" Y="83" CityLocaleName="LOC_CITY_NAME_PRINS_CHRISTIANS_SUND" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- CANADA -->
 	<CityMap>
-		
-		<!-- NORTHWEST TERRITORIES -->	
+
+		<!-- NORTHWEST TERRITORIES -->
 		<Replace MapName="GiantEarth" X="134" Y="80" CityLocaleName="LOC_CITY_NAME_HAY_RIVER" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="80" CityLocaleName="LOC_CITY_NAME_FORT_SMITH" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="81" CityLocaleName="LOC_CITY_NAME_FORT_SIMPSON" Area="1" />
 		<Replace MapName="GiantEarth" X="133" Y="81" CityLocaleName="LOC_CITY_NAME_GAMETI" Area="1" />
-		<Replace MapName="GiantEarth" X="135" Y="81" CityLocaleName="LOC_CITY_NAME_YELLOWKNIFE" Area="0" />	
-		
+		<Replace MapName="GiantEarth" X="135" Y="81" CityLocaleName="LOC_CITY_NAME_YELLOWKNIFE" Area="0" />
+
 		<Replace MapName="GiantEarth" X="130" Y="82" CityLocaleName="LOC_CITY_NAME_NORMAN_WELLS" Area="0" />
 		<Replace MapName="GiantEarth" X="131" Y="82" CityLocaleName="LOC_CITY_NAME_FORT_SIMPSON" Area="0" />
 		<Replace MapName="GiantEarth" X="132" Y="82" CityLocaleName="LOC_CITY_NAME_FORT_SIMPSON" Area="0" />
 		<Replace MapName="GiantEarth" X="133" Y="82" CityLocaleName="LOC_CITY_NAME_WHATI" Area="0" />
 		<Replace MapName="GiantEarth" X="135" Y="82" CityLocaleName="LOC_CITY_NAME_YELLOWKNIFE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="129" Y="83" CityLocaleName="LOC_CITY_NAME_NORMAN_WELLS" Area="0" />
 		<Replace MapName="GiantEarth" X="130" Y="83" CityLocaleName="LOC_CITY_NAME_DELINE" Area="1" />
 		<Replace MapName="GiantEarth" X="133" Y="83" CityLocaleName="LOC_CITY_NAME_SAWMILL_BAY" Area="2" />
-		
+
 		<Replace MapName="GiantEarth" X="130" Y="84" CityLocaleName="LOC_CITY_NAME_COLVILLE_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="131" Y="84" CityLocaleName="LOC_CITY_NAME_COLVILLE_LAKE" Area="1" />
 		<Replace MapName="GiantEarth" X="135" Y="84" CityLocaleName="LOC_CITY_NAME_SAWMILL_BAY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="85" CityLocaleName="LOC_CITY_NAME_COLVILLE_LAKE" Area="0" />
-		<Replace MapName="GiantEarth" X="128" Y="85" CityLocaleName="LOC_CITY_NAME_INUVIK" Area="0" />	
-		
+		<Replace MapName="GiantEarth" X="128" Y="85" CityLocaleName="LOC_CITY_NAME_INUVIK" Area="0" />
+
 		<Replace MapName="GiantEarth" X="128" Y="84" CityLocaleName="LOC_CITY_NAME_FORT_GOOD_HOPE" Area="0" />
 		<Replace MapName="GiantEarth" X="129" Y="84" CityLocaleName="LOC_CITY_NAME_FORT_GOOD_HOPE" Area="0" />
 		<Replace MapName="GiantEarth" X="129" Y="86" CityLocaleName="LOC_CITY_NAME_INUVIK" Area="1" />
@@ -2614,49 +3245,49 @@
 		<Replace MapName="GiantEarth" X="127" Y="85" CityLocaleName="LOC_CITY_NAME_FORT_MCPHERSON" Area="1" />
 		<Replace MapName="GiantEarth" X="130" Y="86" CityLocaleName="LOC_CITY_NAME_TUKTOYAKTUK" Area="0" />
 		<Replace MapName="GiantEarth" X="132" Y="86" CityLocaleName="LOC_CITY_NAME_PAULATUK" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="129" Y="87" CityLocaleName="LOC_CITY_NAME_TUKTOYAKTUK" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="134" Y="89" CityLocaleName="LOC_CITY_NAME_URUKHAKTOK" Area="2" />
 		<Replace MapName="GiantEarth" X="136" Y="89" CityLocaleName="LOC_CITY_NAME_URUKHAKTOK" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="132" Y="90" CityLocaleName="LOC_CITY_NAME_SACHS_HARBOUR" Area="2" />		
-		
+
+		<Replace MapName="GiantEarth" X="132" Y="90" CityLocaleName="LOC_CITY_NAME_SACHS_HARBOUR" Area="2" />
+
 		<Replace MapName="GiantEarth" X="133" Y="91" CityLocaleName="LOC_CITY_NAME_SACHS_HARBOUR" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="136" Y="93" CityLocaleName="LOC_CITY_NAME_MELVILLE_ISLAND" Area="2" />	
-		
+
+		<Replace MapName="GiantEarth" X="136" Y="93" CityLocaleName="LOC_CITY_NAME_MELVILLE_ISLAND" Area="2" />
+
 		<!-- NUNAVUT -->
 		<Replace MapName="GiantEarth" X="140" Y="80" CityLocaleName="LOC_CITY_NAME_ENNADAI" Area="0" />
 		<Replace MapName="GiantEarth" X="150" Y="79" CityLocaleName="LOC_CITY_NAME_SANIKILUAQ" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="139" Y="81" CityLocaleName="LOC_CITY_NAME_ENNADAI" Area="0" />	
-		<Replace MapName="GiantEarth" X="140" Y="81" CityLocaleName="LOC_CITY_NAME_ENNADAI" Area="1" />	
+
+		<Replace MapName="GiantEarth" X="139" Y="81" CityLocaleName="LOC_CITY_NAME_ENNADAI" Area="0" />
+		<Replace MapName="GiantEarth" X="140" Y="81" CityLocaleName="LOC_CITY_NAME_ENNADAI" Area="1" />
 		<Replace MapName="GiantEarth" X="141" Y="81" CityLocaleName="LOC_CITY_NAME_ENNADAI" Area="0" />
 		<Replace MapName="GiantEarth" X="159" Y="81" CityLocaleName="LOC_CITY_NAME_KILLINIQ" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="82" CityLocaleName="LOC_CITY_NAME_DUBAWNT_LAKE" Area="0" />
-		<Replace MapName="GiantEarth" X="142" Y="82" CityLocaleName="LOC_CITY_NAME_PADLEI" Area="1" />	
-		<Replace MapName="GiantEarth" X="143" Y="82" CityLocaleName="LOC_CITY_NAME_ARVIAT" Area="0" />	
+		<Replace MapName="GiantEarth" X="142" Y="82" CityLocaleName="LOC_CITY_NAME_PADLEI" Area="1" />
+		<Replace MapName="GiantEarth" X="143" Y="82" CityLocaleName="LOC_CITY_NAME_ARVIAT" Area="0" />
 		<Replace MapName="GiantEarth" X="151" Y="82" CityLocaleName="LOC_CITY_NAME_COATS_ISLAND" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="83" CityLocaleName="LOC_CITY_NAME_TAKIJUQ_LAKE" Area="1" />
 		<Replace MapName="GiantEarth" X="143" Y="83" CityLocaleName="LOC_CITY_NAME_BAKER_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="144" Y="83" CityLocaleName="LOC_CITY_NAME_RANKIN_INLET" Area="1" />
-		<Replace MapName="GiantEarth" X="148" Y="83" CityLocaleName="LOC_CITY_NAME_CORAL_HARBOUR" Area="0" />	
+		<Replace MapName="GiantEarth" X="148" Y="83" CityLocaleName="LOC_CITY_NAME_CORAL_HARBOUR" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="83" CityLocaleName="LOC_CITY_NAME_KIMMIRUT" Area="1" />
-		<Replace MapName="GiantEarth" X="158" Y="83" CityLocaleName="LOC_CITY_NAME_KIMMIRUT" Area="0" />	
-		
+		<Replace MapName="GiantEarth" X="158" Y="83" CityLocaleName="LOC_CITY_NAME_KIMMIRUT" Area="0" />
+
 		<Replace MapName="GiantEarth" X="140" Y="84" CityLocaleName="LOC_CITY_NAME_BATHURST_INLET" Area="1" />
 		<Replace MapName="GiantEarth" X="142" Y="84" CityLocaleName="LOC_CITY_NAME_BAKER_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="84" CityLocaleName="LOC_CITY_NAME_BAKER_LAKE" Area="1" />
 		<Replace MapName="GiantEarth" X="144" Y="84" CityLocaleName="LOC_CITY_NAME_RANKIN_INLET" Area="0" />
 		<Replace MapName="GiantEarth" X="150" Y="84" CityLocaleName="LOC_CITY_NAME_CORAL_HARBOUR" Area="2" />
 		<Replace MapName="GiantEarth" X="151" Y="84" CityLocaleName="LOC_CITY_NAME_CORAL_HARBOUR" Area="0" />
-		<Replace MapName="GiantEarth" X="157" Y="84" CityLocaleName="LOC_CITY_NAME_KIMMIRUT" Area="0" />	
-		<Replace MapName="GiantEarth" X="158" Y="84" CityLocaleName="LOC_CITY_NAME_IQALUIT" Area="2" />	
+		<Replace MapName="GiantEarth" X="157" Y="84" CityLocaleName="LOC_CITY_NAME_KIMMIRUT" Area="0" />
+		<Replace MapName="GiantEarth" X="158" Y="84" CityLocaleName="LOC_CITY_NAME_IQALUIT" Area="2" />
 		<Replace MapName="GiantEarth" X="160" Y="84" CityLocaleName="LOC_CITY_NAME_RESOLUTION_ISLAND" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="140" Y="85" CityLocaleName="LOC_CITY_NAME_UMINGMAKTOK" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="85" CityLocaleName="LOC_CITY_NAME_UMINGMAKTOK" Area="0" />
 		<Replace MapName="GiantEarth" X="142" Y="85" CityLocaleName="LOC_CITY_NAME_MACALPINE_LAKE" Area="1" />
@@ -2665,41 +3296,41 @@
 		<Replace MapName="GiantEarth" X="152" Y="85" CityLocaleName="LOC_CITY_NAME_CAPE_DORSET" Area="2" />
 		<Replace MapName="GiantEarth" X="155" Y="85" CityLocaleName="LOC_CITY_NAME_AMADJUAK" Area="1" />
 		<Replace MapName="GiantEarth" X="157" Y="85" CityLocaleName="LOC_CITY_NAME_IQALUIT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="135" Y="86" CityLocaleName="LOC_CITY_NAME_KUGLUKTUK" Area="2" />
 		<Replace MapName="GiantEarth" X="138" Y="86" CityLocaleName="LOC_CITY_NAME_EDINBURGH_ISLAND" Area="1" />
 		<Replace MapName="GiantEarth" X="141" Y="86" CityLocaleName="LOC_CITY_NAME_UMINGMAKTOK" Area="1" />
 		<Replace MapName="GiantEarth" X="145" Y="86" CityLocaleName="LOC_CITY_NAME_GJOA_HAVEN" Area="1" />
 		<Replace MapName="GiantEarth" X="150" Y="86" CityLocaleName="LOC_CITY_NAME_HALL_BEACH" Area="1" />
-		<Replace MapName="GiantEarth" X="157" Y="86" CityLocaleName="LOC_CITY_NAME_PANGNIRTUNG" Area="2" />	
+		<Replace MapName="GiantEarth" X="157" Y="86" CityLocaleName="LOC_CITY_NAME_PANGNIRTUNG" Area="2" />
 		<Replace MapName="GiantEarth" X="158" Y="86" CityLocaleName="LOC_CITY_NAME_IQALUIT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="87" CityLocaleName="LOC_CITY_NAME_TALOYOAK" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="141" Y="88" CityLocaleName="LOC_CITY_NAME_CAMBRIDGE_BAY" Area="2" />
 		<Replace MapName="GiantEarth" X="147" Y="88" CityLocaleName="LOC_CITY_NAME_TALOYOAK" Area="0" />
-		<Replace MapName="GiantEarth" X="151" Y="88" CityLocaleName="LOC_CITY_NAME_SHIMIK" Area="2" />	
-		
+		<Replace MapName="GiantEarth" X="151" Y="88" CityLocaleName="LOC_CITY_NAME_SHIMIK" Area="2" />
+
 		<Replace MapName="GiantEarth" X="138" Y="89" CityLocaleName="LOC_CITY_NAME_VICTORIA_ISLAND" Area="2" />
 		<Replace MapName="GiantEarth" X="146" Y="89" CityLocaleName="LOC_CITY_NAME_FORT_ROSS" Area="1" />
-		<Replace MapName="GiantEarth" X="148" Y="89" CityLocaleName="LOC_CITY_NAME_ARCTIC_BAY" Area="1" />	
-		<Replace MapName="GiantEarth" X="153" Y="89" CityLocaleName="LOC_CITY_NAME_CLYDE_RIVER" Area="2" />	
-		
-		<Replace MapName="GiantEarth" X="144" Y="90" CityLocaleName="LOC_CITY_NAME_PRINCE_OF_WALES_ISLAND" Area="1" />	
-		
+		<Replace MapName="GiantEarth" X="148" Y="89" CityLocaleName="LOC_CITY_NAME_ARCTIC_BAY" Area="1" />
+		<Replace MapName="GiantEarth" X="153" Y="89" CityLocaleName="LOC_CITY_NAME_CLYDE_RIVER" Area="2" />
+
+		<Replace MapName="GiantEarth" X="144" Y="90" CityLocaleName="LOC_CITY_NAME_PRINCE_OF_WALES_ISLAND" Area="1" />
+
 		<Replace MapName="GiantEarth" X="141" Y="92" CityLocaleName="LOC_CITY_NAME_BATHURST_ISLAND" Area="1" />
 		<Replace MapName="GiantEarth" X="147" Y="92" CityLocaleName="LOC_CITY_NAME_RESOLUTE" Area="2" />
-		<Replace MapName="GiantEarth" X="150" Y="92" CityLocaleName="LOC_CITY_NAME_DUNDAS_HARBOUR" Area="1" />		
-		
-		<Replace MapName="GiantEarth" X="143" Y="93" CityLocaleName="LOC_CITY_NAME_POLARIS" Area="1" />		
-		
+		<Replace MapName="GiantEarth" X="150" Y="92" CityLocaleName="LOC_CITY_NAME_DUNDAS_HARBOUR" Area="1" />
+
+		<Replace MapName="GiantEarth" X="143" Y="93" CityLocaleName="LOC_CITY_NAME_POLARIS" Area="1" />
+
 		<!-- YUKON -->
 		<Replace MapName="GiantEarth" X="126" Y="80" CityLocaleName="LOC_CITY_NAME_DESTRUCTION_BAY" Area="0" />
 		<Replace MapName="GiantEarth" X="127" Y="80" CityLocaleName="LOC_CITY_NAME_DESTRUCTION_BAY" Area="1" />
 		<Replace MapName="GiantEarth" X="130" Y="80" CityLocaleName="LOC_CITY_NAME_WATSON_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="128" Y="81" CityLocaleName="LOC_CITY_NAME_WHITEHORSE" Area="0" />
 		<Replace MapName="GiantEarth" X="129" Y="80" CityLocaleName="LOC_CITY_NAME_WHITEHORSE" Area="0" />
-		<Replace MapName="GiantEarth" X="128" Y="82" CityLocaleName="LOC_CITY_NAME_MAYO" Area="1" />				
+		<Replace MapName="GiantEarth" X="128" Y="82" CityLocaleName="LOC_CITY_NAME_MAYO" Area="1" />
 		<Replace MapName="GiantEarth" X="129" Y="81" CityLocaleName="LOC_CITY_NAME_ROSS_RIVER" Area="0" />
 		<Replace MapName="GiantEarth" X="127" Y="81" CityLocaleName="LOC_CITY_NAME_CARMACKS" Area="0" />
 		<Replace MapName="GiantEarth" X="126" Y="83" CityLocaleName="LOC_CITY_NAME_DAWSON" Area="1" />
@@ -2707,50 +3338,50 @@
 		<Replace MapName="GiantEarth" X="127" Y="84" CityLocaleName="LOC_CITY_NAME_EAGLE_PLAINS" Area="0" />
 		<Replace MapName="GiantEarth" X="126" Y="82" CityLocaleName="LOC_CITY_NAME_BEAVER_CREEK" Area="0" />
 		<Replace MapName="GiantEarth" X="125" Y="85" CityLocaleName="LOC_CITY_NAME_OLD_CROW" Area="0" />
-		
-		<!-- NEWFOUNDLAND -->	
+
+		<!-- NEWFOUNDLAND -->
 		<Replace MapName="GiantEarth" X="164" Y="72" CityLocaleName="LOC_CITY_NAME_STEPHENVILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="165" Y="72" CityLocaleName="LOC_CITY_NAME_BURGEO" Area="0" />
-		<Replace MapName="GiantEarth" X="166" Y="72" CityLocaleName="LOC_CITY_NAME_MARYSTOWN" Area="0" />	
+		<Replace MapName="GiantEarth" X="166" Y="72" CityLocaleName="LOC_CITY_NAME_MARYSTOWN" Area="0" />
 		<Replace MapName="GiantEarth" X="167" Y="72" CityLocaleName="LOC_CITY_NAME_ST_JOHNS" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="164" Y="73" CityLocaleName="LOC_CITY_NAME_CORNER_BROOK" Area="0" />
 		<Replace MapName="GiantEarth" X="165" Y="73" CityLocaleName="LOC_CITY_NAME_GRAND_FALLS_WINDSOR" Area="0" />
-		<Replace MapName="GiantEarth" X="166" Y="73" CityLocaleName="LOC_CITY_NAME_GANDER" Area="0" />		
-		
-		<Replace MapName="GiantEarth" X="165" Y="75" CityLocaleName="LOC_CITY_NAME_ST_ANTHONY" Area="1" />				
-		
+		<Replace MapName="GiantEarth" X="166" Y="73" CityLocaleName="LOC_CITY_NAME_GANDER" Area="0" />
+
+		<Replace MapName="GiantEarth" X="165" Y="75" CityLocaleName="LOC_CITY_NAME_ST_ANTHONY" Area="1" />
+
 		<!-- LABRADOR -->
 		<Replace MapName="GiantEarth" X="159" Y="75" CityLocaleName="LOC_CITY_NAME_LABRADOR_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="160" Y="75" CityLocaleName="LOC_CITY_NAME_LABRADOR_CITY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="160" Y="76" CityLocaleName="LOC_CITY_NAME_LABRADOR_CITY" Area="1" />
-		<Replace MapName="GiantEarth" X="161" Y="76" CityLocaleName="LOC_CITY_NAME_CHURCHILL_FALLS" Area="0" />	
+		<Replace MapName="GiantEarth" X="161" Y="76" CityLocaleName="LOC_CITY_NAME_CHURCHILL_FALLS" Area="0" />
 		<Replace MapName="GiantEarth" X="163" Y="76" CityLocaleName="LOC_CITY_NAME_HAPPY_VALLEY_GOOSE_BAY" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="159" Y="77" CityLocaleName="LOC_CITY_NAME_CHURCHILL_FALLS" Area="0" />	
-		<Replace MapName="GiantEarth" X="160" Y="77" CityLocaleName="LOC_CITY_NAME_CHURCHILL_FALLS" Area="0" />	
-		<Replace MapName="GiantEarth" X="161" Y="77" CityLocaleName="LOC_CITY_NAME_HAPPY_VALLEY_GOOSE_BAY" Area="1" />	
-		<Replace MapName="GiantEarth" X="162" Y="77" CityLocaleName="LOC_CITY_NAME_CARTWRIGHT" Area="0" />	
-		
+
+		<Replace MapName="GiantEarth" X="159" Y="77" CityLocaleName="LOC_CITY_NAME_CHURCHILL_FALLS" Area="0" />
+		<Replace MapName="GiantEarth" X="160" Y="77" CityLocaleName="LOC_CITY_NAME_CHURCHILL_FALLS" Area="0" />
+		<Replace MapName="GiantEarth" X="161" Y="77" CityLocaleName="LOC_CITY_NAME_HAPPY_VALLEY_GOOSE_BAY" Area="1" />
+		<Replace MapName="GiantEarth" X="162" Y="77" CityLocaleName="LOC_CITY_NAME_CARTWRIGHT" Area="0" />
+
 		<Replace MapName="GiantEarth" X="161" Y="78" CityLocaleName="LOC_CITY_NAME_NAIN" Area="0" />
 		<Replace MapName="GiantEarth" X="162" Y="78" CityLocaleName="LOC_CITY_NAME_NAIN" Area="0" />
 		<Replace MapName="GiantEarth" X="163" Y="78" CityLocaleName="LOC_CITY_NAME_CARTWRIGHT" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="160" Y="79" CityLocaleName="LOC_CITY_NAME_NUTAK" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="160" Y="80" CityLocaleName="LOC_CITY_NAME_NUTAK" Area="0" />	
-		
-		<!-- QUEBEC -->		
+
+		<Replace MapName="GiantEarth" X="160" Y="80" CityLocaleName="LOC_CITY_NAME_NUTAK" Area="0" />
+
+		<!-- QUEBEC -->
 		<Replace MapName="GiantEarth" X="156" Y="70" CityLocaleName="LOC_CITY_NAME_MONTREAL" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="70" CityLocaleName="LOC_CITY_NAME_SHERBROOKE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="71" CityLocaleName="LOC_CITY_NAME_GATINEAU" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="71" CityLocaleName="LOC_CITY_NAME_MONTREAL" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="71" CityLocaleName="LOC_CITY_NAME_TROIS_RIVIERES" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="71" CityLocaleName="LOC_CITY_NAME_QUEBEC_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="71" CityLocaleName="LOC_CITY_NAME_GASPE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="72" CityLocaleName="LOC_CITY_NAME_FORT_RUPERT" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="72" CityLocaleName="LOC_CITY_NAME_VAL_DOR" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="72" CityLocaleName="LOC_CITY_NAME_GATINEAU" Area="0" />
@@ -2759,15 +3390,15 @@
 		<Replace MapName="GiantEarth" X="157" Y="72" CityLocaleName="LOC_CITY_NAME_QUEBEC_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="159" Y="72" CityLocaleName="LOC_CITY_NAME_GASPE" Area="0" />
 		<Replace MapName="GiantEarth" X="161" Y="72" CityLocaleName="LOC_CITY_NAME_PORT_MENIER" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="73" CityLocaleName="LOC_CITY_NAME_FORT_RUPERT" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="73" CityLocaleName="LOC_CITY_NAME_VAL_DOR" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="73" CityLocaleName="LOC_CITY_NAME_VAL_DOR" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="73" CityLocaleName="LOC_CITY_NAME_SAGUENAY" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="73" CityLocaleName="LOC_CITY_NAME_BAIE_COMEAU" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="74" CityLocaleName="LOC_CITY_NAME_EASTMAIN" Area="0" />
-		<Replace MapName="GiantEarth" X="154" Y="74" CityLocaleName="LOC_CITY_NAME_SAKAMI" Area="0" />	
+		<Replace MapName="GiantEarth" X="154" Y="74" CityLocaleName="LOC_CITY_NAME_SAKAMI" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="74" CityLocaleName="LOC_CITY_NAME_CHIBOUGAMAU" Area="1" />
 		<Replace MapName="GiantEarth" X="157" Y="74" CityLocaleName="LOC_CITY_NAME_SAGUENAY" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="74" CityLocaleName="LOC_CITY_NAME_SEPT_ILES" Area="1" />
@@ -2775,64 +3406,64 @@
 		<Replace MapName="GiantEarth" X="160" Y="74" CityLocaleName="LOC_CITY_NAME_HAVRE_SAINT_PIERRE" Area="1" />
 		<Replace MapName="GiantEarth" X="163" Y="74" CityLocaleName="LOC_CITY_NAME_LA_ROMAINE" Area="1" />
 		<Replace MapName="GiantEarth" X="162" Y="74" CityLocaleName="LOC_CITY_NAME_LA_ROMAINE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="75" CityLocaleName="LOC_CITY_NAME_RADISSON" Area="1" />
 		<Replace MapName="GiantEarth" X="154" Y="75" CityLocaleName="LOC_CITY_NAME_SAKAMI" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="75" CityLocaleName="LOC_CITY_NAME_FERMONT" Area="0" />
 		<Replace MapName="GiantEarth" X="162" Y="75" CityLocaleName="LOC_CITY_NAME_SAINT_AUGUSTIN" Area="0" />
 		<Replace MapName="GiantEarth" X="163" Y="75" CityLocaleName="LOC_CITY_NAME_BLANC_SABLON" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="76" CityLocaleName="LOC_CITY_NAME_KUUJJUARAPIK" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="76" CityLocaleName="LOC_CITY_NAME_KUUJJUARAPIK" Area="0" />
-		<Replace MapName="GiantEarth" X="158" Y="76" CityLocaleName="LOC_CITY_NAME_FERMONT" Area="1" />	
-		
+		<Replace MapName="GiantEarth" X="158" Y="76" CityLocaleName="LOC_CITY_NAME_FERMONT" Area="1" />
+
 		<Replace MapName="GiantEarth" X="153" Y="77" CityLocaleName="LOC_CITY_NAME_CHISASIBI" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="77" CityLocaleName="LOC_CITY_NAME_CHISASIBI" Area="1" />
 		<Replace MapName="GiantEarth" X="155" Y="77" CityLocaleName="LOC_CITY_NAME_FORT_MACKENZIE" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="77" CityLocaleName="LOC_CITY_NAME_FORT_MACKENZIE" Area="1" />
 		<Replace MapName="GiantEarth" X="158" Y="77" CityLocaleName="LOC_CITY_NAME_SCHEFFERVILLE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="78" CityLocaleName="LOC_CITY_NAME_UMIUJAQ" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="78" CityLocaleName="LOC_CITY_NAME_UMIUJAQ" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="78" CityLocaleName="LOC_CITY_NAME_FORT_MACKENZIE" Area="0" />
-		<Replace MapName="GiantEarth" X="158" Y="78" CityLocaleName="LOC_CITY_NAME_FORT_MACKENZIE" Area="0" />	
-		
+		<Replace MapName="GiantEarth" X="158" Y="78" CityLocaleName="LOC_CITY_NAME_FORT_MACKENZIE" Area="0" />
+
 		<Replace MapName="GiantEarth" X="153" Y="79" CityLocaleName="LOC_CITY_NAME_INUKJUAK" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="79" CityLocaleName="LOC_CITY_NAME_KANGIRSUK" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="79" CityLocaleName="LOC_CITY_NAME_KUUJJUAQ" Area="1" />
 		<Replace MapName="GiantEarth" X="158" Y="79" CityLocaleName="LOC_CITY_NAME_KUUJJUAQ" Area="0" />
 		<Replace MapName="GiantEarth" X="159" Y="79" CityLocaleName="LOC_CITY_NAME_KANGIQSUALUJJUAQ" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="80" CityLocaleName="LOC_CITY_NAME_PUVIRNITUQ" Area="1" />
 		<Replace MapName="GiantEarth" X="155" Y="80" CityLocaleName="LOC_CITY_NAME_KANGIRSUK" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="80" CityLocaleName="LOC_CITY_NAME_KANGIRSUK" Area="1" />
-		<Replace MapName="GiantEarth" X="157" Y="80" CityLocaleName="LOC_CITY_NAME_TASIUJAQ" Area="1" />	
-		
+		<Replace MapName="GiantEarth" X="157" Y="80" CityLocaleName="LOC_CITY_NAME_TASIUJAQ" Area="1" />
+
 		<Replace MapName="GiantEarth" X="153" Y="81" CityLocaleName="LOC_CITY_NAME_AKULIVIK" Area="0" />
-		<Replace MapName="GiantEarth" X="154" Y="81" CityLocaleName="LOC_CITY_NAME_SALLUIT" Area="0" />	
-		<Replace MapName="GiantEarth" X="155" Y="81" CityLocaleName="LOC_CITY_NAME_DIANA_BAY" Area="0" />					
-		
+		<Replace MapName="GiantEarth" X="154" Y="81" CityLocaleName="LOC_CITY_NAME_SALLUIT" Area="0" />
+		<Replace MapName="GiantEarth" X="155" Y="81" CityLocaleName="LOC_CITY_NAME_DIANA_BAY" Area="0" />
+
 		<Replace MapName="GiantEarth" X="153" Y="82" CityLocaleName="LOC_CITY_NAME_AKULIVIK" Area="1" />
 		<Replace MapName="GiantEarth" X="154" Y="82" CityLocaleName="LOC_CITY_NAME_SALLUIT" Area="1" />
 		<Replace MapName="GiantEarth" X="156" Y="82" CityLocaleName="LOC_CITY_NAME_DIANA_BAY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="83" CityLocaleName="LOC_CITY_NAME_AKULIVIK" Area="0" />
-		<Replace MapName="GiantEarth" X="153" Y="83" CityLocaleName="LOC_CITY_NAME_SALLUIT" Area="0" />	
-		
+		<Replace MapName="GiantEarth" X="153" Y="83" CityLocaleName="LOC_CITY_NAME_SALLUIT" Area="0" />
+
 		<!-- ONTARIO -->
-		<Replace MapName="GiantEarth" X="151" Y="68" CityLocaleName="LOC_CITY_NAME_WINDSOR" Area="1" />	
+		<Replace MapName="GiantEarth" X="151" Y="68" CityLocaleName="LOC_CITY_NAME_WINDSOR" Area="1" />
 		<Replace MapName="GiantEarth" X="152" Y="68" CityLocaleName="LOC_CITY_NAME_CAN_HAMILTON" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="68" CityLocaleName="LOC_CITY_NAME_CAN_HAMILTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="69" CityLocaleName="LOC_CITY_NAME_TORONTO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="70" CityLocaleName="LOC_CITY_NAME_SAULT_STE_MARIE" Area="1" />
 		<Replace MapName="GiantEarth" X="151" Y="70" CityLocaleName="LOC_CITY_NAME_SUDBURY" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="70" CityLocaleName="LOC_CITY_NAME_BARRIE" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="70" CityLocaleName="LOC_CITY_NAME_TORONTO" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="70" CityLocaleName="LOC_CITY_NAME_CAN_KINGSTON" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="70" CityLocaleName="LOC_CITY_NAME_CAN_KINGSTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="145" Y="71" CityLocaleName="LOC_CITY_NAME_FORT_FRANCES" Area="0" />
 		<Replace MapName="GiantEarth" X="147" Y="71" CityLocaleName="LOC_CITY_NAME_THUNDER_BAY" Area="1" />
 		<Replace MapName="GiantEarth" X="148" Y="71" CityLocaleName="LOC_CITY_NAME_SAULT_STE_MARIE" Area="0" />
@@ -2840,12 +3471,12 @@
 		<Replace MapName="GiantEarth" X="151" Y="71" CityLocaleName="LOC_CITY_NAME_NORTH_BAY" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="71" CityLocaleName="LOC_CITY_NAME_OTTAWA" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="71" CityLocaleName="LOC_CITY_NAME_OTTAWA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="145" Y="72" CityLocaleName="LOC_CITY_NAME_KENORA" Area="0" />
 		<Replace MapName="GiantEarth" X="146" Y="72" CityLocaleName="LOC_CITY_NAME_FORT_FRANCES" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="72" CityLocaleName="LOC_CITY_NAME_TIMMINS" Area="0" />
 		<Replace MapName="GiantEarth" X="150" Y="72" CityLocaleName="LOC_CITY_NAME_TIMMINS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="144" Y="73" CityLocaleName="LOC_CITY_NAME_KENORA" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="73" CityLocaleName="LOC_CITY_NAME_DRYDEN" Area="1" />
 		<Replace MapName="GiantEarth" X="146" Y="73" CityLocaleName="LOC_CITY_NAME_THUNDER_BAY" Area="0" />
@@ -2853,160 +3484,160 @@
 		<Replace MapName="GiantEarth" X="148" Y="73" CityLocaleName="LOC_CITY_NAME_KAPUSKASING" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="73" CityLocaleName="LOC_CITY_NAME_KAPUSKASING" Area="0" />
 		<Replace MapName="GiantEarth" X="150" Y="73" CityLocaleName="LOC_CITY_NAME_MOOSONEE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="74" CityLocaleName="LOC_CITY_NAME_PICKLE_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="147" Y="74" CityLocaleName="LOC_CITY_NAME_PICKLE_LAKE" Area="1" />
 		<Replace MapName="GiantEarth" X="148" Y="74" CityLocaleName="LOC_CITY_NAME_KAPUSKASING" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="74" CityLocaleName="LOC_CITY_NAME_KAPUSKASING" Area="0" />
 		<Replace MapName="GiantEarth" X="150" Y="74" CityLocaleName="LOC_CITY_NAME_MOOSONEE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="144" Y="75" CityLocaleName="LOC_CITY_NAME_RED_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="75" CityLocaleName="LOC_CITY_NAME_RED_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="75" CityLocaleName="LOC_CITY_NAME_ATTAWAPISKAT" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="145" Y="76" CityLocaleName="LOC_CITY_NAME_RED_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="146" Y="76" CityLocaleName="LOC_CITY_NAME_RED_LAKE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="147" Y="77" CityLocaleName="LOC_CITY_NAME_FORT_SEVERN" Area="1" />
-		
-		<!-- MARITIMES -->	
-		<Replace MapName="GiantEarth" X="160" Y="68" CityLocaleName="LOC_CITY_NAME_HALIFAX" Area="1" />	
-		
+
+		<!-- MARITIMES -->
+		<Replace MapName="GiantEarth" X="160" Y="68" CityLocaleName="LOC_CITY_NAME_HALIFAX" Area="1" />
+
 		<Replace MapName="GiantEarth" X="159" Y="70" CityLocaleName="LOC_CITY_NAME_SAINT_JOHN" Area="0" />
 		<Replace MapName="GiantEarth" X="160" Y="70" CityLocaleName="LOC_CITY_NAME_CHARLOTTETOWN" Area="0" />
 		<Replace MapName="GiantEarth" X="161" Y="70" CityLocaleName="LOC_CITY_NAME_CAPE_BRETON" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="159" Y="71" CityLocaleName="LOC_CITY_NAME_FREDERICTON" Area="0" />	
-		
-		<!-- MANITOBA -->		
+
+		<Replace MapName="GiantEarth" X="159" Y="71" CityLocaleName="LOC_CITY_NAME_FREDERICTON" Area="0" />
+
+		<!-- MANITOBA -->
 		<Replace MapName="GiantEarth" X="139" Y="71" CityLocaleName="LOC_CITY_NAME_BRANDON" Area="0" />
 		<Replace MapName="GiantEarth" X="142" Y="71" CityLocaleName="LOC_CITY_NAME_STEINBACH" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="71" CityLocaleName="LOC_CITY_NAME_STEINBACH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="72" CityLocaleName="LOC_CITY_NAME_BRANDON" Area="1" />
 		<Replace MapName="GiantEarth" X="140" Y="72" CityLocaleName="LOC_CITY_NAME_BRANDON" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="72" CityLocaleName="LOC_CITY_NAME_WINNIPEG" Area="1" />
 		<Replace MapName="GiantEarth" X="143" Y="72" CityLocaleName="LOC_CITY_NAME_STEINBACH" Area="0" />
 		<Replace MapName="GiantEarth" X="144" Y="72" CityLocaleName="LOC_CITY_NAME_STEINBACH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="73" CityLocaleName="LOC_CITY_NAME_DAUPHIN" Area="0" />
 		<Replace MapName="GiantEarth" X="140" Y="73" CityLocaleName="LOC_CITY_NAME_PORTAGE_LA_PRAIRIE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="74" CityLocaleName="LOC_CITY_NAME_DAUPHIN" Area="1" />
 		<Replace MapName="GiantEarth" X="141" Y="74" CityLocaleName="LOC_CITY_NAME_PORTAGE_LA_PRAIRIE" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="74" CityLocaleName="LOC_CITY_NAME_PINAWA" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="141" Y="76" CityLocaleName="LOC_CITY_NAME_MOOSE_LAKE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="138" Y="77" CityLocaleName="LOC_CITY_NAME_FLIN_FLON" Area="1" />
 		<Replace MapName="GiantEarth" X="139" Y="77" CityLocaleName="LOC_CITY_NAME_LYNN_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="77" CityLocaleName="LOC_CITY_NAME_THOMPSON" Area="1" />
 		<Replace MapName="GiantEarth" X="146" Y="77" CityLocaleName="LOC_CITY_NAME_YORK_FACTORY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="78" CityLocaleName="LOC_CITY_NAME_LYNN_LAKE" Area="0" />
-		<Replace MapName="GiantEarth" X="140" Y="78" CityLocaleName="LOC_CITY_NAME_LYNN_LAKE" Area="1" />	
-		<Replace MapName="GiantEarth" X="143" Y="78" CityLocaleName="LOC_CITY_NAME_THOMPSON" Area="1" />	
+		<Replace MapName="GiantEarth" X="140" Y="78" CityLocaleName="LOC_CITY_NAME_LYNN_LAKE" Area="1" />
+		<Replace MapName="GiantEarth" X="143" Y="78" CityLocaleName="LOC_CITY_NAME_THOMPSON" Area="1" />
 		<Replace MapName="GiantEarth" X="144" Y="78" CityLocaleName="LOC_CITY_NAME_PORT_NELSON" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="78" CityLocaleName="LOC_CITY_NAME_YORK_FACTORY" Area="0" />
 		<Replace MapName="GiantEarth" X="146" Y="78" CityLocaleName="LOC_CITY_NAME_YORK_FACTORY" Area="1" />
 		<Replace MapName="GiantEarth" X="147" Y="78" CityLocaleName="LOC_CITY_NAME_YORK_FACTORY" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="137" Y="81" CityLocaleName="LOC_CITY_NAME_BROCHET" Area="0" />	
+
+		<Replace MapName="GiantEarth" X="137" Y="81" CityLocaleName="LOC_CITY_NAME_BROCHET" Area="0" />
 		<Replace MapName="GiantEarth" X="139" Y="79" CityLocaleName="LOC_CITY_NAME_LYNN_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="79" CityLocaleName="LOC_CITY_NAME_TADOULE_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="142" Y="79" CityLocaleName="LOC_CITY_NAME_TADOULE_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="79" CityLocaleName="LOC_CITY_NAME_CHURCHILL" Area="1" />
 		<Replace MapName="GiantEarth" X="144" Y="79" CityLocaleName="LOC_CITY_NAME_PORT_NELSON" Area="1" />
 		<Replace MapName="GiantEarth" X="145" Y="79" CityLocaleName="LOC_CITY_NAME_YORK_FACTORY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="138" Y="80" CityLocaleName="LOC_CITY_NAME_LYNN_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="139" Y="80" CityLocaleName="LOC_CITY_NAME_BROCHET" Area="1" />
 		<Replace MapName="GiantEarth" X="142" Y="80" CityLocaleName="LOC_CITY_NAME_TADOULE_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="80" CityLocaleName="LOC_CITY_NAME_CHURCHILL" Area="0" />
 		<Replace MapName="GiantEarth" X="144" Y="80" CityLocaleName="LOC_CITY_NAME_CHURCHILL" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="142" Y="81" CityLocaleName="LOC_CITY_NAME_EGG_ISLAND" Area="1" />
-		
-		<!-- SASKATCHEWAN -->	
+
+		<!-- SASKATCHEWAN -->
 		<Replace MapName="GiantEarth" X="138" Y="71" CityLocaleName="LOC_CITY_NAME_REGINA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="138" Y="72" CityLocaleName="LOC_CITY_NAME_REGINA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="73" CityLocaleName="LOC_CITY_NAME_REGINA" Area="0" />
 		<Replace MapName="GiantEarth" X="138" Y="73" CityLocaleName="LOC_CITY_NAME_REGINA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="74" CityLocaleName="LOC_CITY_NAME_SASKATOON" Area="0" />
-		<Replace MapName="GiantEarth" X="138" Y="74" CityLocaleName="LOC_CITY_NAME_REGINA" Area="0" />	
-		
+		<Replace MapName="GiantEarth" X="138" Y="74" CityLocaleName="LOC_CITY_NAME_REGINA" Area="0" />
+
 		<Replace MapName="GiantEarth" X="136" Y="75" CityLocaleName="LOC_CITY_NAME_SASKATOON" Area="0" />
 		<Replace MapName="GiantEarth" X="137" Y="75" CityLocaleName="LOC_CITY_NAME_SASKATOON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="76" CityLocaleName="LOC_CITY_NAME_SASKATOON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="135" Y="79" CityLocaleName="LOC_CITY_NAME_BLACK_LAKE" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="79" CityLocaleName="LOC_CITY_NAME_BLACK_LAKE" Area="1" />
-		
+
 		<!-- ALBERTA -->
 		<Replace MapName="GiantEarth" X="135" Y="71" CityLocaleName="LOC_CITY_NAME_LETHBRIDGE" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="71" CityLocaleName="LOC_CITY_NAME_LETHBRIDGE" Area="0" />
 		<Replace MapName="GiantEarth" X="137" Y="71" CityLocaleName="LOC_CITY_NAME_MEDICINE_HAT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="72" CityLocaleName="LOC_CITY_NAME_MEDICINE_HAT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="134" Y="73" CityLocaleName="LOC_CITY_NAME_BANFF" Area="1" />
 		<Replace MapName="GiantEarth" X="135" Y="73" CityLocaleName="LOC_CITY_NAME_CALGARY" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="73" CityLocaleName="LOC_CITY_NAME_CALGARY" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="135" Y="74" CityLocaleName="LOC_CITY_NAME_RED_DEER" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="75" CityLocaleName="LOC_CITY_NAME_HINTON" Area="0" />
 		<Replace MapName="GiantEarth" X="134" Y="75" CityLocaleName="LOC_CITY_NAME_RED_DEER" Area="0" />
 		<Replace MapName="GiantEarth" X="135" Y="75" CityLocaleName="LOC_CITY_NAME_RED_DEER" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="136" Y="76" CityLocaleName="LOC_CITY_NAME_EDMONTON" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="77" CityLocaleName="LOC_CITY_NAME_GRANDE_PRAIRIE" Area="1" />
 		<Replace MapName="GiantEarth" X="135" Y="77" CityLocaleName="LOC_CITY_NAME_EDMONTON" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="77" CityLocaleName="LOC_CITY_NAME_FORT_MCMURRAY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="132" Y="78" CityLocaleName="LOC_CITY_NAME_HIGH_LEVEL" Area="0" />
 		<Replace MapName="GiantEarth" X="133" Y="78" CityLocaleName="LOC_CITY_NAME_HIGH_LEVEL" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="78" CityLocaleName="LOC_CITY_NAME_FORT_MCMURRAY" Area="1" />
 		<Replace MapName="GiantEarth" X="137" Y="78" CityLocaleName="LOC_CITY_NAME_FORT_MCMURRAY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="132" Y="79" CityLocaleName="LOC_CITY_NAME_HIGH_LEVEL" Area="0" />
 		<Replace MapName="GiantEarth" X="133" Y="79" CityLocaleName="LOC_CITY_NAME_HIGH_LEVEL" Area="0" />
-		
+
 		<!-- BRITISH COLUMBIA -->
 		<Replace MapName="GiantEarth" X="129" Y="69" CityLocaleName="LOC_CITY_NAME_VICTORIA" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="70" CityLocaleName="LOC_CITY_NAME_VANCOUVER" Area="0" />
 		<Replace MapName="GiantEarth" X="132" Y="70" CityLocaleName="LOC_CITY_NAME_VANCOUVER" Area="0" />
 		<Replace MapName="GiantEarth" X="133" Y="70" CityLocaleName="LOC_CITY_NAME_KELOWNA" Area="0" />
 		<Replace MapName="GiantEarth" X="134" Y="70" CityLocaleName="LOC_CITY_NAME_KELOWNA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="71" CityLocaleName="LOC_CITY_NAME_KELOWNA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="132" Y="72" CityLocaleName="LOC_CITY_NAME_KAMLOOPS" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="128" Y="73" CityLocaleName="LOC_CITY_NAME_QUEEN_CHARLOTTE" Area="0" />
 		<Replace MapName="GiantEarth" X="130" Y="73" CityLocaleName="LOC_CITY_NAME_PRINCE_RUPERT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="130" Y="74" CityLocaleName="LOC_CITY_NAME_PRINCE_RUPERT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="75" CityLocaleName="LOC_CITY_NAME_PRINCE_GEORGE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="129" Y="78" CityLocaleName="LOC_CITY_NAME_ATLIN" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="79" CityLocaleName="LOC_CITY_NAME_FORT_NELSON" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="80" CityLocaleName="LOC_CITY_NAME_FORT_NELSON" Area="0" />
 		<Replace MapName="GiantEarth" X="132" Y="80" CityLocaleName="LOC_CITY_NAME_FORT_NELSON" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<CityMap>	 <!-- U.S.A. (MAINLAND, HAWAII, & ALASKA -->
-		
+
 		<!-- HAWAII -->
 		<Replace MapName="GiantEarth" X="110" Y="54" CityLocaleName="LOC_CITY_NAME_KAPAA" Area="0" />
 		<Replace MapName="GiantEarth" X="115" Y="52" CityLocaleName="LOC_CITY_NAME_HONOLULU" Area="1" />
@@ -3016,18 +3647,18 @@
 		<Replace MapName="GiantEarth" X="119" Y="47" CityLocaleName="LOC_CITY_NAME_KAILUA" Area="0" />
 		<Replace MapName="GiantEarth" X="120" Y="49" CityLocaleName="LOC_CITY_NAME_HILO" Area="1" />
 		<Replace MapName="GiantEarth" X="120" Y="47" CityLocaleName="LOC_CITY_NAME_PAHALA" Area="0" />
-		
+
 		<!-- ALASKA -->
 		<Replace MapName="GiantEarth" X="127" Y="74" CityLocaleName="LOC_CITY_NAME_SITKA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="129" Y="75" CityLocaleName="LOC_CITY_NAME_KETCHIKAN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="127" Y="76" CityLocaleName="LOC_CITY_NAME_JUNEAU" Area="0" />
 		<Replace MapName="GiantEarth" X="128" Y="76" CityLocaleName="LOC_CITY_NAME_JUNEAU" Area="1" />
 		<Replace MapName="GiantEarth" X="130" Y="76" CityLocaleName="LOC_CITY_NAME_KETCHIKAN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="126" Y="77" CityLocaleName="LOC_CITY_NAME_YAKUTAT" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="106" Y="74" CityLocaleName="LOC_CITY_NAME_ATTU_ISLAND" Area="0" />
 		<Replace MapName="GiantEarth" X="109" Y="73" CityLocaleName="LOC_CITY_NAME_ADAK" Area="0" />
 		<Replace MapName="GiantEarth" X="112" Y="74" CityLocaleName="LOC_CITY_NAME_UNALASKA" Area="0" />
@@ -3035,14 +3666,14 @@
 		<Replace MapName="GiantEarth" X="114" Y="84" CityLocaleName="LOC_CITY_NAME_NOME" Area="1" />
 		<Replace MapName="GiantEarth" X="114" Y="81" CityLocaleName="LOC_CITY_NAME_BETHEL" Area="1" />
 		<Replace MapName="GiantEarth" X="115" Y="80" CityLocaleName="LOC_CITY_NAME_DILLINGHAM" Area="0" />
-		<Replace MapName="GiantEarth" X="115" Y="84" CityLocaleName="LOC_CITY_NAME_KOTZEBUE" Area="0" />			
+		<Replace MapName="GiantEarth" X="115" Y="84" CityLocaleName="LOC_CITY_NAME_KOTZEBUE" Area="0" />
 		<Replace MapName="GiantEarth" X="116" Y="78" CityLocaleName="LOC_CITY_NAME_KODIAK" Area="0" />
-		<Replace MapName="GiantEarth" X="116" Y="84" CityLocaleName="LOC_CITY_NAME_GALENA" Area="0" />			
-		<Replace MapName="GiantEarth" X="116" Y="85" CityLocaleName="LOC_CITY_NAME_AMBLER" Area="0" />	
-		<Replace MapName="GiantEarth" X="116" Y="86" CityLocaleName="LOC_CITY_NAME_POINT_HOPE" Area="1" />	
+		<Replace MapName="GiantEarth" X="116" Y="84" CityLocaleName="LOC_CITY_NAME_GALENA" Area="0" />
+		<Replace MapName="GiantEarth" X="116" Y="85" CityLocaleName="LOC_CITY_NAME_AMBLER" Area="0" />
+		<Replace MapName="GiantEarth" X="116" Y="86" CityLocaleName="LOC_CITY_NAME_POINT_HOPE" Area="1" />
 		<Replace MapName="GiantEarth" X="117" Y="81" CityLocaleName="LOC_CITY_NAME_KENAI" Area="0" />
 		<Replace MapName="GiantEarth" X="118" Y="80" CityLocaleName="LOC_CITY_NAME_HOMER" Area="0" />
-		<Replace MapName="GiantEarth" X="118" Y="81" CityLocaleName="LOC_CITY_NAME_SEWARD" Area="0" />			
+		<Replace MapName="GiantEarth" X="118" Y="81" CityLocaleName="LOC_CITY_NAME_SEWARD" Area="0" />
 		<Replace MapName="GiantEarth" X="118" Y="82" CityLocaleName="LOC_CITY_NAME_ANCHORAGE" Area="1" />
 		<Replace MapName="GiantEarth" X="118" Y="83" CityLocaleName="LOC_CITY_NAME_WASILLA" Area="0" />
 		<Replace MapName="GiantEarth" X="118" Y="84" CityLocaleName="LOC_CITY_NAME_TANANA" Area="0" />
@@ -3050,8 +3681,8 @@
 		<Replace MapName="GiantEarth" X="120" Y="84" CityLocaleName="LOC_CITY_NAME_FAIRBANKS" Area="1" />
 		<Replace MapName="GiantEarth" X="121" Y="81" CityLocaleName="LOC_CITY_NAME_VALDEZ" Area="1" />
 		<Replace MapName="GiantEarth" X="122" Y="81" CityLocaleName="LOC_CITY_NAME_WORTMANNS" Area="0" />
-		<Replace MapName="GiantEarth" X="122" Y="82" CityLocaleName="LOC_CITY_NAME_PAXSON" Area="0" />	
-		<Replace MapName="GiantEarth" X="122" Y="83" CityLocaleName="LOC_CITY_NAME_DELTA_JUNCTION" Area="1" />				
+		<Replace MapName="GiantEarth" X="122" Y="82" CityLocaleName="LOC_CITY_NAME_PAXSON" Area="0" />
+		<Replace MapName="GiantEarth" X="122" Y="83" CityLocaleName="LOC_CITY_NAME_DELTA_JUNCTION" Area="1" />
 		<Replace MapName="GiantEarth" X="123" Y="80" CityLocaleName="LOC_CITY_NAME_CORDOVA" Area="1" />
 		<Replace MapName="GiantEarth" X="123" Y="85" CityLocaleName="LOC_CITY_NAME_FORT_YUKON" Area="1" />
 		<Replace MapName="GiantEarth" X="124" Y="79" CityLocaleName="LOC_CITY_NAME_KATALLA" Area="1" />
@@ -3064,544 +3695,544 @@
 		<Replace MapName="GiantEarth" X="122" Y="87" CityLocaleName="LOC_CITY_NAME_KAKTOVIK" Area="1" />
 		<Replace MapName="GiantEarth" X="122" Y="88" CityLocaleName="LOC_CITY_NAME_PRUDHOE_BAY" Area="0" />
 		<Replace MapName="GiantEarth" X="121" Y="88" CityLocaleName="LOC_CITY_NAME_PRUDHOE_BAY" Area="1" />
-		<Replace MapName="GiantEarth" X="122" Y="86" CityLocaleName="LOC_CITY_NAME_ANAKTUVUK_PASS" Area="0" />	
-		<Replace MapName="GiantEarth" X="121" Y="87" CityLocaleName="LOC_CITY_NAME_ANAKTUVUK_PASS" Area="0" />			
-		<Replace MapName="GiantEarth" X="121" Y="86" CityLocaleName="LOC_CITY_NAME_ANAKTUVUK_PASS" Area="0" />	
-		<Replace MapName="GiantEarth" X="119" Y="87" CityLocaleName="LOC_CITY_NAME_ATQASUK" Area="0" />			
-		<Replace MapName="GiantEarth" X="118" Y="87" CityLocaleName="LOC_CITY_NAME_ATQASUK" Area="0" />	
-		<Replace MapName="GiantEarth" X="118" Y="88" CityLocaleName="LOC_CITY_NAME_BARROW" Area="1" />	
-		
+		<Replace MapName="GiantEarth" X="122" Y="86" CityLocaleName="LOC_CITY_NAME_ANAKTUVUK_PASS" Area="0" />
+		<Replace MapName="GiantEarth" X="121" Y="87" CityLocaleName="LOC_CITY_NAME_ANAKTUVUK_PASS" Area="0" />
+		<Replace MapName="GiantEarth" X="121" Y="86" CityLocaleName="LOC_CITY_NAME_ANAKTUVUK_PASS" Area="0" />
+		<Replace MapName="GiantEarth" X="119" Y="87" CityLocaleName="LOC_CITY_NAME_ATQASUK" Area="0" />
+		<Replace MapName="GiantEarth" X="118" Y="87" CityLocaleName="LOC_CITY_NAME_ATQASUK" Area="0" />
+		<Replace MapName="GiantEarth" X="118" Y="88" CityLocaleName="LOC_CITY_NAME_BARROW" Area="1" />
+
 		<!-- MAINE -->
 		<Replace MapName="GiantEarth" X="157" Y="69" CityLocaleName="LOC_CITY_NAME_ME_PORTLAND" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="69" CityLocaleName="LOC_CITY_NAME_BANGOR" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="158" Y="70" CityLocaleName="LOC_CITY_NAME_CARIBOU" Area="0" />
-		
+
 		<!-- MASSACHUSETTS -->
 		<Replace MapName="GiantEarth" X="157" Y="67" CityLocaleName="LOC_CITY_NAME_BOSTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="157" Y="68" CityLocaleName="LOC_CITY_NAME_BOSTON" Area="0" />
-		
+
 		<!-- DISTRICT OF COLUMBIA -->
 		<Replace MapName="GiantEarth" X="154" Y="64" CityLocaleName="LOC_CITY_NAME_WASHINGTON" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="64" CityLocaleName="LOC_CITY_NAME_WASHINGTON" Area="0" />
-		
+
 		<!-- NEW YORK STATE -->
 		<Replace MapName="GiantEarth" X="156" Y="66" CityLocaleName="LOC_CITY_NAME_NEW_YORK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="67" CityLocaleName="LOC_CITY_NAME_BUFFALO" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="67" CityLocaleName="LOC_CITY_NAME_USA_ALBANY" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="67" CityLocaleName="LOC_CITY_NAME_NEW_YORK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="68" CityLocaleName="LOC_CITY_NAME_BUFFALO" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="68" CityLocaleName="LOC_CITY_NAME_USA_ALBANY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="156" Y="69" CityLocaleName="LOC_CITY_NAME_ROCHESTER" Area="0" />
-		
+
 		<!-- PENNSYLVANIA -->
 		<Replace MapName="GiantEarth" X="155" Y="65" CityLocaleName="LOC_CITY_NAME_PHILADELPHIA" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="66" CityLocaleName="LOC_CITY_NAME_PITTSBURGH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="67" CityLocaleName="LOC_CITY_NAME_PITTSBURGH" Area="0" />
-		
+
 		<!-- MICHIGAN -->
 		<Replace MapName="GiantEarth" X="151" Y="66" CityLocaleName="LOC_CITY_NAME_DETROIT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="148" Y="67" CityLocaleName="LOC_CITY_NAME_GRAND_RAPIDS" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="67" CityLocaleName="LOC_CITY_NAME_DETROIT" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="68" CityLocaleName="LOC_CITY_NAME_GRAND_RAPIDS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="69" CityLocaleName="LOC_CITY_NAME_MARQUETTE" Area="0" />
 		<Replace MapName="GiantEarth" X="147" Y="69" CityLocaleName="LOC_CITY_NAME_MARQUETTE" Area="0" />
-		
+
 		<!-- VERMONT -->
 		<Replace MapName="GiantEarth" X="156" Y="69" CityLocaleName="LOC_CITY_NAME_MONTPELIER" Area="1" />
-		
-		<!-- MARYLAND -->	
+
+		<!-- MARYLAND -->
 		<Replace MapName="GiantEarth" X="154" Y="65" CityLocaleName="LOC_CITY_NAME_BALTIMORE" Area="0" />
-		
+
 		<!-- VIRGINIA -->
 		<Replace MapName="GiantEarth" X="154" Y="62" CityLocaleName="LOC_CITY_NAME_RICHMOND" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="62" CityLocaleName="LOC_CITY_NAME_RICHMOND" Area="1" />
-		
+
 		<!-- NORTH CAROLINA -->
 		<Replace MapName="GiantEarth" X="152" Y="61" CityLocaleName="LOC_CITY_NAME_CHARLOTTE" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="61" CityLocaleName="LOC_CITY_NAME_WILMINGTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="62" CityLocaleName="LOC_CITY_NAME_CHARLOTTE" Area="1" />
-		
+
 		<!-- SOUTH CAROLINA -->
 		<Replace MapName="GiantEarth" X="154" Y="60" CityLocaleName="LOC_CITY_NAME_CHARLESTON" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="61" CityLocaleName="LOC_CITY_NAME_CHARLESTON" Area="0" />
-		
+
 		<!-- GEORGIA -->
 		<Replace MapName="GiantEarth" X="152" Y="58" CityLocaleName="LOC_CITY_NAME_SAVANNAH" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="150" Y="59" CityLocaleName="LOC_CITY_NAME_ATLANTA" Area="0" />
 		<Replace MapName="GiantEarth" X="151" Y="59" CityLocaleName="LOC_CITY_NAME_ATLANTA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="60" CityLocaleName="LOC_CITY_NAME_ATLANTA" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="61" CityLocaleName="LOC_CITY_NAME_ATLANTA" Area="0" />
-		
+
 		<!-- FLORIDA -->
 		<Replace MapName="GiantEarth" X="151" Y="53" CityLocaleName="LOC_CITY_NAME_MIAMI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="54" CityLocaleName="LOC_CITY_NAME_MIAMI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="150" Y="55" CityLocaleName="LOC_CITY_NAME_TAMPA" Area="1" />
 		<Replace MapName="GiantEarth" X="151" Y="55" CityLocaleName="LOC_CITY_NAME_ORLANDO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="56" CityLocaleName="LOC_CITY_NAME_JACKSONVILLE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="57" CityLocaleName="LOC_CITY_NAME_TALLAHASSEE" Area="0" />
 		<Replace MapName="GiantEarth" X="150" Y="57" CityLocaleName="LOC_CITY_NAME_TALLAHASSEE" Area="0" />
 		<Replace MapName="GiantEarth" X="151" Y="57" CityLocaleName="LOC_CITY_NAME_JACKSONVILLE" Area="0" />
-		
+
 		<!-- OHIO -->
 		<Replace MapName="GiantEarth" X="150" Y="63" CityLocaleName="LOC_CITY_NAME_CINCINNATI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="64" CityLocaleName="LOC_CITY_NAME_CINCINNATI" Area="0" />
 		<Replace MapName="GiantEarth" X="150" Y="64" CityLocaleName="LOC_CITY_NAME_CINCINNATI" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="65" CityLocaleName="LOC_CITY_NAME_COLUMBUS" Area="0" />
 		<Replace MapName="GiantEarth" X="150" Y="65" CityLocaleName="LOC_CITY_NAME_COLUMBUS" Area="1" />
 		<Replace MapName="GiantEarth" X="152" Y="65" CityLocaleName="LOC_CITY_NAME_AKRON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="66" CityLocaleName="LOC_CITY_NAME_CLEVELAND" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="66" CityLocaleName="LOC_CITY_NAME_CLEVELAND" Area="0" />
-		
+
 		<!-- MINNESOTA -->
 		<Replace MapName="GiantEarth" X="143" Y="67" CityLocaleName="LOC_CITY_NAME_MINNEAPOLIS" Area="0" />
 		<Replace MapName="GiantEarth" X="144" Y="67" CityLocaleName="LOC_CITY_NAME_MINNEAPOLIS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="143" Y="68" CityLocaleName="LOC_CITY_NAME_MINNEAPOLIS" Area="0" />
 		<Replace MapName="GiantEarth" X="144" Y="68" CityLocaleName="LOC_CITY_NAME_MINNEAPOLIS" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="142" Y="69" CityLocaleName="LOC_CITY_NAME_BEMIDJI" Area="1" />
 		<Replace MapName="GiantEarth" X="143" Y="69" CityLocaleName="LOC_CITY_NAME_MINNEAPOLIS" Area="0" />
 		<Replace MapName="GiantEarth" X="144" Y="69" CityLocaleName="LOC_CITY_NAME_DULUTH" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="142" Y="70" CityLocaleName="LOC_CITY_NAME_BEMIDJI" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="70" CityLocaleName="LOC_CITY_NAME_DULUTH" Area="1" />
-		
-		<!-- WISCONSIN -->	
+
+		<!-- WISCONSIN -->
 		<Replace MapName="GiantEarth" X="146" Y="66" CityLocaleName="LOC_CITY_NAME_MILWAUKEE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="67" CityLocaleName="LOC_CITY_NAME_MILWAUKEE" Area="1" />
-		
-		<Replace MapName="GiantEarth" X="146" Y="68" CityLocaleName="LOC_CITY_NAME_GREEN_BAY" Area="0" />	
-		<Replace MapName="GiantEarth" X="147" Y="68" CityLocaleName="LOC_CITY_NAME_GREEN_BAY" Area="0" />	
-		
+
+		<Replace MapName="GiantEarth" X="146" Y="68" CityLocaleName="LOC_CITY_NAME_GREEN_BAY" Area="0" />
+		<Replace MapName="GiantEarth" X="147" Y="68" CityLocaleName="LOC_CITY_NAME_GREEN_BAY" Area="0" />
+
 		<!-- ILLINOIS -->
 		<Replace MapName="GiantEarth" X="147" Y="64" CityLocaleName="LOC_CITY_NAME_SPRINGFIELD" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="65" CityLocaleName="LOC_CITY_NAME_CHICAGO" Area="0" />
 		<Replace MapName="GiantEarth" X="147" Y="65" CityLocaleName="LOC_CITY_NAME_CHICAGO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="147" Y="66" CityLocaleName="LOC_CITY_NAME_CHICAGO" Area="1" />
-		
+
 		<!-- INDIANA -->
 		<Replace MapName="GiantEarth" X="148" Y="64" CityLocaleName="LOC_CITY_NAME_INDIANAPOLIS" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="64" CityLocaleName="LOC_CITY_NAME_INDIANAPOLIS" Area="1" />
-		
-		<!-- WEST VIRGINIA -->	
+
+		<!-- WEST VIRGINIA -->
 		<Replace MapName="GiantEarth" X="152" Y="63" CityLocaleName="LOC_CITY_NAME_HUNTINGTON" Area="1" />
 		<Replace MapName="GiantEarth" X="153" Y="63" CityLocaleName="LOC_CITY_NAME_HUNTINGTON" Area="0" />
-		
+
 		<!-- KENTUCKY -->
 		<Replace MapName="GiantEarth" X="148" Y="63" CityLocaleName="LOC_CITY_NAME_LOUISVILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="63" CityLocaleName="LOC_CITY_NAME_LOUISVILLE" Area="1" />
-		
+
 		<!-- TENNESSEE -->
 		<Replace MapName="GiantEarth" X="146" Y="61" CityLocaleName="LOC_CITY_NAME_USA_MEMPHIS" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="62" CityLocaleName="LOC_CITY_NAME_NASHVILLE" Area="1" />
 		<Replace MapName="GiantEarth" X="150" Y="62" CityLocaleName="LOC_CITY_NAME_NASHVILLE" Area="0" />
 		<Replace MapName="GiantEarth" X="151" Y="62" CityLocaleName="LOC_CITY_NAME_KNOXVILLE" Area="1" />
 		<Replace MapName="GiantEarth" X="152" Y="62" CityLocaleName="LOC_CITY_NAME_KNOXVILLE" Area="0" />
-		
+
 		<!-- ALABAMA -->
 		<Replace MapName="GiantEarth" X="148" Y="57" CityLocaleName="LOC_CITY_NAME_MOBILE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="58" CityLocaleName="LOC_CITY_NAME_MONTGOMERY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="148" Y="59" CityLocaleName="LOC_CITY_NAME_MONTGOMERY" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="59" CityLocaleName="LOC_CITY_NAME_MONTGOMERY" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="60" CityLocaleName="LOC_CITY_NAME_USA_BIRMINGHAM" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="148" Y="61" CityLocaleName="LOC_CITY_NAME_USA_BIRMINGHAM" Area="0" />
 		<Replace MapName="GiantEarth" X="149" Y="61" CityLocaleName="LOC_CITY_NAME_USA_BIRMINGHAM" Area="0" />
-		
+
 		<!-- MISSISSIPPI -->
 		<Replace MapName="GiantEarth" X="145" Y="59" CityLocaleName="LOC_CITY_NAME_JACKSON" Area="0" />
 		<Replace MapName="GiantEarth" X="146" Y="59" CityLocaleName="LOC_CITY_NAME_JACKSON" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="60" CityLocaleName="LOC_CITY_NAME_JACKSON" Area="0" />
 		<Replace MapName="GiantEarth" X="147" Y="60" CityLocaleName="LOC_CITY_NAME_JACKSON" Area="0" />
-		
+
 		<!-- WASHINGTON STATE -->
 		<Replace MapName="GiantEarth" X="131" Y="68" CityLocaleName="LOC_CITY_NAME_SEATTLE" Area="0" />
 		<Replace MapName="GiantEarth" X="133" Y="68" CityLocaleName="LOC_CITY_NAME_KENNEWICK" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="69" CityLocaleName="LOC_CITY_NAME_SEATTLE" Area="0" />
 		<Replace MapName="GiantEarth" X="132" Y="69" CityLocaleName="LOC_CITY_NAME_YAKIMA" Area="0" />
 		<Replace MapName="GiantEarth" X="133" Y="69" CityLocaleName="LOC_CITY_NAME_SPOKANE" Area="0" />
-		
+
 		<!-- OREGON -->
 		<Replace MapName="GiantEarth" X="130" Y="66" CityLocaleName="LOC_CITY_NAME_OR_PORTLAND" Area="0" />
 		<Replace MapName="GiantEarth" X="131" Y="66" CityLocaleName="LOC_CITY_NAME_BEND" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="130" Y="67" CityLocaleName="LOC_CITY_NAME_OR_PORTLAND" Area="0" />
-		
+
 		<!-- NEW MEXICO -->
 		<Replace MapName="GiantEarth" X="137" Y="58" CityLocaleName="LOC_CITY_NAME_LAS_CRUCES" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="136" Y="59" CityLocaleName="LOC_CITY_NAME_LAS_CRUCES" Area="0" />
 		<Replace MapName="GiantEarth" X="138" Y="59" CityLocaleName="LOC_CITY_NAME_ALBUQUERQUE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="138" Y="60" CityLocaleName="LOC_CITY_NAME_ALBUQUERQUE" Area="1" />
 		<Replace MapName="GiantEarth" X="139" Y="60" CityLocaleName="LOC_CITY_NAME_ALBUQUERQUE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="138" Y="61" CityLocaleName="LOC_CITY_NAME_SANTA_FE" Area="0" />
-		
+
 		<!-- ARIZONA -->
 		<Replace MapName="GiantEarth" X="136" Y="58" CityLocaleName="LOC_CITY_NAME_TUCSON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="134" Y="59" CityLocaleName="LOC_CITY_NAME_PHOENIX" Area="1" />
 		<Replace MapName="GiantEarth" X="135" Y="59" CityLocaleName="LOC_CITY_NAME_TUCSON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="60" CityLocaleName="LOC_CITY_NAME_LAKE_HAVASU_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="60" CityLocaleName="LOC_CITY_NAME_FLAGSTAFF" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="132" Y="61" CityLocaleName="LOC_CITY_NAME_LAKE_HAVASU_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="133" Y="61" CityLocaleName="LOC_CITY_NAME_BULLHEAD_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="135" Y="61" CityLocaleName="LOC_CITY_NAME_FLAGSTAFF" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="62" CityLocaleName="LOC_CITY_NAME_BULLHEAD_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="134" Y="62" CityLocaleName="LOC_CITY_NAME_BULLHEAD_CITY" Area="0" />
-		
+
 		<!-- NEVADA -->
 		<Replace MapName="GiantEarth" X="133" Y="63" CityLocaleName="LOC_CITY_NAME_LAS_VEGAS" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="64" CityLocaleName="LOC_CITY_NAME_CARSON_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="134" Y="64" CityLocaleName="LOC_CITY_NAME_ELY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="132" Y="65" CityLocaleName="LOC_CITY_NAME_RENO" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="66" CityLocaleName="LOC_CITY_NAME_ELKO" Area="0" />
-		
+
 		<!-- UTAH -->
 		<Replace MapName="GiantEarth" X="134" Y="63" CityLocaleName="LOC_CITY_NAME_ST_GEORGE" Area="0" />
 		<Replace MapName="GiantEarth" X="135" Y="63" CityLocaleName="LOC_CITY_NAME_MOAB" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="63" CityLocaleName="LOC_CITY_NAME_MOAB" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="135" Y="64" CityLocaleName="LOC_CITY_NAME_ST_GEORGE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="134" Y="65" CityLocaleName="LOC_CITY_NAME_PROVO" Area="0" />
 		<Replace MapName="GiantEarth" X="135" Y="65" CityLocaleName="LOC_CITY_NAME_PROVO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="134" Y="66" CityLocaleName="LOC_CITY_NAME_SALT_LAKE_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="135" Y="66" CityLocaleName="LOC_CITY_NAME_SALT_LAKE_CITY" Area="1" />
-		
+
 		<!-- IDAHO -->
 		<Replace MapName="GiantEarth" X="132" Y="67" CityLocaleName="LOC_CITY_NAME_NAMPA" Area="0" />
 		<Replace MapName="GiantEarth" X="133" Y="67" CityLocaleName="LOC_CITY_NAME_BOISE" Area="0" />
 		<Replace MapName="GiantEarth" X="135" Y="67" CityLocaleName="LOC_CITY_NAME_IDAHO_FALLS" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="67" CityLocaleName="LOC_CITY_NAME_IDAHO_FALLS" Area="0" />
-		
+
 		<!-- CALIFORNIA -->
 		<Replace MapName="GiantEarth" X="131" Y="59" CityLocaleName="LOC_CITY_NAME_SAN_DIEGO" Area="0" />
 		<Replace MapName="GiantEarth" X="132" Y="59" CityLocaleName="LOC_CITY_NAME_PALM_DESERT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="60" CityLocaleName="LOC_CITY_NAME_LOS_ANGELES" Area="1" />
 		<Replace MapName="GiantEarth" X="132" Y="60" CityLocaleName="LOC_CITY_NAME_RIVERSIDE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="61" CityLocaleName="LOC_CITY_NAME_BAKERSFIELD" Area="0" />
 		<Replace MapName="GiantEarth" X="132" Y="61" CityLocaleName="LOC_CITY_NAME_VICTORVILLE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="130" Y="62" CityLocaleName="LOC_CITY_NAME_SAN_JOSE" Area="0" />
 		<Replace MapName="GiantEarth" X="131" Y="62" CityLocaleName="LOC_CITY_NAME_FRESNO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="63" CityLocaleName="LOC_CITY_NAME_STOCKTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="130" Y="64" CityLocaleName="LOC_CITY_NAME_SAN_FRANCISCO" Area="1" />
 		<Replace MapName="GiantEarth" X="131" Y="64" CityLocaleName="LOC_CITY_NAME_SACRAMENTO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="130" Y="65" CityLocaleName="LOC_CITY_NAME_EUREKA" Area="0" />
 		<Replace MapName="GiantEarth" X="131" Y="65" CityLocaleName="LOC_CITY_NAME_REDDING" Area="0" />
-		
+
 		<!-- MISSOURI -->
 		<Replace MapName="GiantEarth" X="146" Y="62" CityLocaleName="LOC_CITY_NAME_ST_LOUIS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="143" Y="63" CityLocaleName="LOC_CITY_NAME_KANSAS_CITY" Area="1" />
 		<Replace MapName="GiantEarth" X="144" Y="63" CityLocaleName="LOC_CITY_NAME_ST_LOUIS" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="63" CityLocaleName="LOC_CITY_NAME_ST_LOUIS" Area="1" />
 		<Replace MapName="GiantEarth" X="146" Y="63" CityLocaleName="LOC_CITY_NAME_ST_LOUIS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="64" CityLocaleName="LOC_CITY_NAME_ST_LOUIS" Area="0" />
-		
-		<!-- LOUISIANA -->	
-		<Replace MapName="GiantEarth" X="145" Y="56" CityLocaleName="LOC_CITY_NAME_NEW_ORLEANS" Area="0" />	
+
+		<!-- LOUISIANA -->
+		<Replace MapName="GiantEarth" X="145" Y="56" CityLocaleName="LOC_CITY_NAME_NEW_ORLEANS" Area="0" />
 		<Replace MapName="GiantEarth" X="146" Y="56" CityLocaleName="LOC_CITY_NAME_NEW_ORLEANS" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="144" Y="57" CityLocaleName="LOC_CITY_NAME_LAFAYETTE" Area="1" />
 		<Replace MapName="GiantEarth" X="145" Y="57" CityLocaleName="LOC_CITY_NAME_NEW_ORLEANS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="144" Y="58" CityLocaleName="LOC_CITY_NAME_SHREVEPORT" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="58" CityLocaleName="LOC_CITY_NAME_SHREVEPORT" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="144" Y="59" CityLocaleName="LOC_CITY_NAME_SHREVEPORT" Area="0" />
-		
+
 		<!-- ARKANSAS -->
 		<Replace MapName="GiantEarth" X="144" Y="60" CityLocaleName="LOC_CITY_NAME_LITTLE_ROCK" Area="1" />
-		
+
 		<!-- IOWA -->
 		<Replace MapName="GiantEarth" X="142" Y="65" CityLocaleName="LOC_CITY_NAME_DES_MOINES" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="65" CityLocaleName="LOC_CITY_NAME_DES_MOINES" Area="0" />
-		<Replace MapName="GiantEarth" X="145" Y="65" CityLocaleName="LOC_CITY_NAME_CEDAR_RAPIDS" Area="0" />	
-		
+		<Replace MapName="GiantEarth" X="145" Y="65" CityLocaleName="LOC_CITY_NAME_CEDAR_RAPIDS" Area="0" />
+
 		<Replace MapName="GiantEarth" X="143" Y="66" CityLocaleName="LOC_CITY_NAME_DES_MOINES" Area="0" />
-		<Replace MapName="GiantEarth" X="144" Y="66" CityLocaleName="LOC_CITY_NAME_CEDAR_RAPIDS" Area="1" />	
-		
-		<!-- NORTH DAKOTA -->	
+		<Replace MapName="GiantEarth" X="144" Y="66" CityLocaleName="LOC_CITY_NAME_CEDAR_RAPIDS" Area="1" />
+
+		<!-- NORTH DAKOTA -->
 		<Replace MapName="GiantEarth" X="139" Y="69" CityLocaleName="LOC_CITY_NAME_BISMARCK" Area="1" />
-		<Replace MapName="GiantEarth" X="140" Y="69" CityLocaleName="LOC_CITY_NAME_BISMARCK" Area="0" />	
+		<Replace MapName="GiantEarth" X="140" Y="69" CityLocaleName="LOC_CITY_NAME_BISMARCK" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="69" CityLocaleName="LOC_CITY_NAME_FARGO" Area="1" />
-		
-		<!-- MONTANA -->	
+
+		<!-- MONTANA -->
 		<Replace MapName="GiantEarth" X="135" Y="69" CityLocaleName="LOC_CITY_NAME_MISSOULA" Area="1" />
 		<Replace MapName="GiantEarth" X="137" Y="69" CityLocaleName="LOC_CITY_NAME_BILLINGS" Area="1" />
 		<Replace MapName="GiantEarth" X="138" Y="69" CityLocaleName="LOC_CITY_NAME_BILLINGS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="136" Y="70" CityLocaleName="LOC_CITY_NAME_GREAT_FALLS" Area="0" />
 		<Replace MapName="GiantEarth" X="137" Y="70" CityLocaleName="LOC_CITY_NAME_GREAT_FALLS" Area="1" />
 		<Replace MapName="GiantEarth" X="138" Y="70" CityLocaleName="LOC_CITY_NAME_BILLINGS" Area="0" />
-		
+
 		<!-- TEXAS -->
 		<Replace MapName="GiantEarth" X="141" Y="54" CityLocaleName="LOC_CITY_NAME_CORPUS_CHRISTI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="55" CityLocaleName="LOC_CITY_NAME_USA_SAN_ANTONIO" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="55" CityLocaleName="LOC_CITY_NAME_HOUSTON" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="56" CityLocaleName="LOC_CITY_NAME_EL_PASO" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="56" CityLocaleName="LOC_CITY_NAME_USA_SAN_ANTONIO" Area="1" />
 		<Replace MapName="GiantEarth" X="142" Y="56" CityLocaleName="LOC_CITY_NAME_HOUSTON" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="138" Y="57" CityLocaleName="LOC_CITY_NAME_EL_PASO" Area="0" />
 		<Replace MapName="GiantEarth" X="139" Y="57" CityLocaleName="LOC_CITY_NAME_MIDLAND" Area="0" />
 		<Replace MapName="GiantEarth" X="140" Y="57" CityLocaleName="LOC_CITY_NAME_AUSTIN" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="57" CityLocaleName="LOC_CITY_NAME_AUSTIN" Area="1" />
 		<Replace MapName="GiantEarth" X="142" Y="57" CityLocaleName="LOC_CITY_NAME_AUSTIN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="58" CityLocaleName="LOC_CITY_NAME_LUBBOCK" Area="0" />
 		<Replace MapName="GiantEarth" X="142" Y="58" CityLocaleName="LOC_CITY_NAME_DALLAS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="59" CityLocaleName="LOC_CITY_NAME_LUBBOCK" Area="1" />
 		<Replace MapName="GiantEarth" X="140" Y="59" CityLocaleName="LOC_CITY_NAME_FORT_WORTH" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="59" CityLocaleName="LOC_CITY_NAME_FORT_WORTH" Area="0" />
 		<Replace MapName="GiantEarth" X="142" Y="59" CityLocaleName="LOC_CITY_NAME_DALLAS" Area="1" />
 		<Replace MapName="GiantEarth" X="143" Y="59" CityLocaleName="LOC_CITY_NAME_DALLAS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="140" Y="60" CityLocaleName="LOC_CITY_NAME_AMARILLO" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="60" CityLocaleName="LOC_CITY_NAME_FORT_WORTH" Area="0" />
 		<Replace MapName="GiantEarth" X="142" Y="60" CityLocaleName="LOC_CITY_NAME_DALLAS" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="60" CityLocaleName="LOC_CITY_NAME_DALLAS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="61" CityLocaleName="LOC_CITY_NAME_AMARILLO" Area="0" />
-		
+
 		<!-- OKLAHOMA -->
 		<Replace MapName="GiantEarth" X="141" Y="61" CityLocaleName="LOC_CITY_NAME_OKLAHOMA_CITY" Area="1" />
-		
+
 		<!-- COLORADO -->
 		<Replace MapName="GiantEarth" X="138" Y="62" CityLocaleName="LOC_CITY_NAME_PUEBLO" Area="0" />
 		<Replace MapName="GiantEarth" X="140" Y="62" CityLocaleName="LOC_CITY_NAME_PUEBLO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="64" CityLocaleName="LOC_CITY_NAME_DENVER" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="65" CityLocaleName="LOC_CITY_NAME_BOULDER" Area="0" />
 		<Replace MapName="GiantEarth" X="138" Y="65" CityLocaleName="LOC_CITY_NAME_BOULDER" Area="0" />
-		
+
 		<!-- KANSAS -->
 		<Replace MapName="GiantEarth" X="140" Y="63" CityLocaleName="LOC_CITY_NAME_WICHITA" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="63" CityLocaleName="LOC_CITY_NAME_WICHITA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="141" Y="64" CityLocaleName="LOC_CITY_NAME_TOPEKA" Area="0" />
 		<Replace MapName="GiantEarth" X="142" Y="64" CityLocaleName="LOC_CITY_NAME_TOPEKA" Area="0" />
-		
+
 		<!-- SOUTH DAKOTA -->
 		<Replace MapName="GiantEarth" X="139" Y="67" CityLocaleName="LOC_CITY_NAME_RAPID_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="140" Y="67" CityLocaleName="LOC_CITY_NAME_RAPID_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="67" CityLocaleName="LOC_CITY_NAME_SIOUX_FALLS" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="68" CityLocaleName="LOC_CITY_NAME_RAPID_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="140" Y="68" CityLocaleName="LOC_CITY_NAME_RAPID_CITY" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="68" CityLocaleName="LOC_CITY_NAME_SIOUX_FALLS" Area="0" />
 		<Replace MapName="GiantEarth" X="142" Y="68" CityLocaleName="LOC_CITY_NAME_SIOUX_FALLS" Area="0" />
-		
+
 		<!-- NEBRASKA -->
 		<Replace MapName="GiantEarth" X="141" Y="65" CityLocaleName="LOC_CITY_NAME_OMAHA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="141" Y="66" CityLocaleName="LOC_CITY_NAME_USA_LINCOLN" Area="1" />
 		<Replace MapName="GiantEarth" X="142" Y="66" CityLocaleName="LOC_CITY_NAME_OMAHA" Area="0" />
-		
+
 		<!-- WYOMING -->
 		<Replace MapName="GiantEarth" X="136" Y="64" CityLocaleName="LOC_CITY_NAME_GRAND_JUNCTION" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="65" CityLocaleName="LOC_CITY_NAME_GRAND_JUNCTION" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="66" CityLocaleName="LOC_CITY_NAME_CHEYENNE" Area="0" />
 		<Replace MapName="GiantEarth" X="138" Y="66" CityLocaleName="LOC_CITY_NAME_CHEYENNE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="67" CityLocaleName="LOC_CITY_NAME_CASPER" Area="1" />
 		<Replace MapName="GiantEarth" X="138" Y="67" CityLocaleName="LOC_CITY_NAME_CHEYENNE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="68" CityLocaleName="LOC_CITY_NAME_CASPER" Area="0" />
 		<Replace MapName="GiantEarth" X="138" Y="68" CityLocaleName="LOC_CITY_NAME_CASPER" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- MEXICO & CENTRAL AMERICA-->
 	<CityMap>
-		
+
 		<!-- MEXICO -->
 		<Replace MapName="GiantEarth" X="140" Y="45" CityLocaleName="LOC_CITY_NAME_OAXACA" Area="1" />
 		<Replace MapName="GiantEarth" X="142" Y="45" CityLocaleName="LOC_CITY_NAME_SALINA_CRUZ" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="45" CityLocaleName="LOC_CITY_NAME_JUCHITAN_DE_ZARAGOZA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="144" Y="46" CityLocaleName="LOC_CITY_NAME_TUXTLA" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="46" CityLocaleName="LOC_CITY_NAME_TUXTLA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="137" Y="47" CityLocaleName="LOC_CITY_NAME_ACAPULCO" Area="0" />
 		<Replace MapName="GiantEarth" X="138" Y="47" CityLocaleName="LOC_CITY_NAME_ACAPULCO" Area="0" />
 		<Replace MapName="GiantEarth" X="139" Y="47" CityLocaleName="LOC_CITY_NAME_TEHUACAN" Area="0" />
 		<Replace MapName="GiantEarth" X="143" Y="47" CityLocaleName="LOC_CITY_NAME_COATZACOALCOS" Area="1" />
 		<Replace MapName="GiantEarth" X="144" Y="47" CityLocaleName="LOC_CITY_NAME_VILLAHERMOSA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="139" Y="48" CityLocaleName="LOC_CITY_NAME_PUEBLA" Area="0" />
 		<Replace MapName="GiantEarth" X="140" Y="48" CityLocaleName="LOC_CITY_NAME_TEHUACAN" Area="0" />
 		<Replace MapName="GiantEarth" X="141" Y="48" CityLocaleName="LOC_CITY_NAME_VERACRUZ" Area="1" />
 		<Replace MapName="GiantEarth" X="144" Y="48" CityLocaleName="LOC_CITY_NAME_VILLAHERMOSA" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="48" CityLocaleName="LOC_CITY_NAME_CIUDAD_DEL_CARMEN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="136" Y="49" CityLocaleName="LOC_CITY_NAME_MEX_GUADALAJARA" Area="1" />
 		<Replace MapName="GiantEarth" X="138" Y="49" CityLocaleName="LOC_CITY_NAME_MEXICO_CITY" Area="1" />
 		<Replace MapName="GiantEarth" X="139" Y="49" CityLocaleName="LOC_CITY_NAME_TEXCOCO" Area="0" />
 		<Replace MapName="GiantEarth" X="145" Y="49" CityLocaleName="LOC_CITY_NAME_MERIDA" Area="0" />
 		<Replace MapName="GiantEarth" X="146" Y="49" CityLocaleName="LOC_CITY_NAME_CANCUN" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="50" CityLocaleName="LOC_CITY_NAME_MERIDA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="136" Y="51" CityLocaleName="LOC_CITY_NAME_MEX_LEON" Area="0" />
 		<Replace MapName="GiantEarth" X="137" Y="51" CityLocaleName="LOC_CITY_NAME_SAN_LUIS_POTOSI" Area="0" />
 		<Replace MapName="GiantEarth" X="140" Y="51" CityLocaleName="LOC_CITY_NAME_CIUDAD_VICTORIA" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="52" CityLocaleName="LOC_CITY_NAME_LA_PAZ" Area="0" />
 		<Replace MapName="GiantEarth" X="137" Y="52" CityLocaleName="LOC_CITY_NAME_MEX_LEON" Area="0" />
 		<Replace MapName="GiantEarth" X="138" Y="52" CityLocaleName="LOC_CITY_NAME_SAN_LUIS_POTOSI" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="135" Y="53" CityLocaleName="LOC_CITY_NAME_MAZATLAN" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="53" CityLocaleName="LOC_CITY_NAME_MAZATLAN" Area="0" />
 		<Replace MapName="GiantEarth" X="140" Y="53" CityLocaleName="LOC_CITY_NAME_REYNOSA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="132" Y="54" CityLocaleName="LOC_CITY_NAME_LA_PAZ" Area="1" />
 		<Replace MapName="GiantEarth" X="135" Y="54" CityLocaleName="LOC_CITY_NAME_CULIACAN" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="54" CityLocaleName="LOC_CITY_NAME_CULIACAN" Area="0" />
 		<Replace MapName="GiantEarth" X="137" Y="54" CityLocaleName="LOC_CITY_NAME_DURANGO" Area="0" />
 		<Replace MapName="GiantEarth" X="139" Y="54" CityLocaleName="LOC_CITY_NAME_MONTERREY" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="134" Y="55" CityLocaleName="LOC_CITY_NAME_LOS_MOCHIS" Area="0" />
 		<Replace MapName="GiantEarth" X="135" Y="55" CityLocaleName="LOC_CITY_NAME_LOS_MOCHIS" Area="0" />
 		<Replace MapName="GiantEarth" X="136" Y="55" CityLocaleName="LOC_CITY_NAME_DURANGO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="135" Y="56" CityLocaleName="LOC_CITY_NAME_HERMOSILLO" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="131" Y="57" CityLocaleName="LOC_CITY_NAME_TIJUANA" Area="1" />
 		<Replace MapName="GiantEarth" X="133" Y="57" CityLocaleName="LOC_CITY_NAME_MEXICALI" Area="0" />
 		<Replace MapName="GiantEarth" X="137" Y="57" CityLocaleName="LOC_CITY_NAME_CHIHUAHUA" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="133" Y="58" CityLocaleName="LOC_CITY_NAME_MEXICALI" Area="0" />
-		
+
 		<!-- CENTRAL AMERICA -->
-		
+
 		<Replace MapName="GiantEarth" X="150" Y="40" CityLocaleName="LOC_CITY_NAME_PANAMA_CITY" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="148" Y="41" CityLocaleName="LOC_CITY_NAME_SAN_JOSE_COSTA_RICA" Area="1" />
 		<Replace MapName="GiantEarth" X="149" Y="41" CityLocaleName="LOC_CITY_NAME_PANAMA_CITY" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="148" Y="42" CityLocaleName="LOC_CITY_NAME_MANAGUA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="147" Y="43" CityLocaleName="LOC_CITY_NAME_TEGUCIGALPA" Area="1" />
 		<Replace MapName="GiantEarth" X="148" Y="43" CityLocaleName="LOC_CITY_NAME_MANAGUA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="145" Y="44" CityLocaleName="LOC_CITY_NAME_GUATEMALA" Area="1" />
 		<Replace MapName="GiantEarth" X="149" Y="44" CityLocaleName="LOC_CITY_NAME_MOSQUITO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="45" CityLocaleName="LOC_CITY_NAME_SAN_PEDRO_SULA" Area="0" />
 		<Replace MapName="GiantEarth" X="147" Y="45" CityLocaleName="LOC_CITY_NAME_SAN_PEDRO_SULA" Area="0" />
 		<Replace MapName="GiantEarth" X="148" Y="45" CityLocaleName="LOC_CITY_NAME_MOSQUITO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="146" Y="46" CityLocaleName="LOC_CITY_NAME_BELIZE_CITY" Area="1" />
-		
+
 	</CityMap>
-	
+
 	<!-- SOUTH AMERICA & CARIBBEAN -->
 	<CityMap>
-		
+
 		<!-- SOUTH AMERICA -->
 		<Replace MapName="GiantEarth" X="157" Y="1" CityLocaleName="LOC_CITY_NAME_USHUAIA" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="1" CityLocaleName="LOC_CITY_NAME_QUIQUE" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="1" CityLocaleName="LOC_CITY_NAME_TOLHUIN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="156" Y="2" CityLocaleName="LOC_CITY_NAME_ESTANCIA_SAN_PABLO" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="2" CityLocaleName="LOC_CITY_NAME_TIMAUKEL" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="155" Y="3" CityLocaleName="LOC_CITY_NAME_RIO_GRANDE" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="3" CityLocaleName="LOC_CITY_NAME_PUERTO_NATALES" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="4" CityLocaleName="LOC_CITY_NAME_NATALES" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="4" CityLocaleName="LOC_CITY_NAME_LA_MANCHURIA_ARGENTINA" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="4" CityLocaleName="LOC_CITY_NAME_PUNTA_BUQUE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="5" CityLocaleName="LOC_CITY_NAME_COCHRANE" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="5" CityLocaleName="LOC_CITY_NAME_BAJO_CARACOLES" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="5" CityLocaleName="LOC_CITY_NAME_CALETA_OLIVIA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="6" CityLocaleName="LOC_CITY_NAME_PUERTO_RIO_TRANQUILO" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="6" CityLocaleName="LOC_CITY_NAME_LAS_HERAS" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="6" CityLocaleName="LOC_CITY_NAME_PICO_TRUNCADO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="156" Y="7" CityLocaleName="LOC_CITY_NAME_COMODORO_RIVADAVIA" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="8" CityLocaleName="LOC_CITY_NAME_GUAITECAS" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="8" CityLocaleName="LOC_CITY_NAME_RIO_PICO" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="8" CityLocaleName="LOC_CITY_NAME_CABO_RASO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="9" CityLocaleName="LOC_CITY_NAME_CASTRO" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="9" CityLocaleName="LOC_CITY_NAME_CUSHAMEN" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="9" CityLocaleName="LOC_CITY_NAME_TELSEN" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="9" CityLocaleName="LOC_CITY_NAME_PUERTO_MADRYN" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="10" CityLocaleName="LOC_CITY_NAME_PUERTO_MONTT" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="10" CityLocaleName="LOC_CITY_NAME_EL_CAIN" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="10" CityLocaleName="LOC_CITY_NAME_ARROYO_DE_LA_VENTANA" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="10" CityLocaleName="LOC_CITY_NAME_SIERRA_GRANDE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="11" CityLocaleName="LOC_CITY_NAME_TEMUCO" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="11" CityLocaleName="LOC_CITY_NAME_ZAPALA" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="11" CityLocaleName="LOC_CITY_NAME_CIPOLLETTI" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="11" CityLocaleName="LOC_CITY_NAME_SAN_ANTONIO" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="11" CityLocaleName="LOC_CITY_NAME_VIEDMA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="12" CityLocaleName="LOC_CITY_NAME_CONCEPCION" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="12" CityLocaleName="LOC_CITY_NAME_CHOS_MALAL" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="12" CityLocaleName="LOC_CITY_NAME_SANTA_ROSA" Area="1" />
 		<Replace MapName="GiantEarth" X="160" Y="12" CityLocaleName="LOC_CITY_NAME_MAR_DEL_PLATA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="13" CityLocaleName="LOC_CITY_NAME_CONSTITUCION" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="13" CityLocaleName="LOC_CITY_NAME_TALCA" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="13" CityLocaleName="LOC_CITY_NAME_MALARGUE" Area="0" />
@@ -3609,25 +4240,25 @@
 		<Replace MapName="GiantEarth" X="158" Y="13" CityLocaleName="LOC_CITY_NAME_TRENQUE_LAUQUEN" Area="0" />
 		<Replace MapName="GiantEarth" X="159" Y="13" CityLocaleName="LOC_CITY_NAME_AZUL" Area="0" />
 		<Replace MapName="GiantEarth" X="160" Y="13" CityLocaleName="LOC_CITY_NAME_SANTA_TERESITA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="157" Y="14" CityLocaleName="LOC_CITY_NAME_SAN_RAFAEL" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="14" CityLocaleName="LOC_CITY_NAME_LOMAS_DE_ZAMORA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="15" CityLocaleName="LOC_CITY_NAME_SANTIAGO_CHILE" Area="1" />
 		<Replace MapName="GiantEarth" X="156" Y="15" CityLocaleName="LOC_CITY_NAME_SAN_LUIS" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="15" CityLocaleName="LOC_CITY_NAME_MERCEDES" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="156" Y="16" CityLocaleName="LOC_CITY_NAME_SAN_JUAN_ARGERNTINA" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="16" CityLocaleName="LOC_CITY_NAME_CORDOVA" Area="1" />
 		<Replace MapName="GiantEarth" X="161" Y="16" CityLocaleName="LOC_CITY_NAME_MONTEVIDEO" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="17" CityLocaleName="LOC_CITY_NAME_HUASCO" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="17" CityLocaleName="LOC_CITY_NAME_VALLENAR" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="17" CityLocaleName="LOC_CITY_NAME_SANTIAGO_DEL_ESTERO" Area="0" />
 		<Replace MapName="GiantEarth" X="159" Y="17" CityLocaleName="LOC_CITY_NAME_CORRIENTES" Area="0" />
 		<Replace MapName="GiantEarth" X="160" Y="17" CityLocaleName="LOC_CITY_NAME_SANTA_MARIA" Area="0" />
 		<Replace MapName="GiantEarth" X="162" Y="17" CityLocaleName="LOC_CITY_NAME_PORTO_ALEGRE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="156" Y="18" CityLocaleName="LOC_CITY_NAME_FIAMBALA" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="18" CityLocaleName="LOC_CITY_NAME_SAN_MIGUEL_DE_TUCUMAN" Area="0" />
 		<Replace MapName="GiantEarth" X="159" Y="18" CityLocaleName="LOC_CITY_NAME_SAENZ_PENA" Area="0" />
@@ -3636,7 +4267,7 @@
 		<Replace MapName="GiantEarth" X="162" Y="18" CityLocaleName="LOC_CITY_NAME_LAGES" Area="0" />
 		<Replace MapName="GiantEarth" X="163" Y="18" CityLocaleName="LOC_CITY_NAME_BRUSQUE" Area="0" />
 		<Replace MapName="GiantEarth" X="164" Y="18" CityLocaleName="LOC_CITY_NAME_FLORIANOPOLIS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="19" CityLocaleName="LOC_CITY_NAME_ANTOFAGASTA" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="19" CityLocaleName="LOC_CITY_NAME_SALTA" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="19" CityLocaleName="LOC_CITY_NAME_SAN_PEDRO_DE_JUJUY" Area="0" />
@@ -3644,8 +4275,8 @@
 		<Replace MapName="GiantEarth" X="160" Y="19" CityLocaleName="LOC_CITY_NAME_ASUNCION" Area="1" />
 		<Replace MapName="GiantEarth" X="162" Y="19" CityLocaleName="LOC_CITY_NAME_FOZ_DO_IGUACU" Area="0" />
 		<Replace MapName="GiantEarth" X="164" Y="19" CityLocaleName="LOC_CITY_NAME_CURITIBA" Area="1" />
-		
-		<Replace MapName="GiantEarth" X="155" Y="20" CityLocaleName="LOC_CITY_NAME_TOCOPILLA" Area="0" />		
+
+		<Replace MapName="GiantEarth" X="155" Y="20" CityLocaleName="LOC_CITY_NAME_TOCOPILLA" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="20" CityLocaleName="LOC_CITY_NAME_CALAMA" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="20" CityLocaleName="LOC_CITY_NAME_TARIJA" Area="0" />
 		<Replace MapName="GiantEarth" X="159" Y="20" CityLocaleName="LOC_CITY_NAME_LOMA_PLATA" Area="0" />
@@ -3654,7 +4285,7 @@
 		<Replace MapName="GiantEarth" X="163" Y="20" CityLocaleName="LOC_CITY_NAME_SAO_PAULO" Area="1" />
 		<Replace MapName="GiantEarth" X="165" Y="20" CityLocaleName="LOC_CITY_NAME_SANTOS" Area="0" />
 		<Replace MapName="GiantEarth" X="166" Y="20" CityLocaleName="LOC_CITY_NAME_GUARUJA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="21" CityLocaleName="LOC_CITY_NAME_IQUIQUE" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="21" CityLocaleName="LOC_CITY_NAME_UYUNI" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="21" CityLocaleName="LOC_CITY_NAME_DOURADOS" Area="0" />
@@ -3671,7 +4302,7 @@
 		<Replace MapName="GiantEarth" X="163" Y="22" CityLocaleName="LOC_CITY_NAME_RIBEIRAO_PRETO" Area="0" />
 		<Replace MapName="GiantEarth" X="164" Y="22" CityLocaleName="LOC_CITY_NAME_VOLTA_REDONDA" Area="0" />
 		<Replace MapName="GiantEarth" X="165" Y="22" CityLocaleName="LOC_CITY_NAME_DUKE_OF_CAXIAS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="23" CityLocaleName="LOC_CITY_NAME_IQUIQUE" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="23" CityLocaleName="LOC_CITY_NAME_POTOSI" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="23" CityLocaleName="LOC_CITY_NAME_MONTEAGUDO" Area="0" />
@@ -3683,7 +4314,7 @@
 		<Replace MapName="GiantEarth" X="164" Y="23" CityLocaleName="LOC_CITY_NAME_VENDA_NOVA_DO_IMIGRANTE" Area="0" />
 		<Replace MapName="GiantEarth" X="165" Y="23" CityLocaleName="LOC_CITY_NAME_TERESOPOLIS" Area="0" />
 		<Replace MapName="GiantEarth" X="168" Y="23" CityLocaleName="LOC_CITY_NAME_VICTORY_BRAZIL" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="24" CityLocaleName="LOC_CITY_NAME_NAZCA" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="24" CityLocaleName="LOC_CITY_NAME_YAURI" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="24" CityLocaleName="LOC_CITY_NAME_TRINIDAD" Area="0" />
@@ -3697,7 +4328,7 @@
 		<Replace MapName="GiantEarth" X="167" Y="24" CityLocaleName="LOC_CITY_NAME_ALMENARA" Area="0" />
 		<Replace MapName="GiantEarth" X="168" Y="24" CityLocaleName="LOC_CITY_NAME_EUNAPOLIS" Area="0" />
 		<Replace MapName="GiantEarth" X="169" Y="24" CityLocaleName="LOC_CITY_NAME_PORTO_SEGURO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="25" CityLocaleName="LOC_CITY_NAME_PARACAS" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="25" CityLocaleName="LOC_CITY_NAME_ABANCAY" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="25" CityLocaleName="LOC_CITY_NAME_CUSCO" Area="0" />
@@ -3709,7 +4340,7 @@
 		<Replace MapName="GiantEarth" X="165" Y="25" CityLocaleName="LOC_CITY_NAME_GUANAMBI" Area="0" />
 		<Replace MapName="GiantEarth" X="166" Y="25" CityLocaleName="LOC_CITY_NAME_VITORIA_DA_CONQUISTA" Area="0" />
 		<Replace MapName="GiantEarth" X="167" Y="25" CityLocaleName="LOC_CITY_NAME_VERA_CRUZ" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="26" CityLocaleName="LOC_CITY_NAME_EL_CALLAO" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="26" CityLocaleName="LOC_CITY_NAME_LIMA" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="26" CityLocaleName="LOC_CITY_NAME_ATE" Area="0" />
@@ -3725,7 +4356,7 @@
 		<Replace MapName="GiantEarth" X="166" Y="26" CityLocaleName="LOC_CITY_NAME_CASTRO_ALVES" Area="0" />
 		<Replace MapName="GiantEarth" X="167" Y="26" CityLocaleName="LOC_CITY_NAME_FEIRA_DE_SANTANA" Area="0" />
 		<Replace MapName="GiantEarth" X="169" Y="26" CityLocaleName="LOC_CITY_NAME_SALVADOR" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="27" CityLocaleName="LOC_CITY_NAME_HUACHO" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="27" CityLocaleName="LOC_CITY_NAME_LA_MERCED" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="27" CityLocaleName="LOC_CITY_NAME_PUERTO_OCOPA" Area="0" />
@@ -3739,7 +4370,7 @@
 		<Replace MapName="GiantEarth" X="166" Y="27" CityLocaleName="LOC_CITY_NAME_XIQUE_XIQUE" Area="0" />
 		<Replace MapName="GiantEarth" X="167" Y="27" CityLocaleName="LOC_CITY_NAME_SR__DO_BONFIM" Area="0" />
 		<Replace MapName="GiantEarth" X="170" Y="27" CityLocaleName="LOC_CITY_NAME_ARACAJU" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="28" CityLocaleName="LOC_CITY_NAME_LA_GRAMITA" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="28" CityLocaleName="LOC_CITY_NAME_HUARAZ" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="28" CityLocaleName="LOC_CITY_NAME_SENA_MADUREIRA" Area="0" />
@@ -3757,8 +4388,8 @@
 		<Replace MapName="GiantEarth" X="169" Y="28" CityLocaleName="LOC_CITY_NAME_PAULO_AFONSO" Area="0" />
 		<Replace MapName="GiantEarth" X="170" Y="28" CityLocaleName="LOC_CITY_NAME_ARAPIRACA" Area="0" />
 		<Replace MapName="GiantEarth" X="171" Y="28" CityLocaleName="LOC_CITY_NAME_MACEIO" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="150" Y="29" CityLocaleName="LOC_CITY_NAME_CHIMBOTE" Area="0" />		
+
+		<Replace MapName="GiantEarth" X="150" Y="29" CityLocaleName="LOC_CITY_NAME_CHIMBOTE" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="29" CityLocaleName="LOC_CITY_NAME_PUCALLPA" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="29" CityLocaleName="LOC_CITY_NAME_FEIJO" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="29" CityLocaleName="LOC_CITY_NAME_LABREA" Area="0" />
@@ -3774,7 +4405,7 @@
 		<Replace MapName="GiantEarth" X="168" Y="29" CityLocaleName="LOC_CITY_NAME_CUMARU" Area="0" />
 		<Replace MapName="GiantEarth" X="169" Y="29" CityLocaleName="LOC_CITY_NAME_CARPINA" Area="0" />
 		<Replace MapName="GiantEarth" X="171" Y="29" CityLocaleName="LOC_CITY_NAME_RECIFE" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="30" CityLocaleName="LOC_CITY_NAME_TARAPOTO" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="30" CityLocaleName="LOC_CITY_NAME_SANTOA" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="30" CityLocaleName="LOC_CITY_NAME_FOGOSO" Area="0" />
@@ -3796,7 +4427,7 @@
 		<Replace MapName="GiantEarth" X="169" Y="30" CityLocaleName="LOC_CITY_NAME_CAMPINA_GRANDE" Area="0" />
 		<Replace MapName="GiantEarth" X="170" Y="30" CityLocaleName="LOC_CITY_NAME_SAPE" Area="0" />
 		<Replace MapName="GiantEarth" X="171" Y="30" CityLocaleName="LOC_CITY_NAME_JOAO_PESSOA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="31" CityLocaleName="LOC_CITY_NAME_CHICLAYO" Area="0" />
 		<Replace MapName="GiantEarth" X="151" Y="31" CityLocaleName="LOC_CITY_NAME_TABALOSOS" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="31" CityLocaleName="LOC_CITY_NAME_PONGO_DE_CAYNARACHI" Area="0" />
@@ -3818,7 +4449,7 @@
 		<Replace MapName="GiantEarth" X="168" Y="31" CityLocaleName="LOC_CITY_NAME_ACU" Area="0" />
 		<Replace MapName="GiantEarth" X="169" Y="31" CityLocaleName="LOC_CITY_NAME_SAO_GONCALO_DO_AMARANTE" Area="0" />
 		<Replace MapName="GiantEarth" X="170" Y="31" CityLocaleName="LOC_CITY_NAME_NATAL" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="150" Y="32" CityLocaleName="LOC_CITY_NAME_PIURA" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="32" CityLocaleName="LOC_CITY_NAME_NAUTA" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="32" CityLocaleName="LOC_CITY_NAME_LETICIA" Area="0" />
@@ -3837,7 +4468,7 @@
 		<Replace MapName="GiantEarth" X="166" Y="32" CityLocaleName="LOC_CITY_NAME_PENTECOST" Area="0" />
 		<Replace MapName="GiantEarth" X="167" Y="32" CityLocaleName="LOC_CITY_NAME_CAUCAIA" Area="0" />
 		<Replace MapName="GiantEarth" X="168" Y="32" CityLocaleName="LOC_CITY_NAME_FORTALEZA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="150" Y="33" CityLocaleName="LOC_CITY_NAME_MANTA" Area="0" />
 		<Replace MapName="GiantEarth" X="151" Y="33" CityLocaleName="LOC_CITY_NAME_AMBATO" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="33" CityLocaleName="LOC_CITY_NAME_IQUITOS" Area="0" />
@@ -3855,7 +4486,7 @@
 		<Replace MapName="GiantEarth" X="164" Y="33" CityLocaleName="LOC_CITY_NAME_PENALVA" Area="0" />
 		<Replace MapName="GiantEarth" X="165" Y="33" CityLocaleName="LOC_CITY_NAME_MATINHA" Area="0" />
 		<Replace MapName="GiantEarth" X="167" Y="33" CityLocaleName="LOC_CITY_NAME_SAO_LUIS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="150" Y="34" CityLocaleName="LOC_CITY_NAME_QUITO" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="34" CityLocaleName="LOC_CITY_NAME_FITATA" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="34" CityLocaleName="LOC_CITY_NAME_PUXURI" Area="0" />
@@ -3871,7 +4502,7 @@
 		<Replace MapName="GiantEarth" X="163" Y="34" CityLocaleName="LOC_CITY_NAME_PORTO_DE_MOZ" Area="0" />
 		<Replace MapName="GiantEarth" X="164" Y="34" CityLocaleName="LOC_CITY_NAME_ABAETETUBA" Area="0" />
 		<Replace MapName="GiantEarth" X="166" Y="34" CityLocaleName="LOC_CITY_NAME_BELEM" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="35" CityLocaleName="LOC_CITY_NAME_ESMERALDAS" Area="0" />
 		<Replace MapName="GiantEarth" X="151" Y="35" CityLocaleName="LOC_CITY_NAME_IBARRA" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="35" CityLocaleName="LOC_CITY_NAME_TARAPOA" Area="0" />
@@ -3881,7 +4512,7 @@
 		<Replace MapName="GiantEarth" X="159" Y="35" CityLocaleName="LOC_CITY_NAME_SETE_VARAS" Area="1" />
 		<Replace MapName="GiantEarth" X="162" Y="35" CityLocaleName="LOC_CITY_NAME_VAI_QUEM_QUER" Area="1" />
 		<Replace MapName="GiantEarth" X="164" Y="35" CityLocaleName="LOC_CITY_NAME_MACAPA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="36" CityLocaleName="LOC_CITY_NAME_BUENAVENTURA" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="36" CityLocaleName="LOC_CITY_NAME_CALI" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="36" CityLocaleName="LOC_CITY_NAME_NEIVA" Area="0" />
@@ -3893,7 +4524,7 @@
 		<Replace MapName="GiantEarth" X="162" Y="36" CityLocaleName="LOC_CITY_NAME_ARAQUA" Area="0" />
 		<Replace MapName="GiantEarth" X="163" Y="36" CityLocaleName="LOC_CITY_NAME_APOREMA" Area="0" />
 		<Replace MapName="GiantEarth" X="164" Y="36" CityLocaleName="LOC_CITY_NAME_BOM_AMIGO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="150" Y="37" CityLocaleName="LOC_CITY_NAME_NUQUI" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="37" CityLocaleName="LOC_CITY_NAME_MANIZALES" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="37" CityLocaleName="LOC_CITY_NAME_MEDELIN" Area="0" />
@@ -3905,7 +4536,7 @@
 		<Replace MapName="GiantEarth" X="162" Y="37" CityLocaleName="LOC_CITY_NAME_APETINA" Area="0" />
 		<Replace MapName="GiantEarth" X="163" Y="37" CityLocaleName="LOC_CITY_NAME_WEMPI" Area="0" />
 		<Replace MapName="GiantEarth" X="164" Y="37" CityLocaleName="LOC_CITY_NAME_AMAPA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="38" CityLocaleName="LOC_CITY_NAME_JURADO" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="38" CityLocaleName="LOC_CITY_NAME_SAN_CRISTOBAL" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="38" CityLocaleName="LOC_CITY_NAME_SANTA_BARBARA" Area="0" />
@@ -3914,7 +4545,7 @@
 		<Replace MapName="GiantEarth" X="162" Y="38" CityLocaleName="LOC_CITY_NAME_GODDO" Area="0" />
 		<Replace MapName="GiantEarth" X="163" Y="38" CityLocaleName="LOC_CITY_NAME_SOPHIE" Area="0" />
 		<Replace MapName="GiantEarth" X="164" Y="38" CityLocaleName="LOC_CITY_NAME_CAIENA" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="39" CityLocaleName="LOC_CITY_NAME_SALAQUI" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="39" CityLocaleName="LOC_CITY_NAME_BUCARAMANGA" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="39" CityLocaleName="LOC_CITY_NAME_PUERTO_CARRENO" Area="0" />
@@ -3924,7 +4555,7 @@
 		<Replace MapName="GiantEarth" X="159" Y="39" CityLocaleName="LOC_CITY_NAME_WAGENINGEN" Area="0" />
 		<Replace MapName="GiantEarth" X="160" Y="39" CityLocaleName="LOC_CITY_NAME_GRONINGEN" Area="0" />
 		<Replace MapName="GiantEarth" X="161" Y="39" CityLocaleName="LOC_CITY_NAME_PARAMARIBO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="40" CityLocaleName="LOC_CITY_NAME_RIOSUCIO" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="40" CityLocaleName="LOC_CITY_NAME_LA_ENGANERA" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="40" CityLocaleName="LOC_CITY_NAME_SANTA_BARBARA_DE_ZULIA" Area="0" />
@@ -3934,48 +4565,48 @@
 		<Replace MapName="GiantEarth" X="159" Y="40" CityLocaleName="LOC_CITY_NAME_ZARAZA" Area="0" />
 		<Replace MapName="GiantEarth" X="160" Y="40" CityLocaleName="LOC_CITY_NAME_PUERTO_LA_CRUZ" Area="0" />
 		<Replace MapName="GiantEarth" X="161" Y="40" CityLocaleName="LOC_CITY_NAME_CARUPANO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="41" CityLocaleName="LOC_CITY_NAME_BARRANQUILLA" Area="0" />
 		<Replace MapName="GiantEarth" X="153" Y="41" CityLocaleName="LOC_CITY_NAME_MALAMBO" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="41" CityLocaleName="LOC_CITY_NAME_CIENAGA" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="41" CityLocaleName="LOC_CITY_NAME_SAN_FELIPE" Area="0" />
 		<Replace MapName="GiantEarth" X="157" Y="41" CityLocaleName="LOC_CITY_NAME_CARACAS" Area="0" />
 		<Replace MapName="GiantEarth" X="158" Y="41" CityLocaleName="LOC_CITY_NAME_PORLAMAR" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="154" Y="42" CityLocaleName="LOC_CITY_NAME_MARACAIBO" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="42" CityLocaleName="LOC_CITY_NAME_PUNTO_FIJO" Area="0" />
 
 		<!-- CUBA -->
-		
+
 		<Replace MapName="GiantEarth" X="153" Y="48" CityLocaleName="LOC_CITY_NAME_GUANTANAMO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="152" Y="49" CityLocaleName="LOC_CITY_NAME_LAS_TUNAS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="151" Y="50" CityLocaleName="LOC_CITY_NAME_MATANZAS" Area="0" />
 		<Replace MapName="GiantEarth" X="152" Y="50" CityLocaleName="LOC_CITY_NAME_VARADERO" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="149" Y="51" CityLocaleName="LOC_CITY_NAME_HAVANA" Area="1" />
 
 		<!-- ISLANDS -->
-		
+
 		<Replace MapName="GiantEarth" X="161" Y="4" CityLocaleName="LOC_CITY_NAME_PORT_STEPHENS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="161" Y="5" CityLocaleName="LOC_CITY_NAME_PORTO_SAN_CARLOS" Area="0" />
-		
+
 		<Replace MapName="GiantEarth" X="161" Y="44" CityLocaleName="LOC_CITY_NAME_US_VIRGIN_ISLANDS" Area="0" />
-		
-		<Replace MapName="GiantEarth" X="161" Y="46" CityLocaleName="LOC_CITY_NAME_BRITISH_VIRGIN_ISLANDS" Area="0" />	
-		<Replace MapName="GiantEarth" X="153" Y="46" CityLocaleName="LOC_CITY_NAME_KINGSTON_JAMAICA" Area="0" />		
-		<Replace MapName="GiantEarth" X="152" Y="46" CityLocaleName="LOC_CITY_NAME_BLACK_RIVER" Area="0" />		
-		<Replace MapName="GiantEarth" X="159" Y="46" CityLocaleName="LOC_CITY_NAME_PONCE" Area="0" />	
+
+		<Replace MapName="GiantEarth" X="161" Y="46" CityLocaleName="LOC_CITY_NAME_BRITISH_VIRGIN_ISLANDS" Area="0" />
+		<Replace MapName="GiantEarth" X="153" Y="46" CityLocaleName="LOC_CITY_NAME_KINGSTON_JAMAICA" Area="0" />
+		<Replace MapName="GiantEarth" X="152" Y="46" CityLocaleName="LOC_CITY_NAME_BLACK_RIVER" Area="0" />
+		<Replace MapName="GiantEarth" X="159" Y="46" CityLocaleName="LOC_CITY_NAME_PONCE" Area="0" />
 		<Replace MapName="GiantEarth" X="155" Y="46" CityLocaleName="LOC_CITY_NAME_PORT_PRINCE" Area="1" />
-		
+
 		<Replace MapName="GiantEarth" X="159" Y="47" CityLocaleName="LOC_CITY_NAME_SAN_JUAN_PUERTO_RICO" Area="0" />
 		<Replace MapName="GiantEarth" X="156" Y="47" CityLocaleName="LOC_CITY_NAME_SANTO_DOMINGO" Area="1" />
-		
-		<Replace MapName="GiantEarth" X="154" Y="51" CityLocaleName="LOC_CITY_NAME_BAHAMAS" Area="0" />		
+
+		<Replace MapName="GiantEarth" X="154" Y="51" CityLocaleName="LOC_CITY_NAME_BAHAMAS" Area="0" />
 		<Replace MapName="GiantEarth" X="154" Y="51" CityLocaleName="LOC_CITY_NAME_INAGUA_ISLANDS" Area="0" />
 
 	</CityMap>
-	
+
 </GameData>

--- a/Maps/GiantEarth/CityMap_Egypt.xml
+++ b/Maps/GiantEarth/CityMap_Egypt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+
+	<!-- ++++++++++++++++++++++++++++++++++++ -->
+	<!-- "Giant Earth Map" City Map for Egypt -->
+	<!-- ++++++++++++++++++++++++++++++++++++ -->
+
+
+
+	<!-- +++++++++++++++ -->
+	<!-- Africa City Map -->
+	<!-- +++++++++++++++ -->
+
+
+	<!-- EASTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="33" Y="38" CityLocaleName="LOC_CITY_NAME_MEROE" Area="0" Civilization="CIVILIZATION_EGYPT" />
+
+		<Replace MapName="GiantEarth" X="32" Y="46" CityLocaleName="LOC_CITY_NAME_EL_QUSEIR" Area="0" Civilization="CIVILIZATION_EGYPT" />
+
+		<Replace MapName="GiantEarth" X="31" Y="47" CityLocaleName="LOC_CITY_NAME_ISMAILIA" Area="0" Civilization="CIVILIZATION_EGYPT" />
+
+		<Replace MapName="GiantEarth" X="27" Y="49" CityLocaleName="LOC_CITY_NAME_BAYDA" Area="0" Civilization="CIVILIZATION_EGYPT" />
+
+	</CityMap>
+
+</GameData>

--- a/Maps/GiantEarth/CityMap_Greece.xml
+++ b/Maps/GiantEarth/CityMap_Greece.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+
+	<!-- +++++++++++++++++++++++++++++++++++++ -->
+	<!-- "Giant Earth Map" City Map for Greece -->
+	<!-- +++++++++++++++++++++++++++++++++++++ -->
+
+
+
+	<!-- +++++++++++++++ -->
+	<!-- Africa City Map -->
+	<!-- +++++++++++++++ -->
+
+
+	<!-- CENTRAL & EAST AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="36" Y="35" CityLocaleName="LOC_CITY_NAME_ZEILA" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+		<Replace MapName="GiantEarth" X="36" Y="36" CityLocaleName="LOC_CITY_NAME_ZEILA" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+	</CityMap>
+
+	<!-- WESTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="7" Y="49" CityLocaleName="LOC_CITY_NAME_MEKNES" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+		<Replace MapName="GiantEarth" X="8" Y="50" CityLocaleName="LOC_CITY_NAME_MELILLA" Area="0" Civilization="CIVILIZATION_GREECE" />
+		<Replace MapName="GiantEarth" X="9" Y="50" CityLocaleName="LOC_CITY_NAME_MELILLA" Area="0" Civilization="CIVILIZATION_GREECE" />
+		<Replace MapName="GiantEarth" X="10" Y="50" CityLocaleName="LOC_CITY_NAME_SIGA" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+		<Replace MapName="GiantEarth" X="10" Y="51" CityLocaleName="LOC_CITY_NAME_MOSTAGANEM" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+	</CityMap>
+
+	<!-- EASTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="33" Y="38" CityLocaleName="LOC_CITY_NAME_MEROE" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+		<Replace MapName="GiantEarth" X="32" Y="46" CityLocaleName="LOC_CITY_NAME_EL_QUSEIR" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+		<Replace MapName="GiantEarth" X="31" Y="47" CityLocaleName="LOC_CITY_NAME_ISMAILIA" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+		<Replace MapName="GiantEarth" X="20" Y="49" CityLocaleName="LOC_CITY_NAME_AL_KHUMS" Area="0" Civilization="CIVILIZATION_GREECE" />
+		<Replace MapName="GiantEarth" X="27" Y="49" CityLocaleName="LOC_CITY_NAME_BAYDA" Area="0" Civilization="CIVILIZATION_GREECE" />
+
+	</CityMap>
+
+</GameData>

--- a/Maps/GiantEarth/CityMap_Nubia.xml
+++ b/Maps/GiantEarth/CityMap_Nubia.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+
+	<!-- ++++++++++++++++++++++++++++++++++++ -->
+	<!-- "Giant Earth Map" City Map for Nubia -->
+	<!-- ++++++++++++++++++++++++++++++++++++ -->
+
+
+
+	<!-- +++++++++++++++ -->
+	<!-- Africa City Map -->
+	<!-- +++++++++++++++ -->
+
+
+	<!-- EASTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="33" Y="38" CityLocaleName="LOC_CITY_NAME_MEROE" Area="0" Civilization="CIVILIZATION_NUBIA" />
+
+		<Replace MapName="GiantEarth" X="32" Y="46" CityLocaleName="LOC_CITY_NAME_EL_QUSEIR" Area="0" Civilization="CIVILIZATION_NUBIA" />
+
+		<Replace MapName="GiantEarth" X="31" Y="47" CityLocaleName="LOC_CITY_NAME_ISMAILIA" Area="0" Civilization="CIVILIZATION_NUBIA" />
+
+		<Replace MapName="GiantEarth" X="27" Y="49" CityLocaleName="LOC_CITY_NAME_BAYDA" Area="0" Civilization="CIVILIZATION_NUBIA" />
+
+	</CityMap>
+
+</GameData>

--- a/Maps/GiantEarth/CityMap_Rome.xml
+++ b/Maps/GiantEarth/CityMap_Rome.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+
+	<!-- +++++++++++++++++++++++++++++++++++ -->
+	<!-- "Giant Earth Map" City Map for Rome -->
+	<!-- +++++++++++++++++++++++++++++++++++ -->
+
+
+
+	<!-- +++++++++++++++ -->
+	<!-- Africa City Map -->
+	<!-- +++++++++++++++ -->
+
+
+	<!-- CENTRAL & EAST AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="36" Y="35" CityLocaleName="LOC_CITY_NAME_ZEILA" Area="0" Civilization="CIVILIZATION_ROME" />
+
+		<Replace MapName="GiantEarth" X="36" Y="36" CityLocaleName="LOC_CITY_NAME_ZEILA" Area="0" Civilization="CIVILIZATION_ROME" />
+
+	</CityMap>
+
+	<!-- WESTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="7" Y="49" CityLocaleName="LOC_CITY_NAME_MEKNES" Area="0" Civilization="CIVILIZATION_ROME" />
+
+		<Replace MapName="GiantEarth" X="8" Y="50" CityLocaleName="LOC_CITY_NAME_MELILLA" Area="0" Civilization="CIVILIZATION_ROME" />
+		<Replace MapName="GiantEarth" X="9" Y="50" CityLocaleName="LOC_CITY_NAME_MELILLA" Area="0" Civilization="CIVILIZATION_ROME" />
+		<Replace MapName="GiantEarth" X="10" Y="50" CityLocaleName="LOC_CITY_NAME_PORTUS_SIGENSIS" Area="0" Civilization="CIVILIZATION_ROME" />
+
+		<Replace MapName="GiantEarth" X="10" Y="51" CityLocaleName="LOC_CITY_NAME_MOSTAGANEM" Area="0" Civilization="CIVILIZATION_ROME" />
+		<Replace MapName="GiantEarth" X="13" Y="51" CityLocaleName="LOC_CITY_NAME_RAPIDUM" Area="0" Civilization="CIVILIZATION_ROME" />
+
+	</CityMap>
+
+	<!-- EASTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="33" Y="38" CityLocaleName="LOC_CITY_NAME_MEROE" Area="0" Civilization="CIVILIZATION_ROME" />
+
+		<Replace MapName="GiantEarth" X="30" Y="41" CityLocaleName="LOC_CITY_NAME_CATARACTA_TERTIA" Area="0" Civilization="CIVILIZATION_ROME" />
+		<Replace MapName="GiantEarth" X="32" Y="41" CityLocaleName="LOC_CITY_NAME_CATARACTA_QUARTA" Area="0" Civilization="CIVILIZATION_ROME" />
+
+		<Replace MapName="GiantEarth" X="32" Y="46" CityLocaleName="LOC_CITY_NAME_EL_QUSEIR" Area="0" Civilization="CIVILIZATION_ROME" />
+
+		<Replace MapName="GiantEarth" X="31" Y="47" CityLocaleName="LOC_CITY_NAME_ISMAILIA" Area="0" Civilization="CIVILIZATION_ROME" />
+
+		<Replace MapName="GiantEarth" X="20" Y="49" CityLocaleName="LOC_CITY_NAME_AL_KHUMS" Area="0" Civilization="CIVILIZATION_ROME" />
+		<Replace MapName="GiantEarth" X="27" Y="49" CityLocaleName="LOC_CITY_NAME_BAYDA" Area="0" Civilization="CIVILIZATION_ROME" />
+
+	</CityMap>
+
+</GameData>

--- a/Maps/GiantEarth/CityMap_Spain.xml
+++ b/Maps/GiantEarth/CityMap_Spain.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+
+	<!-- ++++++++++++++++++++++++++++++++++++ -->
+	<!-- "Giant Earth Map" City Map for Spain -->
+	<!-- ++++++++++++++++++++++++++++++++++++ -->
+
+
+
+	<!-- +++++++++++++++ -->
+	<!-- Africa City Map -->
+	<!-- +++++++++++++++ -->
+
+
+	<!-- WESTERN NORTH AFRICA -->
+	<CityMap>
+
+		<Replace MapName="GiantEarth" X="9" Y="50" CityLocaleName="LOC_CITY_NAME_MELILLA" Area="0" Civilization="CIVILIZATION_SPAIN" />
+
+	</CityMap>
+
+</GameData>

--- a/Maps/PlayEuropeAgain/CityMap.xml
+++ b/Maps/PlayEuropeAgain/CityMap.xml
@@ -2,34 +2,34 @@
 <GameData>
 
 		<!--
-		
+
 		* WHEN NO AREA DEFAULT IS AREA="1"
-		
+
 		* COMMENT "OVERLAP" MEANS THIS TILE IS 0 RANGE AND PURE TO EMPHESIZE THIS NAME ON THIS TILE, BECAUSE
 		  SEVERAL RANGES FROM DIFFERENT NAMES OVERLAP THIS TILE (DEPRICATED, ONLY LEFT FOR EVENTUAL DEBUG NEEDS)
-		  
+
 		-->
 
 	<CityMap> <!-- FRANCE -->
 		<Replace MapName="PlayEuropeAgain" X="29" Y="40" CityLocaleName="LOC_CITY_NAME_PERPIGNAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="34" Y="40" CityLocaleName="LOC_CITY_NAME_MARSEILLE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="28" Y="41" CityLocaleName="LOC_CITY_NAME_CARCASSONNE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="41" CityLocaleName="LOC_CITY_NAME_ARLES" />
 		<Replace MapName="PlayEuropeAgain" X="36" Y="41" CityLocaleName="LOC_CITY_NAME_NICE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="30" Y="42" CityLocaleName="LOC_CITY_NAME_MONTPELLIER" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="42" CityLocaleName="LOC_CITY_NAME_MONTPELLIER"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="32" Y="42" CityLocaleName="LOC_CITY_NAME_NIMES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="33" Y="42" CityLocaleName="LOC_CITY_NAME_NIMES" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="43" CityLocaleName="LOC_CITY_NAME_LOURDES" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="43" CityLocaleName="LOC_CITY_NAME_TOULOUSE"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="27" Y="43" CityLocaleName="LOC_CITY_NAME_TOULOUSE" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="43" CityLocaleName="LOC_CITY_NAME_MONTPELLIER"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="32" Y="43" CityLocaleName="LOC_CITY_NAME_NIMES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="34" Y="43" CityLocaleName="LOC_CITY_NAME_AVIGNON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="24" Y="44" CityLocaleName="LOC_CITY_NAME_BAYONNE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="44" CityLocaleName="LOC_CITY_NAME_ALBI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="44" CityLocaleName="LOC_CITY_NAME_SAINT_ETIENNE" />
@@ -41,13 +41,13 @@
 		<Replace MapName="PlayEuropeAgain" X="32" Y="45" CityLocaleName="LOC_CITY_NAME_LYON" />
 		<Replace MapName="PlayEuropeAgain" X="34" Y="45" CityLocaleName="LOC_CITY_NAME_GRENOBLE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="35" Y="45" CityLocaleName="LOC_CITY_NAME_GRENOBLE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="46" CityLocaleName="LOC_CITY_NAME_BORDEAUX" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="46" CityLocaleName="LOC_CITY_NAME_LIMOGES" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="46" CityLocaleName="LOC_CITY_NAME_LIMOGES"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="30" Y="46" CityLocaleName="LOC_CITY_NAME_VICHY" />
 		<Replace MapName="PlayEuropeAgain" X="34" Y="46" CityLocaleName="LOC_CITY_NAME_LONS_LE_SAUNIER" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="47" CityLocaleName="LOC_CITY_NAME_ROCHEFORT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="47" CityLocaleName="LOC_CITY_NAME_POITIERS"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="30" Y="47" CityLocaleName="LOC_CITY_NAME_BOURGES"  Area="0" /> <!-- OVERLAP -->
@@ -62,23 +62,23 @@
 		<Replace MapName="PlayEuropeAgain" X="34" Y="48" CityLocaleName="LOC_CITY_NAME_DIJON" />
 		<Replace MapName="PlayEuropeAgain" X="35" Y="48" CityLocaleName="LOC_CITY_NAME_BESANCON"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="37" Y="48" CityLocaleName="LOC_CITY_NAME_MULHOUSE"  Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="49" CityLocaleName="LOC_CITY_NAME_LA_ROCHELLE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="49" CityLocaleName="LOC_CITY_NAME_POITIERS"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="28" Y="49" CityLocaleName="LOC_CITY_NAME_TOURS" />
 		<Replace MapName="PlayEuropeAgain" X="32" Y="49" CityLocaleName="LOC_CITY_NAME_AUXERRE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="50" CityLocaleName="LOC_CITY_NAME_LA_ROCHELLE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="50" CityLocaleName="LOC_CITY_NAME_BLOIS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="33" Y="50" CityLocaleName="LOC_CITY_NAME_SENS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="34" Y="50" CityLocaleName="LOC_CITY_NAME_SENS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="36" Y="50" CityLocaleName="LOC_CITY_NAME_TROYES" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="26" Y="51" CityLocaleName="LOC_CITY_NAME_NANTES" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="51" CityLocaleName="LOC_CITY_NAME_BLOIS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="51" CityLocaleName="LOC_CITY_NAME_ORLEANS" />
 		<Replace MapName="PlayEuropeAgain" X="38" Y="51" CityLocaleName="LOC_CITY_NAME_STRASBOURG" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="52" CityLocaleName="LOC_CITY_NAME_SAINT_NAZAIRE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="52" CityLocaleName="LOC_CITY_NAME_RENNES"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="28" Y="52" CityLocaleName="LOC_CITY_NAME_RENNES"  Area="0" /> <!-- OVERLAP -->
@@ -86,7 +86,7 @@
 		<Replace MapName="PlayEuropeAgain" X="34" Y="52" CityLocaleName="LOC_CITY_NAME_PARIS" />
 		<Replace MapName="PlayEuropeAgain" X="36" Y="52" CityLocaleName="LOC_CITY_NAME_CHALONS_EN_CHAMPAGNE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="38" Y="52" CityLocaleName="LOC_CITY_NAME_METZ"  Area="0" /> <!-- OVERLAP -->
-		
+
 		<Replace MapName="PlayEuropeAgain" X="24" Y="53" CityLocaleName="LOC_CITY_NAME_SAINT_NAZAIRE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="25" Y="53" CityLocaleName="LOC_CITY_NAME_PONTIVY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="53" CityLocaleName="LOC_CITY_NAME_RENNES" />
@@ -94,7 +94,7 @@
 		<Replace MapName="PlayEuropeAgain" X="30" Y="53" CityLocaleName="LOC_CITY_NAME_ALENCON" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="35" Y="53" CityLocaleName="LOC_CITY_NAME_CHALONS_EN_CHAMPAGNE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="37" Y="53" CityLocaleName="LOC_CITY_NAME_METZ" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="23" Y="54" CityLocaleName="LOC_CITY_NAME_BREST" />
 		<Replace MapName="PlayEuropeAgain" X="25" Y="54" CityLocaleName="LOC_CITY_NAME_PONTIVY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="54" CityLocaleName="LOC_CITY_NAME_SAINT_BRIEUC" Area="0" />
@@ -104,7 +104,7 @@
 		<Replace MapName="PlayEuropeAgain" X="31" Y="54" CityLocaleName="LOC_CITY_NAME_CAEN"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="32" Y="54" CityLocaleName="LOC_CITY_NAME_ROUEN" />
 		<Replace MapName="PlayEuropeAgain" X="37" Y="54" CityLocaleName="LOC_CITY_NAME_REIMS"  Area="0" /> <!-- OVERLAP -->
-		
+
 		<Replace MapName="PlayEuropeAgain" X="24" Y="55" CityLocaleName="LOC_CITY_NAME_MORLAIX" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="25" Y="55" CityLocaleName="LOC_CITY_NAME_SAINT_BRIEUC" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="55" CityLocaleName="LOC_CITY_NAME_COUTANCES" Area="0" />
@@ -114,320 +114,319 @@
 		<Replace MapName="PlayEuropeAgain" X="34" Y="55" CityLocaleName="LOC_CITY_NAME_ARRAS" />
 		<Replace MapName="PlayEuropeAgain" X="35" Y="55" CityLocaleName="LOC_CITY_NAME_ARRAS"  Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="36" Y="55" CityLocaleName="LOC_CITY_NAME_REIMS" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="28" Y="56" CityLocaleName="LOC_CITY_NAME_CHERBOURG_OCTEVILLE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="56" CityLocaleName="LOC_CITY_NAME_CHERBOURG_OCTEVILLE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="32" Y="56" CityLocaleName="LOC_CITY_NAME_LE_HAVRE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="33" Y="56" CityLocaleName="LOC_CITY_NAME_AMIENS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="36" Y="56" CityLocaleName="LOC_CITY_NAME_SAINT_QUENTIN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="32" Y="57" CityLocaleName="LOC_CITY_NAME_CALAIS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="33" Y="57" CityLocaleName="LOC_CITY_NAME_DUNKERQUE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="34" Y="57" CityLocaleName="LOC_CITY_NAME_DUNKERQUE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="35" Y="57" CityLocaleName="LOC_CITY_NAME_LILLE" Area="0" />
-		
+
 	</CityMap>
 
 	<CityMap> <!-- ITALY, SICILY, SARDINIA, & CORSICA -->
-	
+
 		<!-- SICILY, SARDINIA, & CORSICA -->
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="19" CityLocaleName="LOC_CITY_NAME_VALLETTA" Area="0" />
-		
+		<Replace MapName="PlayEuropeAgain" X="42" Y="19" CityLocaleName="LOC_CITY_NAME_VALLETTA" Area="0" />
+
 		<Replace MapName="PlayEuropeAgain" X="43" Y="22" CityLocaleName="LOC_CITY_NAME_RAGUSA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="22" CityLocaleName="LOC_CITY_NAME_SIRACUSA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="41" Y="23" CityLocaleName="LOC_CITY_NAME_AGRIGENTO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="23" CityLocaleName="LOC_CITY_NAME_CALTANISSETTA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="23" CityLocaleName="LOC_CITY_NAME_ENNA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="23" CityLocaleName="LOC_CITY_NAME_CATANIA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="41" Y="24" CityLocaleName="LOC_CITY_NAME_MARSALA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="24" CityLocaleName="LOC_CITY_NAME_PALERMO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="24" CityLocaleName="LOC_CITY_NAME_PALERMO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="24" CityLocaleName="LOC_CITY_NAME_CAPO_DORLANDO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="24" CityLocaleName="LOC_CITY_NAME_MESSINA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="37" Y="30" CityLocaleName="LOC_CITY_NAME_CAGLIARI" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="30" CityLocaleName="LOC_CITY_NAME_CAGLIARI" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="37" Y="31" CityLocaleName="LOC_CITY_NAME_ORISTANO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="31" CityLocaleName="LOC_CITY_NAME_ARBATAX" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="32" CityLocaleName="LOC_CITY_NAME_ALGHERO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="39" Y="32" CityLocaleName="LOC_CITY_NAME_OLBIA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="37" Y="33" CityLocaleName="LOC_CITY_NAME_SASSARI" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="33" CityLocaleName="LOC_CITY_NAME_OLBIA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="35" CityLocaleName="LOC_CITY_NAME_BONIFACIO" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="36" CityLocaleName="LOC_CITY_NAME_AJACCIO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="39" Y="36" CityLocaleName="LOC_CITY_NAME_CORTE" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="37" CityLocaleName="LOC_CITY_NAME_CALVI" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="39" Y="37" CityLocaleName="LOC_CITY_NAME_BASTIA" Area="0" />
-        	
-        	<!-- ITALY (MAINLAND) -->
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="24" CityLocaleName="LOC_CITY_NAME_REGGIO_CALABRIA" Area="0" />
-        
-        	<Replace MapName="PlayEuropeAgain" X="48" Y="25" CityLocaleName="LOC_CITY_NAME_MONTELEONE" Area="0" />
-        
-        	<Replace MapName="PlayEuropeAgain" X="48" Y="26" CityLocaleName="LOC_CITY_NAME_CATANZARO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="49" Y="26" CityLocaleName="LOC_CITY_NAME_CROTONE" Area="0" />
-        
-        
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="27" CityLocaleName="LOC_CITY_NAME_COSENZA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="48" Y="27" CityLocaleName="LOC_CITY_NAME_CORIGLIANO_CALABRO" Area="0" />
-        
-        	<Replace MapName="PlayEuropeAgain" X="48" Y="28" CityLocaleName="LOC_CITY_NAME_CASTROVILLARI" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="52" Y="28" CityLocaleName="LOC_CITY_NAME_LECCE" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="29" CityLocaleName="LOC_CITY_NAME_ELEA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="29" CityLocaleName="LOC_CITY_NAME_GRUMENTO_NOVA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="51" Y="29" CityLocaleName="LOC_CITY_NAME_BRINDISI" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="30" CityLocaleName="LOC_CITY_NAME_SALERNO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="48" Y="30" CityLocaleName="LOC_CITY_NAME_POTENZA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="49" Y="30" CityLocaleName="LOC_CITY_NAME_POLICORO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="50" Y="30" CityLocaleName="LOC_CITY_NAME_TARANTO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="51" Y="30" CityLocaleName="LOC_CITY_NAME_BRINDISI" Area="0" />
-        
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="31" CityLocaleName="LOC_CITY_NAME_NAPOLI" />
-        	<Replace MapName="PlayEuropeAgain" X="48" Y="31" CityLocaleName="LOC_CITY_NAME_MELFI" Area="0"/>
-        	<Replace MapName="PlayEuropeAgain" X="49" Y="31" CityLocaleName="LOC_CITY_NAME_CANOSA" Area="0"/>
-        	<Replace MapName="PlayEuropeAgain" X="50" Y="31" CityLocaleName="LOC_CITY_NAME_BARI" Area="0"/>
-        	
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="32" CityLocaleName="LOC_CITY_NAME_LATINA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="32" CityLocaleName="LOC_CITY_NAME_BENEVENTO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="48" Y="32" CityLocaleName="LOC_CITY_NAME_LUCERA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="49" Y="32" CityLocaleName="LOC_CITY_NAME_FOGGIA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="33" CityLocaleName="LOC_CITY_NAME_ANTIUM" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="33" CityLocaleName="LOC_CITY_NAME_FROSINONE" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="33" CityLocaleName="LOC_CITY_NAME_ISERNIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="33" CityLocaleName="LOC_CITY_NAME_VASTO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="48" Y="33" CityLocaleName="LOC_CITY_NAME_SAN_SEVERO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="49" Y="33" CityLocaleName="LOC_CITY_NAME_VIESTE" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="34" CityLocaleName="LOC_CITY_NAME_ROMA" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="34" CityLocaleName="LOC_CITY_NAME_AQUILA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="34" CityLocaleName="LOC_CITY_NAME_PESCARA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="35" CityLocaleName="LOC_CITY_NAME_TARQUINIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="35" CityLocaleName="LOC_CITY_NAME_RIETI" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="35" CityLocaleName="LOC_CITY_NAME_SAN_BENEDETTO_DEL_TRONTO" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="36" CityLocaleName="LOC_CITY_NAME_GROSSETO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="36" CityLocaleName="LOC_CITY_NAME_VITERBO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="36" CityLocaleName="LOC_CITY_NAME_TERNI" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="36" CityLocaleName="LOC_CITY_NAME_FERMO" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="37" CityLocaleName="LOC_CITY_NAME_PIOMBINO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="37" CityLocaleName="LOC_CITY_NAME_SIENA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="37" CityLocaleName="LOC_CITY_NAME_PERUGIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="37" CityLocaleName="LOC_CITY_NAME_FOLIGNO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="37" CityLocaleName="LOC_CITY_NAME_ANCONA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="38" CityLocaleName="LOC_CITY_NAME_LIVORNO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="38" CityLocaleName="LOC_CITY_NAME_FIRENZE" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="38" CityLocaleName="LOC_CITY_NAME_AREZZO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="38" CityLocaleName="LOC_CITY_NAME_RIMINI" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="39" CityLocaleName="LOC_CITY_NAME_PISA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="39" CityLocaleName="LOC_CITY_NAME_FIRENZE" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="39" CityLocaleName="LOC_CITY_NAME_FAENZA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="39" CityLocaleName="LOC_CITY_NAME_RAVENNA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="40" CityLocaleName="LOC_CITY_NAME_PISA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="40" CityLocaleName="LOC_CITY_NAME_LUCCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="40" CityLocaleName="LOC_CITY_NAME_BOLOGNA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="40" CityLocaleName="LOC_CITY_NAME_FERRARA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="40" Y="41" CityLocaleName="LOC_CITY_NAME_LA_SPEZIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="41" Y="41" CityLocaleName="LOC_CITY_NAME_CARRARA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="41" CityLocaleName="LOC_CITY_NAME_PARMA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="41" CityLocaleName="LOC_CITY_NAME_MANTOVA" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="41" CityLocaleName="LOC_CITY_NAME_FERRARA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="41" CityLocaleName="LOC_CITY_NAME_VENETIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="41" CityLocaleName="LOC_CITY_NAME_TRIESTE" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="37" Y="42" CityLocaleName="LOC_CITY_NAME_SAVONA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="39" Y="42" CityLocaleName="LOC_CITY_NAME_GENOVA" />
-        	<Replace MapName="PlayEuropeAgain" X="41" Y="42" CityLocaleName="LOC_CITY_NAME_PIACENZA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="42" CityLocaleName="LOC_CITY_NAME_CREMONA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="42" CityLocaleName="LOC_CITY_NAME_VERONA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="42" CityLocaleName="LOC_CITY_NAME_PADOVA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="42" CityLocaleName="LOC_CITY_NAME_CONCORDIA_SAGITTARIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="47" Y="42" CityLocaleName="LOC_CITY_NAME_AQUILEIA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="36" Y="43" CityLocaleName="LOC_CITY_NAME_TORINO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="37" Y="43" CityLocaleName="LOC_CITY_NAME_TORINO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="43" CityLocaleName="LOC_CITY_NAME_TORTONA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="39" Y="43" CityLocaleName="LOC_CITY_NAME_PAVIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="41" Y="43" CityLocaleName="LOC_CITY_NAME_BERGAMO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="43" CityLocaleName="LOC_CITY_NAME_BRESCIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="43" CityLocaleName="LOC_CITY_NAME_VERONA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="43" CityLocaleName="LOC_CITY_NAME_VICENZA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="43" CityLocaleName="LOC_CITY_NAME_TREVISO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="43" CityLocaleName="LOC_CITY_NAME_UDINE" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="40" Y="44" CityLocaleName="LOC_CITY_NAME_MILANO" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="44" CityLocaleName="LOC_CITY_NAME_TRENTO" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="38" Y="45" CityLocaleName="LOC_CITY_NAME_LUGANO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="42" Y="45" CityLocaleName="LOC_CITY_NAME_MALLES_VENOSTA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="45" CityLocaleName="LOC_CITY_NAME_BOLZANO" Area="0" />
-	
+		<Replace MapName="PlayEuropeAgain" X="44" Y="22" CityLocaleName="LOC_CITY_NAME_SIRACUSA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="41" Y="23" CityLocaleName="LOC_CITY_NAME_AGRIGENTO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="42" Y="23" CityLocaleName="LOC_CITY_NAME_CALTANISSETTA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="23" CityLocaleName="LOC_CITY_NAME_ENNA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="23" CityLocaleName="LOC_CITY_NAME_CATANIA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="41" Y="24" CityLocaleName="LOC_CITY_NAME_MARSALA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="42" Y="24" CityLocaleName="LOC_CITY_NAME_PALERMO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="24" CityLocaleName="LOC_CITY_NAME_PALERMO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="24" CityLocaleName="LOC_CITY_NAME_CAPO_DORLANDO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="24" CityLocaleName="LOC_CITY_NAME_MESSINA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="37" Y="30" CityLocaleName="LOC_CITY_NAME_CAGLIARI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="38" Y="30" CityLocaleName="LOC_CITY_NAME_CAGLIARI" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="37" Y="31" CityLocaleName="LOC_CITY_NAME_ORISTANO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="38" Y="31" CityLocaleName="LOC_CITY_NAME_ARBATAX" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="38" Y="32" CityLocaleName="LOC_CITY_NAME_ALGHERO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="39" Y="32" CityLocaleName="LOC_CITY_NAME_OLBIA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="37" Y="33" CityLocaleName="LOC_CITY_NAME_SASSARI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="38" Y="33" CityLocaleName="LOC_CITY_NAME_OLBIA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="38" Y="35" CityLocaleName="LOC_CITY_NAME_BONIFACIO" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="38" Y="36" CityLocaleName="LOC_CITY_NAME_AJACCIO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="39" Y="36" CityLocaleName="LOC_CITY_NAME_CORTE" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="38" Y="37" CityLocaleName="LOC_CITY_NAME_CALVI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="39" Y="37" CityLocaleName="LOC_CITY_NAME_BASTIA" Area="0" />
+
+		<!-- ITALY (MAINLAND) -->
+		<Replace MapName="PlayEuropeAgain" X="47" Y="24" CityLocaleName="LOC_CITY_NAME_REGGIO_CALABRIA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="48" Y="25" CityLocaleName="LOC_CITY_NAME_MONTELEONE" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="48" Y="26" CityLocaleName="LOC_CITY_NAME_CATANZARO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="49" Y="26" CityLocaleName="LOC_CITY_NAME_CROTONE" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="47" Y="27" CityLocaleName="LOC_CITY_NAME_COSENZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="48" Y="27" CityLocaleName="LOC_CITY_NAME_CORIGLIANO_CALABRO" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="48" Y="28" CityLocaleName="LOC_CITY_NAME_CASTROVILLARI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="52" Y="28" CityLocaleName="LOC_CITY_NAME_LECCE" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="46" Y="29" CityLocaleName="LOC_CITY_NAME_ELEA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="47" Y="29" CityLocaleName="LOC_CITY_NAME_GRUMENTO_NOVA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="51" Y="29" CityLocaleName="LOC_CITY_NAME_BRINDISI" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="47" Y="30" CityLocaleName="LOC_CITY_NAME_SALERNO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="48" Y="30" CityLocaleName="LOC_CITY_NAME_POTENZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="49" Y="30" CityLocaleName="LOC_CITY_NAME_POLICORO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="50" Y="30" CityLocaleName="LOC_CITY_NAME_TARANTO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="51" Y="30" CityLocaleName="LOC_CITY_NAME_BRINDISI" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="46" Y="31" CityLocaleName="LOC_CITY_NAME_NAPOLI" />
+		<Replace MapName="PlayEuropeAgain" X="48" Y="31" CityLocaleName="LOC_CITY_NAME_MELFI" Area="0"/>
+		<Replace MapName="PlayEuropeAgain" X="49" Y="31" CityLocaleName="LOC_CITY_NAME_CANOSA" Area="0"/>
+		<Replace MapName="PlayEuropeAgain" X="50" Y="31" CityLocaleName="LOC_CITY_NAME_BARI" Area="0"/>
+
+		<Replace MapName="PlayEuropeAgain" X="45" Y="32" CityLocaleName="LOC_CITY_NAME_LATINA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="47" Y="32" CityLocaleName="LOC_CITY_NAME_BENEVENTO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="48" Y="32" CityLocaleName="LOC_CITY_NAME_LUCERA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="49" Y="32" CityLocaleName="LOC_CITY_NAME_FOGGIA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="44" Y="33" CityLocaleName="LOC_CITY_NAME_ANTIUM" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="33" CityLocaleName="LOC_CITY_NAME_FROSINONE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="33" CityLocaleName="LOC_CITY_NAME_ISERNIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="47" Y="33" CityLocaleName="LOC_CITY_NAME_VASTO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="48" Y="33" CityLocaleName="LOC_CITY_NAME_SAN_SEVERO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="49" Y="33" CityLocaleName="LOC_CITY_NAME_VIESTE" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="44" Y="34" CityLocaleName="LOC_CITY_NAME_ROMA" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="34" CityLocaleName="LOC_CITY_NAME_AQUILA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="47" Y="34" CityLocaleName="LOC_CITY_NAME_PESCARA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="43" Y="35" CityLocaleName="LOC_CITY_NAME_TARQUINIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="35" CityLocaleName="LOC_CITY_NAME_RIETI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="35" CityLocaleName="LOC_CITY_NAME_SAN_BENEDETTO_DEL_TRONTO" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="43" Y="36" CityLocaleName="LOC_CITY_NAME_GROSSETO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="36" CityLocaleName="LOC_CITY_NAME_VITERBO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="36" CityLocaleName="LOC_CITY_NAME_TERNI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="36" CityLocaleName="LOC_CITY_NAME_FERMO" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="42" Y="37" CityLocaleName="LOC_CITY_NAME_PIOMBINO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="37" CityLocaleName="LOC_CITY_NAME_SIENA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="37" CityLocaleName="LOC_CITY_NAME_PERUGIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="37" CityLocaleName="LOC_CITY_NAME_FOLIGNO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="37" CityLocaleName="LOC_CITY_NAME_ANCONA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="42" Y="38" CityLocaleName="LOC_CITY_NAME_LIVORNO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="38" CityLocaleName="LOC_CITY_NAME_FIRENZE" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="38" CityLocaleName="LOC_CITY_NAME_AREZZO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="38" CityLocaleName="LOC_CITY_NAME_RIMINI" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="42" Y="39" CityLocaleName="LOC_CITY_NAME_PISA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="39" CityLocaleName="LOC_CITY_NAME_FIRENZE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="39" CityLocaleName="LOC_CITY_NAME_FAENZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="39" CityLocaleName="LOC_CITY_NAME_RAVENNA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="42" Y="40" CityLocaleName="LOC_CITY_NAME_PISA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="40" CityLocaleName="LOC_CITY_NAME_LUCCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="40" CityLocaleName="LOC_CITY_NAME_BOLOGNA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="40" CityLocaleName="LOC_CITY_NAME_FERRARA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="40" Y="41" CityLocaleName="LOC_CITY_NAME_LA_SPEZIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="41" Y="41" CityLocaleName="LOC_CITY_NAME_CARRARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="42" Y="41" CityLocaleName="LOC_CITY_NAME_PARMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="41" CityLocaleName="LOC_CITY_NAME_MANTOVA" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="41" CityLocaleName="LOC_CITY_NAME_FERRARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="41" CityLocaleName="LOC_CITY_NAME_VENETIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="47" Y="41" CityLocaleName="LOC_CITY_NAME_TRIESTE" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="37" Y="42" CityLocaleName="LOC_CITY_NAME_SAVONA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="39" Y="42" CityLocaleName="LOC_CITY_NAME_GENOVA" />
+		<Replace MapName="PlayEuropeAgain" X="41" Y="42" CityLocaleName="LOC_CITY_NAME_PIACENZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="42" Y="42" CityLocaleName="LOC_CITY_NAME_CREMONA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="42" CityLocaleName="LOC_CITY_NAME_VERONA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="42" CityLocaleName="LOC_CITY_NAME_PADOVA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="42" CityLocaleName="LOC_CITY_NAME_CONCORDIA_SAGITTARIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="47" Y="42" CityLocaleName="LOC_CITY_NAME_AQUILEIA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="36" Y="43" CityLocaleName="LOC_CITY_NAME_TORINO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="37" Y="43" CityLocaleName="LOC_CITY_NAME_TORINO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="38" Y="43" CityLocaleName="LOC_CITY_NAME_TORTONA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="39" Y="43" CityLocaleName="LOC_CITY_NAME_PAVIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="41" Y="43" CityLocaleName="LOC_CITY_NAME_BERGAMO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="42" Y="43" CityLocaleName="LOC_CITY_NAME_BRESCIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="43" CityLocaleName="LOC_CITY_NAME_VERONA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="43" CityLocaleName="LOC_CITY_NAME_VICENZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="43" CityLocaleName="LOC_CITY_NAME_TREVISO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="43" CityLocaleName="LOC_CITY_NAME_UDINE" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="40" Y="44" CityLocaleName="LOC_CITY_NAME_MILANO" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="44" CityLocaleName="LOC_CITY_NAME_TRENTO" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="38" Y="45" CityLocaleName="LOC_CITY_NAME_LUGANO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="42" Y="45" CityLocaleName="LOC_CITY_NAME_MALLES_VENOSTA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="45" CityLocaleName="LOC_CITY_NAME_BOLZANO" Area="0" />
+
 	</CityMap>
-	
+
 	<CityMap> <!-- IBERIA -->
 		<Replace MapName="PlayEuropeAgain" X="14" Y="30" CityLocaleName="LOC_CITY_NAME_GIBRALTAR" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="30" CityLocaleName="LOC_CITY_NAME_GIBRALTAR" Area="0" />
-        
-        	<Replace MapName="PlayEuropeAgain" X="13" Y="31" CityLocaleName="LOC_CITY_NAME_CADIZ" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="31" CityLocaleName="LOC_CITY_NAME_CADIZ" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="31" CityLocaleName="LOC_CITY_NAME_MALAGA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="31" CityLocaleName="LOC_CITY_NAME_MALAGA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="17" Y="31" CityLocaleName="LOC_CITY_NAME_MOTRIL" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="31" CityLocaleName="LOC_CITY_NAME_ALMERIA" />
-        
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="32" CityLocaleName="LOC_CITY_NAME_CADIZ" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="32" CityLocaleName="LOC_CITY_NAME_SEVILLA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="32" CityLocaleName="LOC_CITY_NAME_GRANADA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="17" Y="32" CityLocaleName="LOC_CITY_NAME_GRANADA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="32" CityLocaleName="LOC_CITY_NAME_LORCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="20" Y="32" CityLocaleName="LOC_CITY_NAME_MURCIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="32" CityLocaleName="LOC_CITY_NAME_CARTAGENA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="25" Y="32" CityLocaleName="LOC_CITY_NAME_IBIZA" Area="0" />
-        
-        	<Replace MapName="PlayEuropeAgain" X="12" Y="33" CityLocaleName="LOC_CITY_NAME_HUELVA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="33" CityLocaleName="LOC_CITY_NAME_SEVILLA" />
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="33" CityLocaleName="LOC_CITY_NAME_CORDOBA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="18" Y="33" CityLocaleName="LOC_CITY_NAME_JAEN" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="33" CityLocaleName="LOC_CITY_NAME_HELLIN" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="20" Y="33" CityLocaleName="LOC_CITY_NAME_MURCIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="33" CityLocaleName="LOC_CITY_NAME_ALICANTE" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="33" CityLocaleName="LOC_CITY_NAME_DENIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="26" Y="33" CityLocaleName="LOC_CITY_NAME_PALMA_DE_MALLORCA" />
-        
-        	<Replace MapName="PlayEuropeAgain" X="10" Y="34" CityLocaleName="LOC_CITY_NAME_LAGOS" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="11" Y="34" CityLocaleName="LOC_CITY_NAME_FARO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="12" Y="34" CityLocaleName="LOC_CITY_NAME_HUELVA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="34" CityLocaleName="LOC_CITY_NAME_CORDOBA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="34" CityLocaleName="LOC_CITY_NAME_CORDOBA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="18" Y="34" CityLocaleName="LOC_CITY_NAME_LINARES" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="34" CityLocaleName="LOC_CITY_NAME_ALMANSA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="34" CityLocaleName="LOC_CITY_NAME_CULLERA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="27" Y="34" CityLocaleName="LOC_CITY_NAME_PALMA_DE_MALLORCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="29" Y="34" CityLocaleName="LOC_CITY_NAME_CIUTADELLA_DE_MENORCA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="10" Y="35" CityLocaleName="LOC_CITY_NAME_SINES" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="11" Y="35" CityLocaleName="LOC_CITY_NAME_BEJA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="12" Y="35" CityLocaleName="LOC_CITY_NAME_BADAJOZ"	/>
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="35" CityLocaleName="LOC_CITY_NAME_MERIDA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="35" CityLocaleName="LOC_CITY_NAME_CIUDAD_REAL" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="35" CityLocaleName="LOC_CITY_NAME_ALBACETE" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="35" CityLocaleName="LOC_CITY_NAME_REQUENA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="35" CityLocaleName="LOC_CITY_NAME_VALENCIA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="11" Y="36" CityLocaleName="LOC_CITY_NAME_SETUBAL" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="12" Y="36" CityLocaleName="LOC_CITY_NAME_EVORA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="17" Y="36" CityLocaleName="LOC_CITY_NAME_TOLEDO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="18" Y="36" CityLocaleName="LOC_CITY_NAME_TOLEDO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="36" CityLocaleName="LOC_CITY_NAME_CUENCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="36" CityLocaleName="LOC_CITY_NAME_LIRIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="23" Y="36" CityLocaleName="LOC_CITY_NAME_SAGUNTO" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="11" Y="37" CityLocaleName="LOC_CITY_NAME_LISBOA" />
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="37" CityLocaleName="LOC_CITY_NAME_CACERES" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="37" CityLocaleName="LOC_CITY_NAME_TRUJILLO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="17" Y="37" CityLocaleName="LOC_CITY_NAME_TOLEDO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="18" Y="37" CityLocaleName="LOC_CITY_NAME_MADRID" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="37" CityLocaleName="LOC_CITY_NAME_CUENCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="20" Y="37" CityLocaleName="LOC_CITY_NAME_CUENCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="37" CityLocaleName="LOC_CITY_NAME_TERUEL" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="37" CityLocaleName="LOC_CITY_NAME_TERUEL" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="23" Y="37" CityLocaleName="LOC_CITY_NAME_TORTOSA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="24" Y="37" CityLocaleName="LOC_CITY_NAME_TARRAGONA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="13" Y="38" CityLocaleName="LOC_CITY_NAME_CASTELO_BRANCO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="38" CityLocaleName="LOC_CITY_NAME_CASTELO_BRANCO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="38" CityLocaleName="LOC_CITY_NAME_SALAMANCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="38" CityLocaleName="LOC_CITY_NAME_SALAMANCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="18" Y="38" CityLocaleName="LOC_CITY_NAME_MADRID" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="38" CityLocaleName="LOC_CITY_NAME_GUADALAJARA" />
-        	<Replace MapName="PlayEuropeAgain" X="23" Y="38" CityLocaleName="LOC_CITY_NAME_TERUEL" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="24" Y="38" CityLocaleName="LOC_CITY_NAME_TARRAGONA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="30" CityLocaleName="LOC_CITY_NAME_GIBRALTAR" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="13" Y="31" CityLocaleName="LOC_CITY_NAME_CADIZ" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="31" CityLocaleName="LOC_CITY_NAME_CADIZ" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="31" CityLocaleName="LOC_CITY_NAME_MALAGA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="31" CityLocaleName="LOC_CITY_NAME_MALAGA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="31" CityLocaleName="LOC_CITY_NAME_MOTRIL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="31" CityLocaleName="LOC_CITY_NAME_ALMERIA" />
+
+		<Replace MapName="PlayEuropeAgain" X="14" Y="32" CityLocaleName="LOC_CITY_NAME_CADIZ" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="32" CityLocaleName="LOC_CITY_NAME_SEVILLA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="32" CityLocaleName="LOC_CITY_NAME_GRANADA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="32" CityLocaleName="LOC_CITY_NAME_GRANADA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="32" CityLocaleName="LOC_CITY_NAME_LORCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="32" CityLocaleName="LOC_CITY_NAME_MURCIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="32" CityLocaleName="LOC_CITY_NAME_CARTAGENA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="25" Y="32" CityLocaleName="LOC_CITY_NAME_IBIZA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="12" Y="33" CityLocaleName="LOC_CITY_NAME_HUELVA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="33" CityLocaleName="LOC_CITY_NAME_SEVILLA" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="33" CityLocaleName="LOC_CITY_NAME_CORDOBA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="33" CityLocaleName="LOC_CITY_NAME_JAEN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="33" CityLocaleName="LOC_CITY_NAME_HELLIN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="33" CityLocaleName="LOC_CITY_NAME_MURCIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="33" CityLocaleName="LOC_CITY_NAME_ALICANTE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="33" CityLocaleName="LOC_CITY_NAME_DENIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="26" Y="33" CityLocaleName="LOC_CITY_NAME_PALMA_DE_MALLORCA" />
+
+		<Replace MapName="PlayEuropeAgain" X="10" Y="34" CityLocaleName="LOC_CITY_NAME_LAGOS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="11" Y="34" CityLocaleName="LOC_CITY_NAME_FARO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="34" CityLocaleName="LOC_CITY_NAME_HUELVA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="34" CityLocaleName="LOC_CITY_NAME_CORDOBA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="34" CityLocaleName="LOC_CITY_NAME_CORDOBA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="34" CityLocaleName="LOC_CITY_NAME_LINARES" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="34" CityLocaleName="LOC_CITY_NAME_ALMANSA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="34" CityLocaleName="LOC_CITY_NAME_CULLERA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="27" Y="34" CityLocaleName="LOC_CITY_NAME_PALMA_DE_MALLORCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="29" Y="34" CityLocaleName="LOC_CITY_NAME_CIUTADELLA_DE_MENORCA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="10" Y="35" CityLocaleName="LOC_CITY_NAME_SINES" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="11" Y="35" CityLocaleName="LOC_CITY_NAME_BEJA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="35" CityLocaleName="LOC_CITY_NAME_BADAJOZ"	/>
+		<Replace MapName="PlayEuropeAgain" X="14" Y="35" CityLocaleName="LOC_CITY_NAME_MERIDA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="35" CityLocaleName="LOC_CITY_NAME_CIUDAD_REAL" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="35" CityLocaleName="LOC_CITY_NAME_ALBACETE" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="35" CityLocaleName="LOC_CITY_NAME_REQUENA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="35" CityLocaleName="LOC_CITY_NAME_VALENCIA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="11" Y="36" CityLocaleName="LOC_CITY_NAME_SETUBAL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="36" CityLocaleName="LOC_CITY_NAME_EVORA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="36" CityLocaleName="LOC_CITY_NAME_TOLEDO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="36" CityLocaleName="LOC_CITY_NAME_TOLEDO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="36" CityLocaleName="LOC_CITY_NAME_CUENCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="36" CityLocaleName="LOC_CITY_NAME_LIRIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="23" Y="36" CityLocaleName="LOC_CITY_NAME_SAGUNTO" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="11" Y="37" CityLocaleName="LOC_CITY_NAME_LISBOA" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="37" CityLocaleName="LOC_CITY_NAME_CACERES" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="37" CityLocaleName="LOC_CITY_NAME_TRUJILLO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="37" CityLocaleName="LOC_CITY_NAME_TOLEDO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="37" CityLocaleName="LOC_CITY_NAME_MADRID" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="37" CityLocaleName="LOC_CITY_NAME_CUENCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="37" CityLocaleName="LOC_CITY_NAME_CUENCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="37" CityLocaleName="LOC_CITY_NAME_TERUEL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="37" CityLocaleName="LOC_CITY_NAME_TERUEL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="23" Y="37" CityLocaleName="LOC_CITY_NAME_TORTOSA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="24" Y="37" CityLocaleName="LOC_CITY_NAME_TARRAGONA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="13" Y="38" CityLocaleName="LOC_CITY_NAME_CASTELO_BRANCO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="38" CityLocaleName="LOC_CITY_NAME_CASTELO_BRANCO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="38" CityLocaleName="LOC_CITY_NAME_SALAMANCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="38" CityLocaleName="LOC_CITY_NAME_SALAMANCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="38" CityLocaleName="LOC_CITY_NAME_MADRID" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="38" CityLocaleName="LOC_CITY_NAME_GUADALAJARA" />
+		<Replace MapName="PlayEuropeAgain" X="23" Y="38" CityLocaleName="LOC_CITY_NAME_TERUEL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="24" Y="38" CityLocaleName="LOC_CITY_NAME_TARRAGONA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="25" Y="38" CityLocaleName="LOC_CITY_NAME_TARRAGONA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="38" CityLocaleName="LOC_CITY_NAME_BARCELONA" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="38" CityLocaleName="LOC_CITY_NAME_BARCELONA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="28" Y="38" CityLocaleName="LOC_CITY_NAME_GIRONA" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="11" Y="39" CityLocaleName="LOC_CITY_NAME_COIMBRA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="12" Y="39" CityLocaleName="LOC_CITY_NAME_COIMBRA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="13" Y="39" CityLocaleName="LOC_CITY_NAME_CASTELO_BRANCO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="39" CityLocaleName="LOC_CITY_NAME_SALAMANCA" />
-        	<Replace MapName="PlayEuropeAgain" X="20" Y="39" CityLocaleName="LOC_CITY_NAME_SORIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="24" Y="39" CityLocaleName="LOC_CITY_NAME_TARRAGONA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="40" CityLocaleName="LOC_CITY_NAME_ZAMORA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="40" CityLocaleName="LOC_CITY_NAME_TORDESILLAS" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="40" CityLocaleName="LOC_CITY_NAME_SORIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="20" Y="40" CityLocaleName="LOC_CITY_NAME_SORIA" />
-        	<Replace MapName="PlayEuropeAgain" X="23" Y="40" CityLocaleName="LOC_CITY_NAME_ZARAGOZA" />
-        	<Replace MapName="PlayEuropeAgain" X="25" Y="40" CityLocaleName="LOC_CITY_NAME_HUESCA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="26" Y="40" CityLocaleName="LOC_CITY_NAME_LLEIDA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="27" Y="40" CityLocaleName="LOC_CITY_NAME_BERGA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="12" Y="41" CityLocaleName="LOC_CITY_NAME_PORTO" />
-        	<Replace MapName="PlayEuropeAgain" X="13" Y="41" CityLocaleName="LOC_CITY_NAME_PORTO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="41" CityLocaleName="LOC_CITY_NAME_ZAMORA" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="41" CityLocaleName="LOC_CITY_NAME_TORDESILLAS" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="18" Y="41" CityLocaleName="LOC_CITY_NAME_VALLADOLID" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="41" CityLocaleName="LOC_CITY_NAME_SORIA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="41" CityLocaleName="LOC_CITY_NAME_ZARAGOZA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="24" Y="41" CityLocaleName="LOC_CITY_NAME_HUESCA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="13" Y="42" CityLocaleName="LOC_CITY_NAME_PORTO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="42" CityLocaleName="LOC_CITY_NAME_BRAGA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="42" CityLocaleName="LOC_CITY_NAME_OURENSE" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="42" CityLocaleName="LOC_CITY_NAME_BURGOS" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="20" Y="42" CityLocaleName="LOC_CITY_NAME_BURGOS" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="42" CityLocaleName="LOC_CITY_NAME_LOGRONO" />
-        	<Replace MapName="PlayEuropeAgain" X="23" Y="42" CityLocaleName="LOC_CITY_NAME_PAMPLONA" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="12" Y="43" CityLocaleName="LOC_CITY_NAME_PONTEVEDRA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="13" Y="43" CityLocaleName="LOC_CITY_NAME_OURENSE" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="14" Y="43" CityLocaleName="LOC_CITY_NAME_OURENSE" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="43" CityLocaleName="LOC_CITY_NAME_LEON" />
-        	<Replace MapName="PlayEuropeAgain" X="18" Y="43" CityLocaleName="LOC_CITY_NAME_BURGOS" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="19" Y="43" CityLocaleName="LOC_CITY_NAME_BURGOS" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="43" CityLocaleName="LOC_CITY_NAME_BILBAO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="43" CityLocaleName="LOC_CITY_NAME_BILBAO" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="23" Y="43" CityLocaleName="LOC_CITY_NAME_DONOSTIA_SAN_SEBASTIAN" Area="0" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="15" Y="44" CityLocaleName="LOC_CITY_NAME_PONFERRADA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="21" Y="44" CityLocaleName="LOC_CITY_NAME_SANTANDER" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="13" Y="45" CityLocaleName="LOC_CITY_NAME_SANTIAGO_DE_COMPOSTELA" />
-        	<Replace MapName="PlayEuropeAgain" X="18" Y="45" CityLocaleName="LOC_CITY_NAME_GIJON" />
-        	
-        	<Replace MapName="PlayEuropeAgain" X="16" Y="46" CityLocaleName="LOC_CITY_NAME_A_CORUNA" />
-	
+		<Replace MapName="PlayEuropeAgain" X="28" Y="38" CityLocaleName="LOC_CITY_NAME_GIRONA" />
+
+		<Replace MapName="PlayEuropeAgain" X="11" Y="39" CityLocaleName="LOC_CITY_NAME_COIMBRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="39" CityLocaleName="LOC_CITY_NAME_COIMBRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="13" Y="39" CityLocaleName="LOC_CITY_NAME_CASTELO_BRANCO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="39" CityLocaleName="LOC_CITY_NAME_SALAMANCA" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="39" CityLocaleName="LOC_CITY_NAME_SORIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="24" Y="39" CityLocaleName="LOC_CITY_NAME_TARRAGONA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="15" Y="40" CityLocaleName="LOC_CITY_NAME_ZAMORA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="40" CityLocaleName="LOC_CITY_NAME_TORDESILLAS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="40" CityLocaleName="LOC_CITY_NAME_SORIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="40" CityLocaleName="LOC_CITY_NAME_SORIA" />
+		<Replace MapName="PlayEuropeAgain" X="23" Y="40" CityLocaleName="LOC_CITY_NAME_ZARAGOZA" />
+		<Replace MapName="PlayEuropeAgain" X="25" Y="40" CityLocaleName="LOC_CITY_NAME_HUESCA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="26" Y="40" CityLocaleName="LOC_CITY_NAME_LLEIDA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="27" Y="40" CityLocaleName="LOC_CITY_NAME_BERGA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="12" Y="41" CityLocaleName="LOC_CITY_NAME_PORTO" />
+		<Replace MapName="PlayEuropeAgain" X="13" Y="41" CityLocaleName="LOC_CITY_NAME_PORTO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="41" CityLocaleName="LOC_CITY_NAME_ZAMORA" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="41" CityLocaleName="LOC_CITY_NAME_TORDESILLAS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="41" CityLocaleName="LOC_CITY_NAME_VALLADOLID" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="41" CityLocaleName="LOC_CITY_NAME_SORIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="41" CityLocaleName="LOC_CITY_NAME_ZARAGOZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="24" Y="41" CityLocaleName="LOC_CITY_NAME_HUESCA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="13" Y="42" CityLocaleName="LOC_CITY_NAME_PORTO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="42" CityLocaleName="LOC_CITY_NAME_BRAGA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="42" CityLocaleName="LOC_CITY_NAME_OURENSE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="42" CityLocaleName="LOC_CITY_NAME_BURGOS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="42" CityLocaleName="LOC_CITY_NAME_BURGOS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="42" CityLocaleName="LOC_CITY_NAME_LOGRONO" />
+		<Replace MapName="PlayEuropeAgain" X="23" Y="42" CityLocaleName="LOC_CITY_NAME_PAMPLONA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="12" Y="43" CityLocaleName="LOC_CITY_NAME_PONTEVEDRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="13" Y="43" CityLocaleName="LOC_CITY_NAME_OURENSE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="43" CityLocaleName="LOC_CITY_NAME_OURENSE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="43" CityLocaleName="LOC_CITY_NAME_LEON" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="43" CityLocaleName="LOC_CITY_NAME_BURGOS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="43" CityLocaleName="LOC_CITY_NAME_BURGOS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="43" CityLocaleName="LOC_CITY_NAME_BILBAO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="43" CityLocaleName="LOC_CITY_NAME_BILBAO" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="23" Y="43" CityLocaleName="LOC_CITY_NAME_DONOSTIA_SAN_SEBASTIAN" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="15" Y="44" CityLocaleName="LOC_CITY_NAME_PONFERRADA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="44" CityLocaleName="LOC_CITY_NAME_SANTANDER" />
+
+		<Replace MapName="PlayEuropeAgain" X="13" Y="45" CityLocaleName="LOC_CITY_NAME_SANTIAGO_DE_COMPOSTELA" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="45" CityLocaleName="LOC_CITY_NAME_GIJON" />
+
+		<Replace MapName="PlayEuropeAgain" X="16" Y="46" CityLocaleName="LOC_CITY_NAME_A_CORUNA" />
+
 	</CityMap>
-	
+
 	<CityMap> <!-- BRITISH ISLES -->
-        
-        	<!-- GREAT BRITAIN, MAN, SKYE, ORKNEYS, & FAROES -->
+
+		<!-- GREAT BRITAIN, MAN, SKYE, ORKNEYS, & FAROES -->
 		<Replace MapName="PlayEuropeAgain" X="25" Y="58" CityLocaleName="LOC_CITY_NAME_TORQUAY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="22" Y="59" CityLocaleName="LOC_CITY_NAME_ST_IVES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="23" Y="59" CityLocaleName="LOC_CITY_NAME_ST_AUSTELL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="24" Y="59" CityLocaleName="LOC_CITY_NAME_PLYMOUTH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="25" Y="59" CityLocaleName="LOC_CITY_NAME_EXETER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="59" CityLocaleName="LOC_CITY_NAME_EXETER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="59" CityLocaleName="LOC_CITY_NAME_SOUTHAMPTON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="24" Y="60" CityLocaleName="LOC_CITY_NAME_BIDEFORD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="25" Y="60" CityLocaleName="LOC_CITY_NAME_BRIDGWATER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="60" CityLocaleName="LOC_CITY_NAME_WESTON_SUPER_MARE" Area="0" />
@@ -435,11 +434,11 @@
 		<Replace MapName="PlayEuropeAgain" X="28" Y="60" CityLocaleName="LOC_CITY_NAME_WINCHESTER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="60" CityLocaleName="LOC_CITY_NAME_WINCHESTER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="60" CityLocaleName="LOC_CITY_NAME_LONDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="26" Y="61" CityLocaleName="LOC_CITY_NAME_BRISTOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="61" CityLocaleName="LOC_CITY_NAME_BATH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="32" Y="61" CityLocaleName="LOC_CITY_NAME_SOUTHEND_ON_SEA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="24" Y="62" CityLocaleName="LOC_CITY_NAME_SWANSEA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="25" Y="62" CityLocaleName="LOC_CITY_NAME_SWANSEA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="62" CityLocaleName="LOC_CITY_NAME_CARDIFF" Area="0" />
@@ -447,7 +446,7 @@
 		<Replace MapName="PlayEuropeAgain" X="29" Y="62" CityLocaleName="LOC_CITY_NAME_OXFORD" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="62" CityLocaleName="LOC_CITY_NAME_CAMBRIDGE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="62" CityLocaleName="LOC_CITY_NAME_CAMBRIDGE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="24" Y="63" CityLocaleName="LOC_CITY_NAME_CARDIGAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="25" Y="63" CityLocaleName="LOC_CITY_NAME_ABERYSTWYTH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="63" CityLocaleName="LOC_CITY_NAME_BIRMINGHAM" />
@@ -455,13 +454,13 @@
 		<Replace MapName="PlayEuropeAgain" X="29" Y="63" CityLocaleName="LOC_CITY_NAME_LEICESTER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="63" CityLocaleName="LOC_CITY_NAME_PETERBOROUGH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="32" Y="63" CityLocaleName="LOC_CITY_NAME_NORWICH" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="26" Y="64" CityLocaleName="LOC_CITY_NAME_ABERYSTWYTH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="64" CityLocaleName="LOC_CITY_NAME_STOKE_ON_TRENT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="64" CityLocaleName="LOC_CITY_NAME_NOTTINGHAM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="64" CityLocaleName="LOC_CITY_NAME_LINCOLN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="64" CityLocaleName="LOC_CITY_NAME_BOSTON" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="65" CityLocaleName="LOC_CITY_NAME_CAERNARFON" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="65" CityLocaleName="LOC_CITY_NAME_COLWYN_BAY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="65" CityLocaleName="LOC_CITY_NAME_LIVERPOOL" Area="0" />
@@ -469,132 +468,132 @@
 		<Replace MapName="PlayEuropeAgain" X="29" Y="65" CityLocaleName="LOC_CITY_NAME_SHEFFIELD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="65" CityLocaleName="LOC_CITY_NAME_SCUNTHORPE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="65" CityLocaleName="LOC_CITY_NAME_GRIMSBY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="28" Y="66" CityLocaleName="LOC_CITY_NAME_MANCHESTER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="66" CityLocaleName="LOC_CITY_NAME_MANCHESTER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="66" CityLocaleName="LOC_CITY_NAME_LEEDS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="66" CityLocaleName="LOC_CITY_NAME_KINGSTON_UPON_HULL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="28" Y="67" CityLocaleName="LOC_CITY_NAME_LANCASTER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="67" CityLocaleName="LOC_CITY_NAME_LEEDS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="67" CityLocaleName="LOC_CITY_NAME_SCARBOROUGH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="26" Y="68" CityLocaleName="LOC_CITY_NAME_DOUGLAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="68" CityLocaleName="LOC_CITY_NAME_BARROW_IN_FURNESS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="68" CityLocaleName="LOC_CITY_NAME_KENDAL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="68" CityLocaleName="LOC_CITY_NAME_MIDDLESBROUGH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="28" Y="69" CityLocaleName="LOC_CITY_NAME_CARLISLE" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="69" CityLocaleName="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="26" Y="70" CityLocaleName="LOC_CITY_NAME_STRANRAER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="70" CityLocaleName="LOC_CITY_NAME_NEWTON_STEWART" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="70" CityLocaleName="LOC_CITY_NAME_DUMFRIES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="70" CityLocaleName="LOC_CITY_NAME_ALNWICK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="28" Y="71" CityLocaleName="LOC_CITY_NAME_EDINBURGH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="71" CityLocaleName="LOC_CITY_NAME_EDINBURGH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="27" Y="72" CityLocaleName="LOC_CITY_NAME_GLASGOW" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="72" CityLocaleName="LOC_CITY_NAME_KIRKCALDY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="28" Y="73" CityLocaleName="LOC_CITY_NAME_STIRLING" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="73" CityLocaleName="LOC_CITY_NAME_DUNDEE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="74" CityLocaleName="LOC_CITY_NAME_CALGARY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="74" CityLocaleName="LOC_CITY_NAME_LOCHALINE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="74" CityLocaleName="LOC_CITY_NAME_FORT_WILLIAM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="74" CityLocaleName="LOC_CITY_NAME_FORT_WILLIAM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="74" CityLocaleName="LOC_CITY_NAME_PERTH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="26" Y="75" CityLocaleName="LOC_CITY_NAME_MALLAIG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="75" CityLocaleName="LOC_CITY_NAME_FORT_WILLIAM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="75" CityLocaleName="LOC_CITY_NAME_FORT_AUGUSTUS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="75" CityLocaleName="LOC_CITY_NAME_ABERDEEN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="27" Y="76" CityLocaleName="LOC_CITY_NAME_MALLAIG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="76" CityLocaleName="LOC_CITY_NAME_FORT_AUGUSTUS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="76" CityLocaleName="LOC_CITY_NAME_INVERNESS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="76" CityLocaleName="LOC_CITY_NAME_ELGIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="31" Y="76" CityLocaleName="LOC_CITY_NAME_FRASERBURGH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="77" CityLocaleName="LOC_CITY_NAME_PORTREE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="26" Y="77" CityLocaleName="LOC_CITY_NAME_KYLE_OF_LOCHALSH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="77" CityLocaleName="LOC_CITY_NAME_STRATHPEFFER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="77" CityLocaleName="LOC_CITY_NAME_INVERNESS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="78" CityLocaleName="LOC_CITY_NAME_LOCHMADDY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="78" CityLocaleName="LOC_CITY_NAME_ULLAPOOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="78" CityLocaleName="LOC_CITY_NAME_LAIRG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="78" CityLocaleName="LOC_CITY_NAME_HELMSDALE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="25" Y="79" CityLocaleName="LOC_CITY_NAME_STORNOWAY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="79" CityLocaleName="LOC_CITY_NAME_DURNESS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="79" CityLocaleName="LOC_CITY_NAME_BETTYHILL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="79" CityLocaleName="LOC_CITY_NAME_WICK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="31" Y="80" CityLocaleName="LOC_CITY_NAME_KIRKWALL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="35" Y="81" CityLocaleName="LOC_CITY_NAME_LERWICK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="36" Y="82" CityLocaleName="LOC_CITY_NAME_GUTCHER" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="29" Y="88" CityLocaleName="LOC_CITY_NAME_TORSHAVN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="28" Y="89" CityLocaleName="LOC_CITY_NAME_KLAKSVIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="89" CityLocaleName="LOC_CITY_NAME_SORVAGUR" Area="0" />
-		
+
 		<!-- IRELAND -->
 		<Replace MapName="PlayEuropeAgain" X="18" Y="64" CityLocaleName="LOC_CITY_NAME_CORK" />
 		<Replace MapName="PlayEuropeAgain" X="20" Y="64" CityLocaleName="LOC_CITY_NAME_WATERFORD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="21" Y="64" CityLocaleName="LOC_CITY_NAME_WEXFORD" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="16" Y="65" CityLocaleName="LOC_CITY_NAME_KILLARNEY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="17" Y="65" CityLocaleName="LOC_CITY_NAME_LISTOWEL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="18" Y="65" CityLocaleName="LOC_CITY_NAME_LIMERICK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="20" Y="65" CityLocaleName="LOC_CITY_NAME_KILKENNY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="21" Y="65" CityLocaleName="LOC_CITY_NAME_ARKLOW" Area="0" />
-				
+
 		<Replace MapName="PlayEuropeAgain" X="17" Y="66" CityLocaleName="LOC_CITY_NAME_TRALEE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="19" Y="66" CityLocaleName="LOC_CITY_NAME_LIMERICK" />
 		<Replace MapName="PlayEuropeAgain" X="20" Y="66" CityLocaleName="LOC_CITY_NAME_NENAGH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="21" Y="66" CityLocaleName="LOC_CITY_NAME_TULLAMORE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="22" Y="66" CityLocaleName="LOC_CITY_NAME_DUBLIN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="18" Y="67" CityLocaleName="LOC_CITY_NAME_GALWAY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="19" Y="67" CityLocaleName="LOC_CITY_NAME_ATHLONE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="20" Y="67" CityLocaleName="LOC_CITY_NAME_ATHLONE" />
 		<Replace MapName="PlayEuropeAgain" X="21" Y="67" CityLocaleName="LOC_CITY_NAME_ATHLONE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="22" Y="67" CityLocaleName="LOC_CITY_NAME_DUBLIN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="19" Y="68" CityLocaleName="LOC_CITY_NAME_GALWAY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="20" Y="68" CityLocaleName="LOC_CITY_NAME_ROSCOMMON" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="22" Y="68" CityLocaleName="LOC_CITY_NAME_MULLINGAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="23" Y="68" CityLocaleName="LOC_CITY_NAME_DUNDALK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="24" Y="68" CityLocaleName="LOC_CITY_NAME_NEWCASTLE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="18" Y="69" CityLocaleName="LOC_CITY_NAME_WESTPORT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="19" Y="69" CityLocaleName="LOC_CITY_NAME_CASTLEBAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="20" Y="69" CityLocaleName="LOC_CITY_NAME_CARRICK_ON_SHANNON" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="21" Y="69" CityLocaleName="LOC_CITY_NAME_CAVAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="22" Y="69" CityLocaleName="LOC_CITY_NAME_OMAGH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="24" Y="69" CityLocaleName="LOC_CITY_NAME_BELFAST" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="19" Y="70" CityLocaleName="LOC_CITY_NAME_BALLINA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="20" Y="70" CityLocaleName="LOC_CITY_NAME_SLIGO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="21" Y="70" CityLocaleName="LOC_CITY_NAME_SLIGO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="22" Y="70" CityLocaleName="LOC_CITY_NAME_DONEGAL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="23" Y="70" CityLocaleName="LOC_CITY_NAME_COOKSTOWN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="22" Y="71" CityLocaleName="LOC_CITY_NAME_DERRY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="23" Y="71" CityLocaleName="LOC_CITY_NAME_CLOERAINE" Area="0" />
 	</CityMap>
-	
+
 	<CityMap> <!-- GERMANY (INCLUDING BENELUX & HELVETIA; EXCLUDING DENMARK, CZECHIA, & AUSTRIA) -->
-	
+
 		<!-- NORTHERN GERMANY -->
 		<Replace MapName="PlayEuropeAgain" X="38" Y="56" CityLocaleName="LOC_CITY_NAME_NIJMEGEN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="36" Y="57" CityLocaleName="LOC_CITY_NAME_BRUSSELS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="37" Y="57" CityLocaleName="LOC_CITY_NAME_TILBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="38" Y="57" CityLocaleName="LOC_CITY_NAME_ELST" Area="0" />
@@ -604,7 +603,7 @@
 		<Replace MapName="PlayEuropeAgain" X="44" Y="57" CityLocaleName="LOC_CITY_NAME_LEIPZIG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="57" CityLocaleName="LOC_CITY_NAME_LEIPZIG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="57" CityLocaleName="LOC_CITY_NAME_COTTBUS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="35" Y="58" CityLocaleName="LOC_CITY_NAME_BRUGGE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="36" Y="58" CityLocaleName="LOC_CITY_NAME_GENT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="37" Y="58" CityLocaleName="LOC_CITY_NAME_DORDRECHT" Area="0" />
@@ -616,7 +615,7 @@
 		<Replace MapName="PlayEuropeAgain" X="45" Y="58" CityLocaleName="LOC_CITY_NAME_MAGDEBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="58" CityLocaleName="LOC_CITY_NAME_BERLIN" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="58" CityLocaleName="LOC_CITY_NAME_FRANKFURT_ODER" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="36" Y="59" CityLocaleName="LOC_CITY_NAME_ROTTERDAM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="37" Y="59" CityLocaleName="LOC_CITY_NAME_UTRECHT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="38" Y="59" CityLocaleName="LOC_CITY_NAME_ZWOLLE" Area="0" />
@@ -624,11 +623,11 @@
 		<Replace MapName="PlayEuropeAgain" X="40" Y="59" CityLocaleName="LOC_CITY_NAME_OSNABRUECK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="42" Y="59" CityLocaleName="LOC_CITY_NAME_HANNOVER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="59" CityLocaleName="LOC_CITY_NAME_LUENEBURG" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="44" Y="59" CityLocaleName="LOC_CITY_NAME_LUENEBURG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="59" CityLocaleName="LOC_CITY_NAME_LUENEBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="59" CityLocaleName="LOC_CITY_NAME_SCHWERIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="59" CityLocaleName="LOC_CITY_NAME_EBERSWALDE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="59" CityLocaleName="LOC_CITY_NAME_FRANKFURT_ODER" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="37" Y="60" CityLocaleName="LOC_CITY_NAME_AMSTERDAM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="39" Y="60" CityLocaleName="LOC_CITY_NAME_MEPPEL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="40" Y="60" CityLocaleName="LOC_CITY_NAME_EMMEN" Area="0" />
@@ -639,7 +638,7 @@
 		<Replace MapName="PlayEuropeAgain" X="47" Y="60" CityLocaleName="LOC_CITY_NAME_ROSTOCK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="60" CityLocaleName="LOC_CITY_NAME_NEUBRANDENBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="60" CityLocaleName="LOC_CITY_NAME_SZCZECIN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="37" Y="61" CityLocaleName="LOC_CITY_NAME_DEN_HELDER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="39" Y="61" CityLocaleName="LOC_CITY_NAME_LEEUWARDEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="40" Y="61" CityLocaleName="LOC_CITY_NAME_GRONINGEN" Area="0" />
@@ -649,18 +648,18 @@
 		<Replace MapName="PlayEuropeAgain" X="45" Y="61" CityLocaleName="LOC_CITY_NAME_LUEBECK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="61" CityLocaleName="LOC_CITY_NAME_ROSTOCK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="61" CityLocaleName="LOC_CITY_NAME_STRALSUND" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="45" Y="62" CityLocaleName="LOC_CITY_NAME_KIEL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="43" Y="63" CityLocaleName="LOC_CITY_NAME_HUSUM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="63" CityLocaleName="LOC_CITY_NAME_FLENSBURG" Area="0" />
-		
+
 		<!-- SOUTHERN GERMANY -->
 		<Replace MapName="PlayEuropeAgain" X="36" Y="45" CityLocaleName="LOC_CITY_NAME_GENEVA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="36" Y="46" CityLocaleName="LOC_CITY_NAME_GENEVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="41" Y="46" CityLocaleName="LOC_CITY_NAME_VADUZ" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="36" Y="47" CityLocaleName="LOC_CITY_NAME_LAUSANNE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="37" Y="47" CityLocaleName="LOC_CITY_NAME_LAUSANNE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="38" Y="47" CityLocaleName="LOC_CITY_NAME_BERN" Area="0" />
@@ -669,16 +668,16 @@
 		<Replace MapName="PlayEuropeAgain" X="41" Y="47" CityLocaleName="LOC_CITY_NAME_FELDKIRCH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="42" Y="47" CityLocaleName="LOC_CITY_NAME_KEMPTEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="47" CityLocaleName="LOC_CITY_NAME_GARMISCH_PARTENKIRCHEN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="38" Y="48" CityLocaleName="LOC_CITY_NAME_BASEL" />
 		<Replace MapName="PlayEuropeAgain" X="40" Y="48" CityLocaleName="LOC_CITY_NAME_WINTERTHUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="42" Y="48" CityLocaleName="LOC_CITY_NAME_BREGENZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="48" CityLocaleName="LOC_CITY_NAME_KEMPTEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="48" CityLocaleName="LOC_CITY_NAME_AUGSBURG" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="45" Y="48" CityLocaleName="LOC_CITY_NAME_SALZBURG" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="46" Y="48" CityLocaleName="LOC_CITY_NAME_SALZBURG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="48" CityLocaleName="LOC_CITY_NAME_SALZBURG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="46" Y="48" CityLocaleName="LOC_CITY_NAME_SALZBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="48" CityLocaleName="LOC_CITY_NAME_PASSAU" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="38" Y="49" CityLocaleName="LOC_CITY_NAME_LOERRACH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="39" Y="49" CityLocaleName="LOC_CITY_NAME_SCHAFFHAUSEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="40" Y="49" CityLocaleName="LOC_CITY_NAME_KONSTANZ" Area="0" />
@@ -687,7 +686,7 @@
 		<Replace MapName="PlayEuropeAgain" X="43" Y="49" CityLocaleName="LOC_CITY_NAME_AUGSBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="49" CityLocaleName="LOC_CITY_NAME_MUNICH" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="49" CityLocaleName="LOC_CITY_NAME_WEGSCHEID" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="39" Y="50" CityLocaleName="LOC_CITY_NAME_FREIBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="40" Y="50" CityLocaleName="LOC_CITY_NAME_FREIBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="42" Y="50" CityLocaleName="LOC_CITY_NAME_ULM" Area="0" />
@@ -696,36 +695,36 @@
 		<Replace MapName="PlayEuropeAgain" X="45" Y="50" CityLocaleName="LOC_CITY_NAME_REGENSBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="46" Y="50" CityLocaleName="LOC_CITY_NAME_DEGGENDORF" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="50" CityLocaleName="LOC_CITY_NAME_DEGGENDORF" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="39" Y="51" CityLocaleName="LOC_CITY_NAME_KARLSRUHE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="41" Y="51" CityLocaleName="LOC_CITY_NAME_STUTTGART" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="51" CityLocaleName="LOC_CITY_NAME_ULM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="51" CityLocaleName="LOC_CITY_NAME_INGOLSTADT" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="40" Y="52" CityLocaleName="LOC_CITY_NAME_KARLSRUHE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="52" CityLocaleName="LOC_CITY_NAME_HEILBRONN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="52" CityLocaleName="LOC_CITY_NAME_CRAILSHEIM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="46" Y="52" CityLocaleName="LOC_CITY_NAME_NUREMBERG" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="39" Y="53" CityLocaleName="LOC_CITY_NAME_MAINZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="53" CityLocaleName="LOC_CITY_NAME_WUERZBURG" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="53" CityLocaleName="LOC_CITY_NAME_BAYREUTH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="39" Y="54" CityLocaleName="LOC_CITY_NAME_BONN" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="40" Y="54" CityLocaleName="LOC_CITY_NAME_WIESBADEN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="40" Y="54" CityLocaleName="LOC_CITY_NAME_WIESBADEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="41" Y="54" CityLocaleName="LOC_CITY_NAME_FRANKFURT_MAIN" />
-        	<Replace MapName="PlayEuropeAgain" X="43" Y="54" CityLocaleName="LOC_CITY_NAME_ASCHAFFENBURG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="54" CityLocaleName="LOC_CITY_NAME_ASCHAFFENBURG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="54" CityLocaleName="LOC_CITY_NAME_ZWICKAU" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="38" Y="55" CityLocaleName="LOC_CITY_NAME_AACHEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="39" Y="55" CityLocaleName="LOC_CITY_NAME_COLOGNE" />
 		<Replace MapName="PlayEuropeAgain" X="40" Y="55" CityLocaleName="LOC_CITY_NAME_KOBLENZ" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="41" Y="55" CityLocaleName="LOC_CITY_NAME_SIEGEN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="41" Y="55" CityLocaleName="LOC_CITY_NAME_SIEGEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="42" Y="55" CityLocaleName="LOC_CITY_NAME_KASSEL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="55" CityLocaleName="LOC_CITY_NAME_FULDA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="55" CityLocaleName="LOC_CITY_NAME_ERFURT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="46" Y="55" CityLocaleName="LOC_CITY_NAME_DRESDEN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="40" Y="56" CityLocaleName="LOC_CITY_NAME_DUESSELDORF" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="41" Y="56" CityLocaleName="LOC_CITY_NAME_DORTMUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="42" Y="56" CityLocaleName="LOC_CITY_NAME_PADERBORN" Area="0" />
@@ -733,21 +732,21 @@
 		<Replace MapName="PlayEuropeAgain" X="44" Y="56" CityLocaleName="LOC_CITY_NAME_GOETTINGEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="56" CityLocaleName="LOC_CITY_NAME_LEIPZIG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="56" CityLocaleName="LOC_CITY_NAME_COTTBUS" Area="0" />
-	
+
 	</CityMap>
-	
+
 	<CityMap> <!-- SCANDINAVIA -->
-	
+
 		<!-- DENMARK, NORWAY, SWEDEN, NORTHERN FINLAND, KOLA PENINSULA, & SAAREMAA/OSEL -->
 		<Replace MapName="PlayEuropeAgain" X="46" Y="63" CityLocaleName="LOC_CITY_NAME_NAKSKOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="63" CityLocaleName="LOC_CITY_NAME_KOBENHAVN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="44" Y="64" CityLocaleName="LOC_CITY_NAME_TONDER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="64" CityLocaleName="LOC_CITY_NAME_ODENSE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="64" CityLocaleName="LOC_CITY_NAME_KOBENHAVN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="64" CityLocaleName="LOC_CITY_NAME_MALMOE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="64" CityLocaleName="LOC_CITY_NAME_YSTAD" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="43" Y="65" CityLocaleName="LOC_CITY_NAME_ESBJERG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="65" CityLocaleName="LOC_CITY_NAME_HERNING" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="65" CityLocaleName="LOC_CITY_NAME_AARHUS" Area="0" />
@@ -755,7 +754,7 @@
 		<Replace MapName="PlayEuropeAgain" X="49" Y="65" CityLocaleName="LOC_CITY_NAME_VAERNAMO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="65" CityLocaleName="LOC_CITY_NAME_KRISTIANSTAD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="65" CityLocaleName="LOC_CITY_NAME_KARLSKRONA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="44" Y="66" CityLocaleName="LOC_CITY_NAME_HOLSTEBRO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="66" CityLocaleName="LOC_CITY_NAME_AALBORG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="46" Y="66" CityLocaleName="LOC_CITY_NAME_AALBORG" Area="0" />
@@ -764,7 +763,7 @@
 		<Replace MapName="PlayEuropeAgain" X="51" Y="66" CityLocaleName="LOC_CITY_NAME_VAEXJOE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="66" CityLocaleName="LOC_CITY_NAME_KALMAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="66" CityLocaleName="LOC_CITY_NAME_VISBY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="44" Y="67" CityLocaleName="LOC_CITY_NAME_KLITMOLLER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="67" CityLocaleName="LOC_CITY_NAME_FREDERIKSHAVN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="67" CityLocaleName="LOC_CITY_NAME_BORAS" Area="0" />
@@ -772,26 +771,26 @@
 		<Replace MapName="PlayEuropeAgain" X="51" Y="67" CityLocaleName="LOC_CITY_NAME_JOENKOEPING" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="67" CityLocaleName="LOC_CITY_NAME_VAESTERVIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="67" CityLocaleName="LOC_CITY_NAME_VISBY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="46" Y="68" CityLocaleName="LOC_CITY_NAME_FREDERIKSHAVN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="68" CityLocaleName="LOC_CITY_NAME_GOETEBORG" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="68" CityLocaleName="LOC_CITY_NAME_KARLSBORG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="68" CityLocaleName="LOC_CITY_NAME_KURESSAARE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="68" CityLocaleName="LOC_CITY_NAME_KURESSAARE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="49" Y="69" CityLocaleName="LOC_CITY_NAME_TROLLHAETTAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="69" CityLocaleName="LOC_CITY_NAME_SKOEVDE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="69" CityLocaleName="LOC_CITY_NAME_ASKERSUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="69" CityLocaleName="LOC_CITY_NAME_NORRKOEPING" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="69" CityLocaleName="LOC_CITY_NAME_KAERDLA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="43" Y="70" CityLocaleName="LOC_CITY_NAME_FLEKKEFJORD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="70" CityLocaleName="LOC_CITY_NAME_KRISTIANSAND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="70" CityLocaleName="LOC_CITY_NAME_KRISTIANSAND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="70" CityLocaleName="LOC_CITY_NAME_FREDRIKSTAD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="70" CityLocaleName="LOC_CITY_NAME_MELLERUD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="70" CityLocaleName="LOC_CITY_NAME_LIDKOEPING" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="42" Y="71" CityLocaleName="LOC_CITY_NAME_STAVANGER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="71" CityLocaleName="LOC_CITY_NAME_BYKLE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="71" CityLocaleName="LOC_CITY_NAME_BYKLE" Area="0" />
@@ -802,7 +801,7 @@
 		<Replace MapName="PlayEuropeAgain" X="52" Y="71" CityLocaleName="LOC_CITY_NAME_OEREBRO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="71" CityLocaleName="LOC_CITY_NAME_NYKOEPING" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="71" CityLocaleName="LOC_CITY_NAME_MARIEHAMN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="42" Y="72" CityLocaleName="LOC_CITY_NAME_STAVANGER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="72" CityLocaleName="LOC_CITY_NAME_ROLDAL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="72" CityLocaleName="LOC_CITY_NAME_RJUKAN" Area="0" />
@@ -814,34 +813,34 @@
 		<Replace MapName="PlayEuropeAgain" X="53" Y="72" CityLocaleName="LOC_CITY_NAME_OEREBRO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="72" CityLocaleName="LOC_CITY_NAME_STOCKHOLM" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="72" CityLocaleName="LOC_CITY_NAME_MARIEHAMN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="44" Y="73" CityLocaleName="LOC_CITY_NAME_RJUKAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="73" CityLocaleName="LOC_CITY_NAME_SELJORD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="73" CityLocaleName="LOC_CITY_NAME_OSLO" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="73" CityLocaleName="LOC_CITY_NAME_ARVIKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="73" CityLocaleName="LOC_CITY_NAME_OEREBRO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="73" CityLocaleName="LOC_CITY_NAME_UPPSALA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="42" Y="74" CityLocaleName="LOC_CITY_NAME_BERGEN" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="74" CityLocaleName="LOC_CITY_NAME_BORLAENGE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="74" CityLocaleName="LOC_CITY_NAME_BORLAENGE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="74" CityLocaleName="LOC_CITY_NAME_UPPSALA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="74" CityLocaleName="LOC_CITY_NAME_FORSMARK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="74" CityLocaleName="LOC_CITY_NAME_GRISSLEHAMN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="43" Y="75" CityLocaleName="LOC_CITY_NAME_FLAM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="45" Y="75" CityLocaleName="LOC_CITY_NAME_GEILO" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="75" CityLocaleName="LOC_CITY_NAME_MALUNG" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="75" CityLocaleName="LOC_CITY_NAME_FALUN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="75" CityLocaleName="LOC_CITY_NAME_FALUN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="75" CityLocaleName="LOC_CITY_NAME_GAEVLE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="42" Y="76" CityLocaleName="LOC_CITY_NAME_ASKVOLL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="76" CityLocaleName="LOC_CITY_NAME_FORDE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="76" CityLocaleName="LOC_CITY_NAME_MALUNG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="76" CityLocaleName="LOC_CITY_NAME_LJUSDAL" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="76" CityLocaleName="LOC_CITY_NAME_GAEVLE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="42" Y="77" CityLocaleName="LOC_CITY_NAME_FLORO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="43" Y="77" CityLocaleName="LOC_CITY_NAME_FORDE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="77" CityLocaleName="LOC_CITY_NAME_SKEI" Area="0" />
@@ -850,51 +849,51 @@
 		<Replace MapName="PlayEuropeAgain" X="49" Y="77" CityLocaleName="LOC_CITY_NAME_MORA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="77" CityLocaleName="LOC_CITY_NAME_MORA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="77" CityLocaleName="LOC_CITY_NAME_HASSELA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="43" Y="78" CityLocaleName="LOC_CITY_NAME_ALESUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="78" CityLocaleName="LOC_CITY_NAME_ALESUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="46" Y="78" CityLocaleName="LOC_CITY_NAME_TINGVOLL" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="78" CityLocaleName="LOC_CITY_NAME_SVEG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="78" CityLocaleName="LOC_CITY_NAME_SUNDSVALL" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="44" Y="79" CityLocaleName="LOC_CITY_NAME_MOLDE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="79" CityLocaleName="LOC_CITY_NAME_MELDAL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="79" CityLocaleName="LOC_CITY_NAME_TOLGA" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="79" CityLocaleName="LOC_CITY_NAME_ARE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="79" CityLocaleName="LOC_CITY_NAME_SVEG" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="46" Y="80" CityLocaleName="LOC_CITY_NAME_KRISTIANSUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="80" CityLocaleName="LOC_CITY_NAME_KRISTIANSUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="80" CityLocaleName="LOC_CITY_NAME_ARE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="80" CityLocaleName="LOC_CITY_NAME_RAMSELE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="48" Y="81" CityLocaleName="LOC_CITY_NAME_TRONDHEIM" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="81" CityLocaleName="LOC_CITY_NAME_OESTERSUND" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="81" CityLocaleName="LOC_CITY_NAME_UMEA" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="51" Y="82" CityLocaleName="LOC_CITY_NAME_STROEMSUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="82" CityLocaleName="LOC_CITY_NAME_STROEMSUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="82" CityLocaleName="LOC_CITY_NAME_STROEMSUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="82" CityLocaleName="LOC_CITY_NAME_LYCKSELE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="82" CityLocaleName="LOC_CITY_NAME_ROBERTSFORS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="82" CityLocaleName="LOC_CITY_NAME_ROBERTSFORS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="51" Y="83" CityLocaleName="LOC_CITY_NAME_HARRAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="83" CityLocaleName="LOC_CITY_NAME_MALA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="83" CityLocaleName="LOC_CITY_NAME_SKELLEFTEA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="84" CityLocaleName="LOC_CITY_NAME_NAMSOS" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="84" CityLocaleName="LOC_CITY_NAME_HARRAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="84" CityLocaleName="LOC_CITY_NAME_ARJEPLOG" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="84" CityLocaleName="LOC_CITY_NAME_ARVIDSJAUR" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="84" CityLocaleName="LOC_CITY_NAME_PITEA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="51" Y="85" CityLocaleName="LOC_CITY_NAME_TRONES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="85" CityLocaleName="LOC_CITY_NAME_TRONES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="85" CityLocaleName="LOC_CITY_NAME_JOKKMOKK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="85" CityLocaleName="LOC_CITY_NAME_VIDSEL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="85" CityLocaleName="LOC_CITY_NAME_LULEA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="51" Y="86" CityLocaleName="LOC_CITY_NAME_BRONNOYSUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="86" CityLocaleName="LOC_CITY_NAME_TRONES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="86" CityLocaleName="LOC_CITY_NAME_JOKKMOKK" />
@@ -906,7 +905,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="86" CityLocaleName="LOC_CITY_NAME_RANUA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="86" CityLocaleName="LOC_CITY_NAME_RANUA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="86" CityLocaleName="LOC_CITY_NAME_MALINOVAYA_VARAKKA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="51" Y="87" CityLocaleName="LOC_CITY_NAME_BRONNOYSUND" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="87" CityLocaleName="LOC_CITY_NAME_STORFJORD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="87" CityLocaleName="LOC_CITY_NAME_GAELLIVARE" Area="0" />
@@ -916,7 +915,7 @@
 		<Replace MapName="PlayEuropeAgain" X="61" Y="87" CityLocaleName="LOC_CITY_NAME_PELLO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="87" CityLocaleName="LOC_CITY_NAME_KUUSAMO" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="87" CityLocaleName="LOC_CITY_NAME_KOVDA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="53" Y="88" CityLocaleName="LOC_CITY_NAME_BODO" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="88" CityLocaleName="LOC_CITY_NAME_RITSEM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="88" CityLocaleName="LOC_CITY_NAME_PAJALA" Area="0" />
@@ -926,7 +925,7 @@
 		<Replace MapName="PlayEuropeAgain" X="70" Y="88" CityLocaleName="LOC_CITY_NAME_UMBA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="88" CityLocaleName="LOC_CITY_NAME_KASHKARANTSY" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="88" CityLocaleName="LOC_CITY_NAME_CHAPOMA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="89" CityLocaleName="LOC_CITY_NAME_LAPPLANDIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="89" CityLocaleName="LOC_CITY_NAME_NIKKALUOKTA" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="89" CityLocaleName="LOC_CITY_NAME_PAJALA" Area="0" />
@@ -937,7 +936,7 @@
 		<Replace MapName="PlayEuropeAgain" X="70" Y="89" CityLocaleName="LOC_CITY_NAME_APATITY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="89" CityLocaleName="LOC_CITY_NAME_KANEVKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="89" CityLocaleName="LOC_CITY_NAME_PONOY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="90" CityLocaleName="LOC_CITY_NAME_LAPPLANDIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="90" CityLocaleName="LOC_CITY_NAME_KARESUVANOT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="90" CityLocaleName="LOC_CITY_NAME_HETTA" />
@@ -950,7 +949,7 @@
 		<Replace MapName="PlayEuropeAgain" X="72" Y="90" CityLocaleName="LOC_CITY_NAME_KANEVKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="90" CityLocaleName="LOC_CITY_NAME_KANEVKA" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="90" CityLocaleName="LOC_CITY_NAME_PONOY" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="91" CityLocaleName="LOC_CITY_NAME_NARVIK" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="91" CityLocaleName="LOC_CITY_NAME_LAPPLANDIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="91" CityLocaleName="LOC_CITY_NAME_SAARISELKAE" Area="0" />
@@ -960,7 +959,7 @@
 		<Replace MapName="PlayEuropeAgain" X="71" Y="91" CityLocaleName="LOC_CITY_NAME_KRASNOSHCHELYE" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="91" CityLocaleName="LOC_CITY_NAME_KANEVKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="91" CityLocaleName="LOC_CITY_NAME_LUMBOVKA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="53" Y="92" CityLocaleName="LOC_CITY_NAME_A_I_LOFOTEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="92" CityLocaleName="LOC_CITY_NAME_FINNSNES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="92" CityLocaleName="LOC_CITY_NAME_FINNSNES" Area="0" />
@@ -970,7 +969,7 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="92" CityLocaleName="LOC_CITY_NAME_SAARISELKAE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="92" CityLocaleName="LOC_CITY_NAME_MYS_CHYORNY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="92" CityLocaleName="LOC_CITY_NAME_MYS_CHYORNY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="53" Y="93" CityLocaleName="LOC_CITY_NAME_STO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="93" CityLocaleName="LOC_CITY_NAME_HARSTAD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="93" CityLocaleName="LOC_CITY_NAME_TROMSO" />
@@ -980,35 +979,35 @@
 		<Replace MapName="PlayEuropeAgain" X="69" Y="93" CityLocaleName="LOC_CITY_NAME_MURMANSK" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="93" CityLocaleName="LOC_CITY_NAME_TERIBERKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="93" CityLocaleName="LOC_CITY_NAME_TERIBERKA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="59" Y="94" CityLocaleName="LOC_CITY_NAME_STORSLETT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="94" CityLocaleName="LOC_CITY_NAME_UTSJOKI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="94" CityLocaleName="LOC_CITY_NAME_KIRKENES" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="94" CityLocaleName="LOC_CITY_NAME_PETSCHENGA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="60" Y="95" CityLocaleName="LOC_CITY_NAME_ALTA" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="95" CityLocaleName="LOC_CITY_NAME_TANA" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="96" CityLocaleName="LOC_CITY_NAME_NORDKAPP" Area="0" />
-		
+
 		<!-- SOUTHERN FINLAND & RUSSIAN KARELIA -->
 		<Replace MapName="PlayEuropeAgain" X="61" Y="72" CityLocaleName="LOC_CITY_NAME_HELSINKI" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="72" CityLocaleName="LOC_CITY_NAME_VSEVOLOZHSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="72" CityLocaleName="LOC_CITY_NAME_KIROVSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="72" CityLocaleName="LOC_CITY_NAME_VOLKHOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="72" CityLocaleName="LOC_CITY_NAME_VOLKHOV" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="58" Y="73" CityLocaleName="LOC_CITY_NAME_TURKU" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="73" CityLocaleName="LOC_CITY_NAME_KOTKA" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="73" CityLocaleName="LOC_CITY_NAME_VYBORG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="73" CityLocaleName="LOC_CITY_NAME_PRIOZERSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="63" Y="74" CityLocaleName="LOC_CITY_NAME_LAHTI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="74" CityLocaleName="LOC_CITY_NAME_MIKKELI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="74" CityLocaleName="LOC_CITY_NAME_PRIOZERSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="74" CityLocaleName="LOC_CITY_NAME_KUYTEZHA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="74" CityLocaleName="LOC_CITY_NAME_LODEYNOYE_POLE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="60" Y="75" CityLocaleName="LOC_CITY_NAME_TAMPERE" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="75" CityLocaleName="LOC_CITY_NAME_JAEMSAE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="75" CityLocaleName="LOC_CITY_NAME_MIKKELI" Area="0" />
@@ -1018,7 +1017,7 @@
 		<Replace MapName="PlayEuropeAgain" X="70" Y="75" CityLocaleName="LOC_CITY_NAME_KUYTEZHA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="75" CityLocaleName="LOC_CITY_NAME_LADVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="75" CityLocaleName="LOC_CITY_NAME_SHCHELEYKI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="58" Y="76" CityLocaleName="LOC_CITY_NAME_PORI" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="76" CityLocaleName="LOC_CITY_NAME_KEURUU" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="76" CityLocaleName="LOC_CITY_NAME_JYVAESKYLAE" Area="0" />
@@ -1028,7 +1027,7 @@
 		<Replace MapName="PlayEuropeAgain" X="69" Y="76" CityLocaleName="LOC_CITY_NAME_PITKYARANTA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="76" CityLocaleName="LOC_CITY_NAME_VEDLOZERO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="76" CityLocaleName="LOC_CITY_NAME_PETROZAVODSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="59" Y="77" CityLocaleName="LOC_CITY_NAME_ALAVUS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="77" CityLocaleName="LOC_CITY_NAME_ALAVUS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="77" CityLocaleName="LOC_CITY_NAME_VIITASAARI" Area="0" />
@@ -1037,28 +1036,28 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="77" CityLocaleName="LOC_CITY_NAME_LIPERI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="77" CityLocaleName="LOC_CITY_NAME_SUYSTAMO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="77" CityLocaleName="LOC_CITY_NAME_PETROZAVODSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="61" Y="78" CityLocaleName="LOC_CITY_NAME_HAAPAJAERVI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="78" CityLocaleName="LOC_CITY_NAME_SUONENJOKI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="78" CityLocaleName="LOC_CITY_NAME_KUOPIO" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="78" CityLocaleName="LOC_CITY_NAME_SUOYARVI" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="78" CityLocaleName="LOC_CITY_NAME_PINDUSHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="78" CityLocaleName="LOC_CITY_NAME_PINDUSHI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="59" Y="79" CityLocaleName="LOC_CITY_NAME_VAASA" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="79" CityLocaleName="LOC_CITY_NAME_SIIKALATVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="79" CityLocaleName="LOC_CITY_NAME_VUOLIJOKI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="79" CityLocaleName="LOC_CITY_NAME_KAJAANI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="79" CityLocaleName="LOC_CITY_NAME_ROMPPALA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="79" CityLocaleName="LOC_CITY_NAME_JOENSUU" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="80" CityLocaleName="LOC_CITY_NAME_VAALA" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="80" CityLocaleName="LOC_CITY_NAME_KAJAANI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="80" CityLocaleName="LOC_CITY_NAME_JUUKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="80" CityLocaleName="LOC_CITY_NAME_POPOV_POROG" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="80" CityLocaleName="LOC_CITY_NAME_LEKHTA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="80" CityLocaleName="LOC_CITY_NAME_SEGEZHA" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="60" Y="81" CityLocaleName="LOC_CITY_NAME_KOKKOLA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="81" CityLocaleName="LOC_CITY_NAME_RAAHE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="81" CityLocaleName="LOC_CITY_NAME_PALTAMO" Area="0" />
@@ -1068,32 +1067,32 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="81" CityLocaleName="LOC_CITY_NAME_SHALGOVAARA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="81" CityLocaleName="LOC_CITY_NAME_NOVOYE_MASHEZERO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="81" CityLocaleName="LOC_CITY_NAME_LEKHTA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="64" Y="82" CityLocaleName="LOC_CITY_NAME_PUOLANKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="82" CityLocaleName="LOC_CITY_NAME_NURMES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="82" CityLocaleName="LOC_CITY_NAME_NURMES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="82" CityLocaleName="LOC_CITY_NAME_KOSTOMUKSCHA" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="82" CityLocaleName="LOC_CITY_NAME_NOVOYE_MASHEZERO" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="83" CityLocaleName="LOC_CITY_NAME_OULU" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="83" CityLocaleName="LOC_CITY_NAME_KOSTOMUKSCHA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="83" CityLocaleName="LOC_CITY_NAME_NOVOYE_MASHEZERO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="83" CityLocaleName="LOC_CITY_NAME_KOLEZHMA" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="65" Y="84" CityLocaleName="LOC_CITY_NAME_TAIVALKOSKI" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="84" CityLocaleName="LOC_CITY_NAME_TAIVALKOSKI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="84" CityLocaleName="LOC_CITY_NAME_KESTENGA" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="63" Y="85" CityLocaleName="LOC_CITY_NAME_RANUA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="85" CityLocaleName="LOC_CITY_NAME_PLOTINA" />
-		
+
 		<!-- ICELAND -->
 		<Replace MapName="PlayEuropeAgain" X="8" Y="88" CityLocaleName="LOC_CITY_NAME_KEFLAVIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="9" Y="88" CityLocaleName="LOC_CITY_NAME_HAFNARFJORTHUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="11" Y="88" CityLocaleName="LOC_CITY_NAME_HELLA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="12" Y="88" CityLocaleName="LOC_CITY_NAME_HELLA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="15" Y="88" CityLocaleName="LOC_CITY_NAME_HOFN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="9" Y="89" CityLocaleName="LOC_CITY_NAME_HAFNARFJORTHUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="10" Y="89" CityLocaleName="LOC_CITY_NAME_SELFOSS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="11" Y="89" CityLocaleName="LOC_CITY_NAME_HELLA" Area="0" />
@@ -1101,7 +1100,7 @@
 		<Replace MapName="PlayEuropeAgain" X="13" Y="89" CityLocaleName="LOC_CITY_NAME_FLJOTSDALSHREPPUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="14" Y="89" CityLocaleName="LOC_CITY_NAME_FLJOTSDALSHREPPUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="15" Y="89" CityLocaleName="LOC_CITY_NAME_REYTHARFJORTHUR" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="9" Y="90" CityLocaleName="LOC_CITY_NAME_REYKJAVIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="10" Y="90" CityLocaleName="LOC_CITY_NAME_HVERAGERTHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="11" Y="90" CityLocaleName="LOC_CITY_NAME_HVERAGERTHI" Area="0" />
@@ -1110,7 +1109,7 @@
 		<Replace MapName="PlayEuropeAgain" X="14" Y="90" CityLocaleName="LOC_CITY_NAME_FLJOTSDALSHREPPUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="15" Y="90" CityLocaleName="LOC_CITY_NAME_REYTHARFJORTHUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="16" Y="90" CityLocaleName="LOC_CITY_NAME_REYTHARFJORTHUR" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="9" Y="91" CityLocaleName="LOC_CITY_NAME_REYKJAVIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="10" Y="91" CityLocaleName="LOC_CITY_NAME_SKALHOLT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="11" Y="91" CityLocaleName="LOC_CITY_NAME_SKEITHA" Area="0" />
@@ -1118,7 +1117,7 @@
 		<Replace MapName="PlayEuropeAgain" X="13" Y="91" CityLocaleName="LOC_CITY_NAME_SKEITHA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="14" Y="91" CityLocaleName="LOC_CITY_NAME_HRAFNAGIL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="15" Y="91" CityLocaleName="LOC_CITY_NAME_REYTHARFJORTHUR" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="8" Y="92" CityLocaleName="LOC_CITY_NAME_GRUNDARFJORTHUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="9" Y="92" CityLocaleName="LOC_CITY_NAME_GRUNDARFJORTHUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="10" Y="92" CityLocaleName="LOC_CITY_NAME_BUTHARDALUR" Area="0" />
@@ -1129,68 +1128,68 @@
 		<Replace MapName="PlayEuropeAgain" X="15" Y="92" CityLocaleName="LOC_CITY_NAME_AKUREYRI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="16" Y="92" CityLocaleName="LOC_CITY_NAME_THORSHOFN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="17" Y="92" CityLocaleName="LOC_CITY_NAME_THORSHOFN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="10" Y="93" CityLocaleName="LOC_CITY_NAME_BUTHARDALUR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="11" Y="93" CityLocaleName="LOC_CITY_NAME_HVAMMSTANGI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="13" Y="93" CityLocaleName="LOC_CITY_NAME_AKUREYRI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="14" Y="93" CityLocaleName="LOC_CITY_NAME_AKUREYRI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="15" Y="93" CityLocaleName="LOC_CITY_NAME_THORSHOFN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="11" Y="94" CityLocaleName="LOC_CITY_NAME_HVAMMSTANGI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="9" Y="95" CityLocaleName="LOC_CITY_NAME_ISAFJORTHUR" />
-		
+
 	</CityMap>
-	
+
 	<CityMap> <!-- GREECE -->
-		
+
 		<!-- GREECE (MAINLAND) -->
 		<Replace MapName="PlayEuropeAgain" X="58" Y="20" CityLocaleName="LOC_CITY_NAME_KALAMATA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="20" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="57" Y="21" CityLocaleName="LOC_CITY_NAME_KYPARISSIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="21" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="21" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="21" CityLocaleName="LOC_CITY_NAME_POROS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="57" Y="22" CityLocaleName="LOC_CITY_NAME_ARCHEA_OLIMPIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="22" CityLocaleName="LOC_CITY_NAME_TRIPOLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="22" CityLocaleName="LOC_CITY_NAME_ARGOS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="22" CityLocaleName="LOC_CITY_NAME_NAFPLION" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="23" CityLocaleName="LOC_CITY_NAME_VARDA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="23" CityLocaleName="LOC_CITY_NAME_PATRAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="23" CityLocaleName="LOC_CITY_NAME_PATRAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="23" CityLocaleName="LOC_CITY_NAME_CORINTH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="23" CityLocaleName="LOC_CITY_NAME_KORFOS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="60" Y="24" CityLocaleName="LOC_CITY_NAME_CORINTH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="25" CityLocaleName="LOC_CITY_NAME_MISSOLONGHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="25" CityLocaleName="LOC_CITY_NAME_NAFPAKTOS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="25" CityLocaleName="LOC_CITY_NAME_ARACHOVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="25" CityLocaleName="LOC_CITY_NAME_THIVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="25" CityLocaleName="LOC_CITY_NAME_ATHENS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="25" CityLocaleName="LOC_CITY_NAME_ATHENS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="26" CityLocaleName="LOC_CITY_NAME_PREVEZA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="26" CityLocaleName="LOC_CITY_NAME_AGRINIO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="26" CityLocaleName="LOC_CITY_NAME_KARPENISSI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="26" CityLocaleName="LOC_CITY_NAME_LAMIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="26" CityLocaleName="LOC_CITY_NAME_LAMIA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="27" CityLocaleName="LOC_CITY_NAME_IGOUMENITSA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="27" CityLocaleName="LOC_CITY_NAME_IOANNINA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="27" CityLocaleName="LOC_CITY_NAME_LARISSA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="27" CityLocaleName="LOC_CITY_NAME_LARISSA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="27" CityLocaleName="LOC_CITY_NAME_VOLOS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="28" CityLocaleName="LOC_CITY_NAME_SARANDE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="28" CityLocaleName="LOC_CITY_NAME_GJIROKASTER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="28" CityLocaleName="LOC_CITY_NAME_GREVENA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="28" CityLocaleName="LOC_CITY_NAME_SERVIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="28" CityLocaleName="LOC_CITY_NAME_KATERINI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="29" CityLocaleName="LOC_CITY_NAME_VLORE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="29" CityLocaleName="LOC_CITY_NAME_TEPELENE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="29" CityLocaleName="LOC_CITY_NAME_KORCE" Area="0" />
@@ -1199,7 +1198,7 @@
 		<Replace MapName="PlayEuropeAgain" X="59" Y="29" CityLocaleName="LOC_CITY_NAME_THESSALONIKI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="29" CityLocaleName="LOC_CITY_NAME_THESSALONIKI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="29" CityLocaleName="LOC_CITY_NAME_OURANOUPOLI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="30" CityLocaleName="LOC_CITY_NAME_VLORE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="30" CityLocaleName="LOC_CITY_NAME_BERAT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="30" CityLocaleName="LOC_CITY_NAME_KORCE" Area="0" />
@@ -1210,7 +1209,7 @@
 		<Replace MapName="PlayEuropeAgain" X="61" Y="30" CityLocaleName="LOC_CITY_NAME_STAVROS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="30" CityLocaleName="LOC_CITY_NAME_ALEXANDROUPOLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="30" CityLocaleName="LOC_CITY_NAME_ALEXANDROUPOLI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="31" CityLocaleName="LOC_CITY_NAME_DURRES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="31" CityLocaleName="LOC_CITY_NAME_TIRANA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="31" CityLocaleName="LOC_CITY_NAME_OHRID" Area="0" />
@@ -1223,7 +1222,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="31" CityLocaleName="LOC_CITY_NAME_ALEXANDROUPOLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="31" CityLocaleName="LOC_CITY_NAME_ALEXANDROUPOLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="31" CityLocaleName="LOC_CITY_NAME_GALLIPOLI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="32" CityLocaleName="LOC_CITY_NAME_DURRES" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="32" CityLocaleName="LOC_CITY_NAME_TIRANA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="32" CityLocaleName="LOC_CITY_NAME_OHRID" Area="0" />
@@ -1237,29 +1236,29 @@
 		<Replace MapName="PlayEuropeAgain" X="67" Y="32" CityLocaleName="LOC_CITY_NAME_GALLIPOLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="32" CityLocaleName="LOC_CITY_NAME_ISTANBUL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="32" CityLocaleName="LOC_CITY_NAME_ISTANBUL" Area="0" />
-		
+
 		<!-- GREECE (AEGEAN ISLANDS) -->
 		<Replace MapName="PlayEuropeAgain" X="60" Y="18" CityLocaleName="LOC_CITY_NAME_CHANIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="18" CityLocaleName="LOC_CITY_NAME_RETHYMNO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="18" CityLocaleName="LOC_CITY_NAME_HERAKLION" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="18" CityLocaleName="LOC_CITY_NAME_AGIOS_NIKOLAOS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="20" CityLocaleName="LOC_CITY_NAME_FIRA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="64" Y="21" CityLocaleName="LOC_CITY_NAME_KOS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="21" CityLocaleName="LOC_CITY_NAME_RHODES" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="23" CityLocaleName="LOC_CITY_NAME_ANDROS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="23" CityLocaleName="LOC_CITY_NAME_SAMOS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="23" CityLocaleName="LOC_CITY_NAME_SAMOS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="63" Y="26" CityLocaleName="LOC_CITY_NAME_SKYROS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="29" CityLocaleName="LOC_CITY_NAME_MYRINA" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<CityMap> <!-- BALKANS -->
-	
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="33" CityLocaleName="LOC_CITY_NAME_SHKODER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="33" CityLocaleName="LOC_CITY_NAME_SHKODER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="33" CityLocaleName="LOC_CITY_NAME_STRUMICA" Area="0" />
@@ -1267,7 +1266,7 @@
 		<Replace MapName="PlayEuropeAgain" X="61" Y="33" CityLocaleName="LOC_CITY_NAME_SMOLYAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="33" CityLocaleName="LOC_CITY_NAME_EDIRNE" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="33" CityLocaleName="LOC_CITY_NAME_KIRKLARELI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="34" CityLocaleName="LOC_CITY_NAME_SHKODER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="34" CityLocaleName="LOC_CITY_NAME_SHKODER" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="34" CityLocaleName="LOC_CITY_NAME_SKOPJE" />
@@ -1275,22 +1274,22 @@
 		<Replace MapName="PlayEuropeAgain" X="61" Y="34" CityLocaleName="LOC_CITY_NAME_BLAGOEVGRAD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="34" CityLocaleName="LOC_CITY_NAME_PLOVDIV" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="34" CityLocaleName="LOC_CITY_NAME_BURGAS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="59" Y="35" CityLocaleName="LOC_CITY_NAME_SOFIA" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="35" CityLocaleName="LOC_CITY_NAME_YAMBOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="35" CityLocaleName="LOC_CITY_NAME_BURGAS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="52" Y="36" CityLocaleName="LOC_CITY_NAME_DUBROVNIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="36" CityLocaleName="LOC_CITY_NAME_PODGORICA" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="36" CityLocaleName="LOC_CITY_NAME_PRISTINA" Area="0" />
-        	<Replace MapName="PlayEuropeAgain" X="57" Y="36" CityLocaleName="LOC_CITY_NAME_PRISTINA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="57" Y="36" CityLocaleName="LOC_CITY_NAME_PRISTINA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="36" CityLocaleName="LOC_CITY_NAME_NIS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="36" CityLocaleName="LOC_CITY_NAME_PLEVEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="36" CityLocaleName="LOC_CITY_NAME_SVISHTOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="36" CityLocaleName="LOC_CITY_NAME_RUSE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="36" CityLocaleName="LOC_CITY_NAME_VELIKO_TARNOVO" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="36" CityLocaleName="LOC_CITY_NAME_VARNA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="37" CityLocaleName="LOC_CITY_NAME_DUBROVNIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="37" CityLocaleName="LOC_CITY_NAME_DUBROVNIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="37" CityLocaleName="LOC_CITY_NAME_SARAJEVO" Area="0" />
@@ -1307,13 +1306,13 @@
 		<Replace MapName="PlayEuropeAgain" X="65" Y="37" CityLocaleName="LOC_CITY_NAME_PRESLAV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="37" CityLocaleName="LOC_CITY_NAME_PRESLAV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="37" CityLocaleName="LOC_CITY_NAME_VARNA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="38" CityLocaleName="LOC_CITY_NAME_SPLIT" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="38" CityLocaleName="LOC_CITY_NAME_SARAJEVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="38" CityLocaleName="LOC_CITY_NAME_SABAC" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="38" CityLocaleName="LOC_CITY_NAME_SABAC" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="38" CityLocaleName="LOC_CITY_NAME_BEOGRAD" Area="0" /> <!-- OVERLAP -->
-        	<Replace MapName="PlayEuropeAgain" X="57" Y="38" CityLocaleName="LOC_CITY_NAME_BEOGRAD" />
+		<Replace MapName="PlayEuropeAgain" X="57" Y="38" CityLocaleName="LOC_CITY_NAME_BEOGRAD" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="38" CityLocaleName="LOC_CITY_NAME_VIDIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="38" CityLocaleName="LOC_CITY_NAME_CRAIOVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="38" CityLocaleName="LOC_CITY_NAME_CRAIOVA" Area="0" />
@@ -1322,7 +1321,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="38" CityLocaleName="LOC_CITY_NAME_GIURGU" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="38" CityLocaleName="LOC_CITY_NAME_CALARASI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="38" CityLocaleName="LOC_CITY_NAME_CONSTANTA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="52" Y="39" CityLocaleName="LOC_CITY_NAME_ZENICA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="39" CityLocaleName="LOC_CITY_NAME_SLAVONSKI_BROD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="39" CityLocaleName="LOC_CITY_NAME_SABAC" Area="0" />
@@ -1333,7 +1332,7 @@
 		<Replace MapName="PlayEuropeAgain" X="65" Y="39" CityLocaleName="LOC_CITY_NAME_BUCHAREST" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="39" CityLocaleName="LOC_CITY_NAME_BRAILA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="39" CityLocaleName="LOC_CITY_NAME_CONSTANTA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="48" Y="40" CityLocaleName="LOC_CITY_NAME_PULA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="40" CityLocaleName="LOC_CITY_NAME_RIJEKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="40" CityLocaleName="LOC_CITY_NAME_SLAVONSKI_BROD" Area="0" />
@@ -1350,7 +1349,7 @@
 		<Replace MapName="PlayEuropeAgain" X="67" Y="40" CityLocaleName="LOC_CITY_NAME_BRAILA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="40" CityLocaleName="LOC_CITY_NAME_BRAILA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="40" CityLocaleName="LOC_CITY_NAME_TULCEA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="41" CityLocaleName="LOC_CITY_NAME_ZAGREB" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="41" CityLocaleName="LOC_CITY_NAME_PECS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="41" CityLocaleName="LOC_CITY_NAME_OSIJEK" Area="0" />
@@ -1366,7 +1365,7 @@
 		<Replace MapName="PlayEuropeAgain" X="67" Y="41" CityLocaleName="LOC_CITY_NAME_GALATI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="41" CityLocaleName="LOC_CITY_NAME_GALATI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="41" CityLocaleName="LOC_CITY_NAME_IZMAIL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="48" Y="42" CityLocaleName="LOC_CITY_NAME_LJUBLJANA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="42" CityLocaleName="LOC_CITY_NAME_LJUBLJANA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="42" CityLocaleName="LOC_CITY_NAME_PECS" Area="0" />
@@ -1387,11 +1386,11 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="42" CityLocaleName="LOC_CITY_NAME_BACAU" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="42" CityLocaleName="LOC_CITY_NAME_GALATI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="42" CityLocaleName="LOC_CITY_NAME_IZMAIL" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<CityMap> <!-- CENTRAL & EASTERN EUROPE (AUSTRIA, CZECHIA, POLAND, HUNGARY, SLOVAKIA, BELARUS, WESTERN UKRAINE, MOLDOVA, NORTHERN ROMANIA, & SOUTHERN LITHUANIA) -->
-	
+
 		<Replace MapName="PlayEuropeAgain" X="47" Y="43" CityLocaleName="LOC_CITY_NAME_KLAGENFURT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="43" CityLocaleName="LOC_CITY_NAME_LJUBLJANA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="43" CityLocaleName="LOC_CITY_NAME_SZOMBATHELY" Area="0" />
@@ -1408,7 +1407,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="43" CityLocaleName="LOC_CITY_NAME_VASLUI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="43" CityLocaleName="LOC_CITY_NAME_TIRASPOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="43" CityLocaleName="LOC_CITY_NAME_BILHOROD_DNISTROVSKYI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="48" Y="44" CityLocaleName="LOC_CITY_NAME_GRAZ" />
 		<Replace MapName="PlayEuropeAgain" X="50" Y="44" CityLocaleName="LOC_CITY_NAME_SZOMBATHELY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="44" CityLocaleName="LOC_CITY_NAME_SZOMBATHELY" Area="0" />
@@ -1423,7 +1422,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="44" CityLocaleName="LOC_CITY_NAME_VATRA_DORNEI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="44" CityLocaleName="LOC_CITY_NAME_IASI" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="44" CityLocaleName="LOC_CITY_NAME_TIRASPOL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="45" Y="45" CityLocaleName="LOC_CITY_NAME_INNSBRUCK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="46" Y="45" CityLocaleName="LOC_CITY_NAME_LIENZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="45" CityLocaleName="LOC_CITY_NAME_WIENER_NEUSTADT" Area="0" />
@@ -1438,7 +1437,7 @@
 		<Replace MapName="PlayEuropeAgain" X="63" Y="45" CityLocaleName="LOC_CITY_NAME_SIGHETU_MARMATIEI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="45" CityLocaleName="LOC_CITY_NAME_KOLOMYYA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="45" CityLocaleName="LOC_CITY_NAME_CHISINAU" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="45" Y="46" CityLocaleName="LOC_CITY_NAME_INNSBRUCK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="47" Y="46" CityLocaleName="LOC_CITY_NAME_LIEZEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="48" Y="46" CityLocaleName="LOC_CITY_NAME_ST_POLTEN" Area="0" />
@@ -1456,7 +1455,7 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="46" CityLocaleName="LOC_CITY_NAME_CHERNIVTSI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="46" CityLocaleName="LOC_CITY_NAME_BALTI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="46" CityLocaleName="LOC_CITY_NAME_ORHEI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="48" Y="47" CityLocaleName="LOC_CITY_NAME_ST_POLTEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="47" CityLocaleName="LOC_CITY_NAME_NITRA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="47" CityLocaleName="LOC_CITY_NAME_ZVOLEN" Area="0" />
@@ -1471,7 +1470,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="47" CityLocaleName="LOC_CITY_NAME_HAISYN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="47" CityLocaleName="LOC_CITY_NAME_HAISYN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="47" CityLocaleName="LOC_CITY_NAME_UMAN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="48" Y="48" CityLocaleName="LOC_CITY_NAME_LINZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="48" CityLocaleName="LOC_CITY_NAME_LINZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="48" CityLocaleName="LOC_CITY_NAME_TRENCIN" Area="0" />
@@ -1483,7 +1482,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="48" CityLocaleName="LOC_CITY_NAME_KHMELNYTSKYI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="48" CityLocaleName="LOC_CITY_NAME_VINNYTSIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="48" CityLocaleName="LOC_CITY_NAME_VINNYTSIA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="49" CityLocaleName="LOC_CITY_NAME_BRNO" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="49" CityLocaleName="LOC_CITY_NAME_ZILINA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="49" CityLocaleName="LOC_CITY_NAME_ZILINA" Area="0" />
@@ -1509,7 +1508,7 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="50" CityLocaleName="LOC_CITY_NAME_SHEPETIVKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="50" CityLocaleName="LOC_CITY_NAME_SHEPETIVKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="50" CityLocaleName="LOC_CITY_NAME_ZHYTOMYR" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="47" Y="51" CityLocaleName="LOC_CITY_NAME_PLZEN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="51" CityLocaleName="LOC_CITY_NAME_OSTRAVA" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="51" CityLocaleName="LOC_CITY_NAME_KATOWICE" Area="0" />
@@ -1527,7 +1526,7 @@
 		<Replace MapName="PlayEuropeAgain" X="60" Y="52" CityLocaleName="LOC_CITY_NAME_BIALA_PODLASKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="52" CityLocaleName="LOC_CITY_NAME_BREST_LITOVSK" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="52" CityLocaleName="LOC_CITY_NAME_NOVOHRAD_VOLYNSKYI" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="47" Y="53" CityLocaleName="LOC_CITY_NAME_USTI_NAD_LABEM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="53" CityLocaleName="LOC_CITY_NAME_CZESTOCHOWA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="53" CityLocaleName="LOC_CITY_NAME_LODZ" />
@@ -1538,7 +1537,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="53" CityLocaleName="LOC_CITY_NAME_KOVEL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="53" CityLocaleName="LOC_CITY_NAME_NOVOHRAD_VOLYNSKYI" Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="69" Y="53" CityLocaleName="LOC_CITY_NAME_KOROSTEN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="48" Y="54" CityLocaleName="LOC_CITY_NAME_USTI_NAD_LABEM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="49" Y="54" CityLocaleName="LOC_CITY_NAME_LIBEREC" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="54" CityLocaleName="LOC_CITY_NAME_WROCLAW" />
@@ -1566,7 +1565,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="55" CityLocaleName="LOC_CITY_NAME_KOBRYN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="55" CityLocaleName="LOC_CITY_NAME_ZYTKAVICY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="55" CityLocaleName="LOC_CITY_NAME_MAZYR" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="56" CityLocaleName="LOC_CITY_NAME_ZIELONA_GORA" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="56" CityLocaleName="LOC_CITY_NAME_WLOCLAWEK" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="56" CityLocaleName="LOC_CITY_NAME_CIECHANOW" Area="0" />
@@ -1579,7 +1578,7 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="56" CityLocaleName="LOC_CITY_NAME_SALIHORSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="56" CityLocaleName="LOC_CITY_NAME_ZYTKAVICY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="56" CityLocaleName="LOC_CITY_NAME_BABRYUSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="52" Y="57" CityLocaleName="LOC_CITY_NAME_POZNAN" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="57" CityLocaleName="LOC_CITY_NAME_BYDGOSZCZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="57" CityLocaleName="LOC_CITY_NAME_BYDGOSZCZ" Area="0" />
@@ -1594,7 +1593,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="57" CityLocaleName="LOC_CITY_NAME_BABRYUSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="57" CityLocaleName="LOC_CITY_NAME_BABRYUSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="57" CityLocaleName="LOC_CITY_NAME_ZHLOBIN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="58" CityLocaleName="LOC_CITY_NAME_GORZOW_WIELKOPOLSI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="58" CityLocaleName="LOC_CITY_NAME_GORZOW_WIELKOPOLSI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="58" CityLocaleName="LOC_CITY_NAME_MALBORK" Area="0" />
@@ -1610,7 +1609,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="58" CityLocaleName="LOC_CITY_NAME_BABRYUSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="58" CityLocaleName="LOC_CITY_NAME_BABRYUSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="58" CityLocaleName="LOC_CITY_NAME_ZHLOBIN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="59" CityLocaleName="LOC_CITY_NAME_GORZOW_WIELKOPOLSI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="59" CityLocaleName="LOC_CITY_NAME_PILA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="59" CityLocaleName="LOC_CITY_NAME_CHOJNICE" Area="0" />
@@ -1625,7 +1624,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="59" CityLocaleName="LOC_CITY_NAME_MOGILEV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="59" CityLocaleName="LOC_CITY_NAME_MOGILEV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="59" CityLocaleName="LOC_CITY_NAME_HORKI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="50" Y="60" CityLocaleName="LOC_CITY_NAME_SZCZECIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="51" Y="60" CityLocaleName="LOC_CITY_NAME_KOSZALIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="52" Y="60" CityLocaleName="LOC_CITY_NAME_KOSZALIN" Area="0" />
@@ -1643,7 +1642,7 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="60" CityLocaleName="LOC_CITY_NAME_POLOTSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="60" CityLocaleName="LOC_CITY_NAME_POLOTSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="60" CityLocaleName="LOC_CITY_NAME_ORSHA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="52" Y="61" CityLocaleName="LOC_CITY_NAME_SLUPSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="53" Y="61" CityLocaleName="LOC_CITY_NAME_GDYNIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="61" CityLocaleName="LOC_CITY_NAME_KLAIPEDA" Area="0" />
@@ -1657,11 +1656,11 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="61" CityLocaleName="LOC_CITY_NAME_POLOTSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="61" CityLocaleName="LOC_CITY_NAME_VITEBSK" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="61" CityLocaleName="LOC_CITY_NAME_RUDNYA" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<CityMap> <!-- BALTICS -->
-	
+
 		<Replace MapName="PlayEuropeAgain" X="58" Y="62" CityLocaleName="LOC_CITY_NAME_KLAIPEDA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="62" CityLocaleName="LOC_CITY_NAME_SIAULIAI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="62" CityLocaleName="LOC_CITY_NAME_PANEVEZYS" Area="0" />
@@ -1673,7 +1672,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="62" CityLocaleName="LOC_CITY_NAME_NEVEL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="62" CityLocaleName="LOC_CITY_NAME_NEVEL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="62" CityLocaleName="LOC_CITY_NAME_VELIZH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="58" Y="63" CityLocaleName="LOC_CITY_NAME_LIEPAJA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="63" CityLocaleName="LOC_CITY_NAME_SIAULIAI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="63" CityLocaleName="LOC_CITY_NAME_PANEVEZYS" Area="0" />
@@ -1683,7 +1682,7 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="63" CityLocaleName="LOC_CITY_NAME_VERKHNYADZVINSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="63" CityLocaleName="LOC_CITY_NAME_RASONY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="63" CityLocaleName="LOC_CITY_NAME_VELIZH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="58" Y="64" CityLocaleName="LOC_CITY_NAME_LIEPAJA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="64" CityLocaleName="LOC_CITY_NAME_MAZEIKIAI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="64" CityLocaleName="LOC_CITY_NAME_AIZKRAUKLE" Area="0" />
@@ -1693,7 +1692,7 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="64" CityLocaleName="LOC_CITY_NAME_OPOCHKA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="64" CityLocaleName="LOC_CITY_NAME_PUSHKINSKIYE_GORY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="64" CityLocaleName="LOC_CITY_NAME_VELIKIYE_LUKI" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="58" Y="65" CityLocaleName="LOC_CITY_NAME_VENTSPILS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="65" CityLocaleName="LOC_CITY_NAME_RIGA" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="65" CityLocaleName="LOC_CITY_NAME_AIZKRAUKLE" Area="0" />
@@ -1703,7 +1702,7 @@
 		<Replace MapName="PlayEuropeAgain" X="66" Y="65" CityLocaleName="LOC_CITY_NAME_PUSHKINSKIYE_GORY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="65" CityLocaleName="LOC_CITY_NAME_PUSHKINSKIYE_GORY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="65" CityLocaleName="LOC_CITY_NAME_TOROPETS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="59" Y="66" CityLocaleName="LOC_CITY_NAME_VENTSPILS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="66" CityLocaleName="LOC_CITY_NAME_VALMEIRA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="66" CityLocaleName="LOC_CITY_NAME_ALUKSNE" Area="0" />
@@ -1712,7 +1711,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="66" CityLocaleName="LOC_CITY_NAME_KHOLM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="66" CityLocaleName="LOC_CITY_NAME_KHOLM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="66" CityLocaleName="LOC_CITY_NAME_TOROPETS" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="61" Y="67" CityLocaleName="LOC_CITY_NAME_VALMEIRA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="67" CityLocaleName="LOC_CITY_NAME_VALMEIRA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="67" CityLocaleName="LOC_CITY_NAME_PSKOV" />
@@ -1730,7 +1729,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="68" CityLocaleName="LOC_CITY_NAME_STARAYA_RUSSA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="68" CityLocaleName="LOC_CITY_NAME_STARAYA_RUSSA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="68" CityLocaleName="LOC_CITY_NAME_SUCHKI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="69" CityLocaleName="LOC_CITY_NAME_TARTU" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="69" CityLocaleName="LOC_CITY_NAME_NARVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="69" CityLocaleName="LOC_CITY_NAME_LUGA" Area="0" />
@@ -1738,7 +1737,7 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="69" CityLocaleName="LOC_CITY_NAME_VELIKY_NOVGOROD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="69" CityLocaleName="LOC_CITY_NAME_CHUDOVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="69" CityLocaleName="LOC_CITY_NAME_CHUDOVO" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="61" Y="70" CityLocaleName="LOC_CITY_NAME_TALLINN" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="70" CityLocaleName="LOC_CITY_NAME_NARVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="70" CityLocaleName="LOC_CITY_NAME_NARVA" Area="0" />
@@ -1746,17 +1745,17 @@
 		<Replace MapName="PlayEuropeAgain" X="68" Y="70" CityLocaleName="LOC_CITY_NAME_VELIKY_NOVGOROD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="70" CityLocaleName="LOC_CITY_NAME_KIRISHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="70" CityLocaleName="LOC_CITY_NAME_KIRISHI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="65" Y="71" CityLocaleName="LOC_CITY_NAME_ST_PETERSBURG" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="71" CityLocaleName="LOC_CITY_NAME_KOLPINO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="71" CityLocaleName="LOC_CITY_NAME_KIRISHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="71" CityLocaleName="LOC_CITY_NAME_KIRISHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="71" CityLocaleName="LOC_CITY_NAME_KIRISHI" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<CityMap> <!-- RUSSIA (CENTRAL) -->
-	
+
 		<Replace MapName="PlayEuropeAgain" X="78" Y="55" CityLocaleName="LOC_CITY_NAME_YELETS" />
 		<Replace MapName="PlayEuropeAgain" X="82" Y="55" CityLocaleName="LOC_CITY_NAME_GRYAZI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="55" CityLocaleName="LOC_CITY_NAME_GRYAZI" Area="0" />
@@ -1767,7 +1766,7 @@
 		<Replace MapName="PlayEuropeAgain" X="88" Y="55" CityLocaleName="LOC_CITY_NAME_VOLSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="55" CityLocaleName="LOC_CITY_NAME_VOLSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="55" CityLocaleName="LOC_CITY_NAME_YERSHOV" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="72" Y="56" CityLocaleName="LOC_CITY_NAME_GOMEL" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="56" CityLocaleName="LOC_CITY_NAME_BRYANSK" Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="74" Y="56" CityLocaleName="LOC_CITY_NAME_BRYANSK" />
@@ -1776,12 +1775,12 @@
 		<Replace MapName="PlayEuropeAgain" X="81" Y="56" CityLocaleName="LOC_CITY_NAME_LIPETSK" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="56" CityLocaleName="LOC_CITY_NAME_KIRSANOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="56" CityLocaleName="LOC_CITY_NAME_PETROVSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="79" Y="57" CityLocaleName="LOC_CITY_NAME_NOVOMOSKOVSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="57" CityLocaleName="LOC_CITY_NAME_TAMBOV" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="57" CityLocaleName="LOC_CITY_NAME_PENZA" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="57" CityLocaleName="LOC_CITY_NAME_BALAKOVO" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="58" CityLocaleName="LOC_CITY_NAME_LABKOVICY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="58" CityLocaleName="LOC_CITY_NAME_LABKOVICY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="58" CityLocaleName="LOC_CITY_NAME_ROSLAVL" Area="0" />
@@ -1790,7 +1789,7 @@
 		<Replace MapName="PlayEuropeAgain" X="80" Y="58" CityLocaleName="LOC_CITY_NAME_NOVOMOSKOVSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="58" CityLocaleName="LOC_CITY_NAME_NIZHNY_LOMOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="58" CityLocaleName="LOC_CITY_NAME_SARANSK" Area="0" /> <!-- OVERLAP -->
-		
+
 		<Replace MapName="PlayEuropeAgain" X="73" Y="59" CityLocaleName="LOC_CITY_NAME_ROSLAVL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="59" CityLocaleName="LOC_CITY_NAME_KALUGA" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="59" CityLocaleName="LOC_CITY_NAME_RYAZAN" Area="0" /> <!-- OVERLAP -->
@@ -1799,7 +1798,7 @@
 		<Replace MapName="PlayEuropeAgain" X="84" Y="59" CityLocaleName="LOC_CITY_NAME_KASIMOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="59" CityLocaleName="LOC_CITY_NAME_SARANSK" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="59" CityLocaleName="LOC_CITY_NAME_SAMARA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="72" Y="60" CityLocaleName="LOC_CITY_NAME_SMOLENSK" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="60" CityLocaleName="LOC_CITY_NAME_ROSLAVL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="60" CityLocaleName="LOC_CITY_NAME_PODOLSK" Area="0" />
@@ -1810,7 +1809,7 @@
 		<Replace MapName="PlayEuropeAgain" X="84" Y="60" CityLocaleName="LOC_CITY_NAME_KASIMOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="60" CityLocaleName="LOC_CITY_NAME_VYSKA" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="60" CityLocaleName="LOC_CITY_NAME_ULYANOVSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="75" Y="61" CityLocaleName="LOC_CITY_NAME_OBNINSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="61" CityLocaleName="LOC_CITY_NAME_OBNINSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="61" CityLocaleName="LOC_CITY_NAME_GUS_KHRUSTALNY" Area="0" />
@@ -1819,7 +1818,7 @@
 		<Replace MapName="PlayEuropeAgain" X="85" Y="61" CityLocaleName="LOC_CITY_NAME_MUROM" Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="87" Y="61" CityLocaleName="LOC_CITY_NAME_ARZAMAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="61" CityLocaleName="LOC_CITY_NAME_ULYANOVSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="62" CityLocaleName="LOC_CITY_NAME_ZHARKOVSKIY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="62" CityLocaleName="LOC_CITY_NAME_ZHARKOVSKIY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="62" CityLocaleName="LOC_CITY_NAME_VYAZMA" />
@@ -1830,7 +1829,7 @@
 		<Replace MapName="PlayEuropeAgain" X="85" Y="62" CityLocaleName="LOC_CITY_NAME_MUROM" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="62" CityLocaleName="LOC_CITY_NAME_ARZAMAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="62" CityLocaleName="LOC_CITY_NAME_SURSKOYE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="63" CityLocaleName="LOC_CITY_NAME_ZHARKOVSKIY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="63" CityLocaleName="LOC_CITY_NAME_ZHARKOVSKIY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="63" CityLocaleName="LOC_CITY_NAME_OREKHOVO_ZUYEVO" Area="0" />
@@ -1839,7 +1838,7 @@
 		<Replace MapName="PlayEuropeAgain" X="86" Y="63" CityLocaleName="LOC_CITY_NAME_PAVLOVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="63" CityLocaleName="LOC_CITY_NAME_ARZAMAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="63" CityLocaleName="LOC_CITY_NAME_KAZAN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="64" CityLocaleName="LOC_CITY_NAME_NELIDOVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="64" CityLocaleName="LOC_CITY_NAME_NELIDOVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="64" CityLocaleName="LOC_CITY_NAME_ZELENOGRAD" />
@@ -1852,7 +1851,7 @@
 		<Replace MapName="PlayEuropeAgain" X="88" Y="64" CityLocaleName="LOC_CITY_NAME_SERGACH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="64" CityLocaleName="LOC_CITY_NAME_SERGACH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="64" CityLocaleName="LOC_CITY_NAME_SERGACH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="65" CityLocaleName="LOC_CITY_NAME_NELIDOVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="65" CityLocaleName="LOC_CITY_NAME_RZHEV" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="65" CityLocaleName="LOC_CITY_NAME_TVER" Area="0" /> <!-- OVERLAP -->
@@ -1861,7 +1860,7 @@
 		<Replace MapName="PlayEuropeAgain" X="80" Y="65" CityLocaleName="LOC_CITY_NAME_ROSTOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="65" CityLocaleName="LOC_CITY_NAME_KOVROV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="65" CityLocaleName="LOC_CITY_NAME_SERGACH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="66" CityLocaleName="LOC_CITY_NAME_FIROVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="66" CityLocaleName="LOC_CITY_NAME_FIROVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="66" CityLocaleName="LOC_CITY_NAME_VYSHNY_VOLOCHYOK" Area="0" /> <!-- OVERLAP -->
@@ -1873,12 +1872,12 @@
 		<Replace MapName="PlayEuropeAgain" X="84" Y="66" CityLocaleName="LOC_CITY_NAME_IVANOVO" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="66" CityLocaleName="LOC_CITY_NAME_NIZHNY_NOVGOROD" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="66" CityLocaleName="LOC_CITY_NAME_CHEBOKSARY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="67" CityLocaleName="LOC_CITY_NAME_FIROVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="67" CityLocaleName="LOC_CITY_NAME_VYSHNY_VOLOCHYOK" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="67" CityLocaleName="LOC_CITY_NAME_KINESHMA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="67" CityLocaleName="LOC_CITY_NAME_YOSHKAR_OLA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="68" CityLocaleName="LOC_CITY_NAME_FIROVO" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="68" CityLocaleName="LOC_CITY_NAME_BOROVICHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="68" CityLocaleName="LOC_CITY_NAME_RYBINSK" />
@@ -1889,7 +1888,7 @@
 		<Replace MapName="PlayEuropeAgain" X="86" Y="68" CityLocaleName="LOC_CITY_NAME_KINESHMA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="68" CityLocaleName="LOC_CITY_NAME_YOSHKAR_OLA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="68" CityLocaleName="LOC_CITY_NAME_YOSHKAR_OLA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="69" CityLocaleName="LOC_CITY_NAME_BOROVICHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="69" CityLocaleName="LOC_CITY_NAME_BOROVICHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="69" CityLocaleName="LOC_CITY_NAME_BOROVICHI" Area="0" />
@@ -1898,7 +1897,7 @@
 		<Replace MapName="PlayEuropeAgain" X="87" Y="69" CityLocaleName="LOC_CITY_NAME_SHARYA" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="69" CityLocaleName="LOC_CITY_NAME_YOSHKAR_OLA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="69" CityLocaleName="LOC_CITY_NAME_YARANSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="70" CityLocaleName="LOC_CITY_NAME_TIKHVIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="70" CityLocaleName="LOC_CITY_NAME_TIKHVIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="70" CityLocaleName="LOC_CITY_NAME_CHEREPOVETS" Area="0" /> <!-- OVERLAP -->
@@ -1907,14 +1906,14 @@
 		<Replace MapName="PlayEuropeAgain" X="80" Y="70" CityLocaleName="LOC_CITY_NAME_DANILOV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="70" CityLocaleName="LOC_CITY_NAME_SYAMZHA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="70" CityLocaleName="LOC_CITY_NAME_GALICH" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="71" CityLocaleName="LOC_CITY_NAME_TIKHVIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="71" CityLocaleName="LOC_CITY_NAME_CHAGODA" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="71" CityLocaleName="LOC_CITY_NAME_CHEREPOVETS" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="71" CityLocaleName="LOC_CITY_NAME_SYAMZHA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="71" CityLocaleName="LOC_CITY_NAME_CHUKHLOMA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="71" CityLocaleName="LOC_CITY_NAME_KAZHIROVO" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="72" CityLocaleName="LOC_CITY_NAME_TIKHVIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="72" CityLocaleName="LOC_CITY_NAME_TIKHVIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="72" CityLocaleName="LOC_CITY_NAME_BELOZERSK" Area="0" />
@@ -1923,18 +1922,18 @@
 		<Replace MapName="PlayEuropeAgain" X="79" Y="72" CityLocaleName="LOC_CITY_NAME_VOLOGDA" />
 		<Replace MapName="PlayEuropeAgain" X="82" Y="72" CityLocaleName="LOC_CITY_NAME_TOTMA" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="72" CityLocaleName="LOC_CITY_NAME_NIKOLSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="72" Y="73" CityLocaleName="LOC_CITY_NAME_KURBA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="73" CityLocaleName="LOC_CITY_NAME_KIRILLOV" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="73" CityLocaleName="LOC_CITY_NAME_TOLSTUKHA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="73" CityLocaleName="LOC_CITY_NAME_NYUKSENITSA" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="73" CityLocaleName="LOC_CITY_NAME_LUZA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="74" Y="74" CityLocaleName="LOC_CITY_NAME_VYTEGRA" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="74" CityLocaleName="LOC_CITY_NAME_VOZHEGA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="74" CityLocaleName="LOC_CITY_NAME_TOLSTUKHA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="74" CityLocaleName="LOC_CITY_NAME_PODOSINOVETS" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="75" Y="75" CityLocaleName="LOC_CITY_NAME_KARGOPOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="75" CityLocaleName="LOC_CITY_NAME_KARGOPOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="75" CityLocaleName="LOC_CITY_NAME_KARGOPOL" Area="0" />
@@ -1943,657 +1942,661 @@
 		<Replace MapName="PlayEuropeAgain" X="84" Y="75" CityLocaleName="LOC_CITY_NAME_KIZEMA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="75" CityLocaleName="LOC_CITY_NAME_VELIKY_USTYUG" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="75" CityLocaleName="LOC_CITY_NAME_OPARINO" Area="0" />
-	
+
 	</CityMap>
-	
+
 	<!-- RUSSIA (EAST) -->
 	<CityMap>
-	
-	<Replace MapName="PlayEuropeAgain" X="93" Y="55" CityLocaleName="LOC_CITY_NAME_SMORODINKA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="96" Y="55" CityLocaleName="LOC_CITY_NAME_ORENBURG" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="55" CityLocaleName="LOC_CITY_NAME_ORENBURG" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="98" Y="55" CityLocaleName="LOC_CITY_NAME_ORENBURG" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="99" Y="55" CityLocaleName="LOC_CITY_NAME_SIBAY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="100" Y="55" CityLocaleName="LOC_CITY_NAME_SIBAY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="103" Y="55" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="104" Y="55" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="105" Y="55" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="55" CityLocaleName="LOC_CITY_NAME_ESIL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="55" CityLocaleName="LOC_CITY_NAME_ESIL" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="92" Y="56" CityLocaleName="LOC_CITY_NAME_PUGACHYOV" />
-	<Replace MapName="PlayEuropeAgain" X="95" Y="56" CityLocaleName="LOC_CITY_NAME_PESTRAVKA" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="56" CityLocaleName="LOC_CITY_NAME_ORENBURG" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="102" Y="56" CityLocaleName="LOC_CITY_NAME_MAGNITOGORSK" />
-	<Replace MapName="PlayEuropeAgain" X="104" Y="56" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="105" Y="56" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="93" Y="57" CityLocaleName="LOC_CITY_NAME_NEFTEGORSK" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="99" Y="57" CityLocaleName="LOC_CITY_NAME_SALAVAT" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="57" CityLocaleName="LOC_CITY_NAME_KOSTANAY" />
-	
-	<Replace MapName="PlayEuropeAgain" X="93" Y="58" CityLocaleName="LOC_CITY_NAME_NEFTEGORSK" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="58" CityLocaleName="LOC_CITY_NAME_BELEBEY" />
-	<Replace MapName="PlayEuropeAgain" X="104" Y="58" CityLocaleName="LOC_CITY_NAME_TROITSK" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="59" CityLocaleName="LOC_CITY_NAME_SAMARA" />
-	<Replace MapName="PlayEuropeAgain" X="94" Y="59" CityLocaleName="LOC_CITY_NAME_BUZULUK" />
-	<Replace MapName="PlayEuropeAgain" X="101" Y="59" CityLocaleName="LOC_CITY_NAME_BELORETSK" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="59" CityLocaleName="LOC_CITY_NAME_PETROPAVL" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="93" Y="60" CityLocaleName="LOC_CITY_NAME_DIMITROVGRAD" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="99" Y="60" CityLocaleName="LOC_CITY_NAME_UFA" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="60" CityLocaleName="LOC_CITY_NAME_KURGAN" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="61" CityLocaleName="LOC_CITY_NAME_ULYANOVSK" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="61" CityLocaleName="LOC_CITY_NAME_DIMITROVGRAD" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="96" Y="61" CityLocaleName="LOC_CITY_NAME_NABEREZHNYE_CHELNYE" />
-	<Replace MapName="PlayEuropeAgain" X="103" Y="61" CityLocaleName="LOC_CITY_NAME_CHELYABINSK" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="61" CityLocaleName="LOC_CITY_NAME_SHADRINSK" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="94" Y="62" CityLocaleName="LOC_CITY_NAME_CHISTOPOL" />
-	<Replace MapName="PlayEuropeAgain" X="101" Y="62" CityLocaleName="LOC_CITY_NAME_MIASS" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="62" CityLocaleName="LOC_CITY_NAME_SHADRINSK" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="63" CityLocaleName="LOC_CITY_NAME_KAZAN" />
-	<Replace MapName="PlayEuropeAgain" X="98" Y="63" CityLocaleName="LOC_CITY_NAME_NEFTEKAMSK" />
-	<Replace MapName="PlayEuropeAgain" X="105" Y="63" CityLocaleName="LOC_CITY_NAME_KAMENSK_URALSKY" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="63" CityLocaleName="LOC_CITY_NAME_SHADRINSK" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="96" Y="64" CityLocaleName="LOC_CITY_NAME_IZHEVSK" />
-	<Replace MapName="PlayEuropeAgain" X="103" Y="64" CityLocaleName="LOC_CITY_NAME_YEKATERINBURG" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="65" CityLocaleName="LOC_CITY_NAME_URZHUM" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="93" Y="65" CityLocaleName="LOC_CITY_NAME_UVA" />
-	<Replace MapName="PlayEuropeAgain" X="100" Y="65" CityLocaleName="LOC_CITY_NAME_KRASNOUFIMSK" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="65" CityLocaleName="LOC_CITY_NAME_TYUMEN" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="66" CityLocaleName="LOC_CITY_NAME_URZHUM" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="66" CityLocaleName="LOC_CITY_NAME_URZHUM" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="98" Y="66" CityLocaleName="LOC_CITY_NAME_VOTKINSK" />
-	<Replace MapName="PlayEuropeAgain" X="105" Y="66" CityLocaleName="LOC_CITY_NAME_IRBIT" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="67" CityLocaleName="LOC_CITY_NAME_URZHUM" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="95" Y="67" CityLocaleName="LOC_CITY_NAME_IGRA" />
-	<Replace MapName="PlayEuropeAgain" X="102" Y="67" CityLocaleName="LOC_CITY_NAME_NIZHNY_TAGIL" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="68" CityLocaleName="LOC_CITY_NAME_SOVIETSK" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="93" Y="68" CityLocaleName="LOC_CITY_NAME_POREZ" />
-	<Replace MapName="PlayEuropeAgain" X="100" Y="68" CityLocaleName="LOC_CITY_NAME_PERM" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="68" CityLocaleName="LOC_CITY_NAME_TABORY" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="69" CityLocaleName="LOC_CITY_NAME_SOVIETSK" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="69" CityLocaleName="LOC_CITY_NAME_KRASNOKAMSK" />
-	<Replace MapName="PlayEuropeAgain" X="104" Y="69" CityLocaleName="LOC_CITY_NAME_SOSVA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="70" CityLocaleName="LOC_CITY_NAME_SOVIETSK" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="95" Y="70" CityLocaleName="LOC_CITY_NAME_GLAZOV" />
-	<Replace MapName="PlayEuropeAgain" X="102" Y="70" CityLocaleName="LOC_CITY_NAME_VERKHOTURYE" />
-	
-	<Replace MapName="PlayEuropeAgain" X="92" Y="71" CityLocaleName="LOC_CITY_NAME_KIROV" />
-	<Replace MapName="PlayEuropeAgain" X="99" Y="71" CityLocaleName="LOC_CITY_NAME_SOLIKAMSK" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="71" CityLocaleName="LOC_CITY_NAME_PELYM" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="72" CityLocaleName="LOC_CITY_NAME_DAROVSKOY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="72" CityLocaleName="LOC_CITY_NAME_KIRS" />
-	<Replace MapName="PlayEuropeAgain" X="104" Y="72" CityLocaleName="LOC_CITY_NAME_MOROZKOVO" />
-	
-	<Replace MapName="PlayEuropeAgain" X="94" Y="73" CityLocaleName="LOC_CITY_NAME_NAGORSK" />
-	<Replace MapName="PlayEuropeAgain" X="101" Y="73" CityLocaleName="LOC_CITY_NAME_SEROV" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="73" CityLocaleName="LOC_CITY_NAME_SUPRA" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="92" Y="74" CityLocaleName="LOC_CITY_NAME_MURASHI" />
-	<Replace MapName="PlayEuropeAgain" X="96" Y="74" CityLocaleName="LOC_CITY_NAME_SEYVA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="74" CityLocaleName="LOC_CITY_NAME_SEYVA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="99" Y="74" CityLocaleName="LOC_CITY_NAME_NYROB" />
-	<Replace MapName="PlayEuropeAgain" X="103" Y="74" CityLocaleName="LOC_CITY_NAME_OUS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="104" Y="74" CityLocaleName="LOC_CITY_NAME_OUS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="74" CityLocaleName="LOC_CITY_NAME_YUGORSK" />
-	
-	<Replace MapName="PlayEuropeAgain" X="93" Y="75" CityLocaleName="LOC_CITY_NAME_SINEGORYE" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="94" Y="75" CityLocaleName="LOC_CITY_NAME_SINEGORYE" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="95" Y="75" CityLocaleName="LOC_CITY_NAME_SINEGORYE" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="96" Y="75" CityLocaleName="LOC_CITY_NAME_SEYVA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="100" Y="75" CityLocaleName="LOC_CITY_NAME_VIZHAY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="101" Y="75" CityLocaleName="LOC_CITY_NAME_VIZHAY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="102" Y="75" CityLocaleName="LOC_CITY_NAME_VIZHAY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="103" Y="75" CityLocaleName="LOC_CITY_NAME_OUS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="104" Y="75" CityLocaleName="LOC_CITY_NAME_OUS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="75" CityLocaleName="LOC_CITY_NAME_SUPRA" Area="0" />
-	
+
+		<Replace MapName="PlayEuropeAgain" X="93" Y="55" CityLocaleName="LOC_CITY_NAME_SMORODINKA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="96" Y="55" CityLocaleName="LOC_CITY_NAME_ORENBURG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="55" CityLocaleName="LOC_CITY_NAME_ORENBURG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="98" Y="55" CityLocaleName="LOC_CITY_NAME_ORENBURG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="99" Y="55" CityLocaleName="LOC_CITY_NAME_SIBAY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="100" Y="55" CityLocaleName="LOC_CITY_NAME_SIBAY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="103" Y="55" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="104" Y="55" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="105" Y="55" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="55" CityLocaleName="LOC_CITY_NAME_ESIL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="55" CityLocaleName="LOC_CITY_NAME_ESIL" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="92" Y="56" CityLocaleName="LOC_CITY_NAME_PUGACHYOV" />
+		<Replace MapName="PlayEuropeAgain" X="95" Y="56" CityLocaleName="LOC_CITY_NAME_PESTRAVKA" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="56" CityLocaleName="LOC_CITY_NAME_ORENBURG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="102" Y="56" CityLocaleName="LOC_CITY_NAME_MAGNITOGORSK" />
+		<Replace MapName="PlayEuropeAgain" X="104" Y="56" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="105" Y="56" CityLocaleName="LOC_CITY_NAME_ZHETIKARA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="93" Y="57" CityLocaleName="LOC_CITY_NAME_NEFTEGORSK" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="99" Y="57" CityLocaleName="LOC_CITY_NAME_SALAVAT" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="57" CityLocaleName="LOC_CITY_NAME_KOSTANAY" />
+
+		<Replace MapName="PlayEuropeAgain" X="93" Y="58" CityLocaleName="LOC_CITY_NAME_NEFTEGORSK" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="58" CityLocaleName="LOC_CITY_NAME_BELEBEY" />
+		<Replace MapName="PlayEuropeAgain" X="104" Y="58" CityLocaleName="LOC_CITY_NAME_TROITSK" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="59" CityLocaleName="LOC_CITY_NAME_SAMARA" />
+		<Replace MapName="PlayEuropeAgain" X="94" Y="59" CityLocaleName="LOC_CITY_NAME_BUZULUK" />
+		<Replace MapName="PlayEuropeAgain" X="101" Y="59" CityLocaleName="LOC_CITY_NAME_BELORETSK" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="59" CityLocaleName="LOC_CITY_NAME_PETROPAVL" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="93" Y="60" CityLocaleName="LOC_CITY_NAME_DIMITROVGRAD" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="99" Y="60" CityLocaleName="LOC_CITY_NAME_UFA" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="60" CityLocaleName="LOC_CITY_NAME_KURGAN" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="61" CityLocaleName="LOC_CITY_NAME_ULYANOVSK" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="61" CityLocaleName="LOC_CITY_NAME_DIMITROVGRAD" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="96" Y="61" CityLocaleName="LOC_CITY_NAME_NABEREZHNYE_CHELNYE" />
+		<Replace MapName="PlayEuropeAgain" X="103" Y="61" CityLocaleName="LOC_CITY_NAME_CHELYABINSK" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="61" CityLocaleName="LOC_CITY_NAME_SHADRINSK" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="94" Y="62" CityLocaleName="LOC_CITY_NAME_CHISTOPOL" />
+		<Replace MapName="PlayEuropeAgain" X="101" Y="62" CityLocaleName="LOC_CITY_NAME_MIASS" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="62" CityLocaleName="LOC_CITY_NAME_SHADRINSK" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="63" CityLocaleName="LOC_CITY_NAME_KAZAN" />
+		<Replace MapName="PlayEuropeAgain" X="98" Y="63" CityLocaleName="LOC_CITY_NAME_NEFTEKAMSK" />
+		<Replace MapName="PlayEuropeAgain" X="105" Y="63" CityLocaleName="LOC_CITY_NAME_KAMENSK_URALSKY" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="63" CityLocaleName="LOC_CITY_NAME_SHADRINSK" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="96" Y="64" CityLocaleName="LOC_CITY_NAME_IZHEVSK" />
+		<Replace MapName="PlayEuropeAgain" X="103" Y="64" CityLocaleName="LOC_CITY_NAME_YEKATERINBURG" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="65" CityLocaleName="LOC_CITY_NAME_URZHUM" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="93" Y="65" CityLocaleName="LOC_CITY_NAME_UVA" />
+		<Replace MapName="PlayEuropeAgain" X="100" Y="65" CityLocaleName="LOC_CITY_NAME_KRASNOUFIMSK" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="65" CityLocaleName="LOC_CITY_NAME_TYUMEN" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="66" CityLocaleName="LOC_CITY_NAME_URZHUM" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="66" CityLocaleName="LOC_CITY_NAME_URZHUM" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="98" Y="66" CityLocaleName="LOC_CITY_NAME_VOTKINSK" />
+		<Replace MapName="PlayEuropeAgain" X="105" Y="66" CityLocaleName="LOC_CITY_NAME_IRBIT" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="67" CityLocaleName="LOC_CITY_NAME_URZHUM" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="95" Y="67" CityLocaleName="LOC_CITY_NAME_IGRA" />
+		<Replace MapName="PlayEuropeAgain" X="102" Y="67" CityLocaleName="LOC_CITY_NAME_NIZHNY_TAGIL" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="68" CityLocaleName="LOC_CITY_NAME_SOVIETSK" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="93" Y="68" CityLocaleName="LOC_CITY_NAME_POREZ" />
+		<Replace MapName="PlayEuropeAgain" X="100" Y="68" CityLocaleName="LOC_CITY_NAME_PERM" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="68" CityLocaleName="LOC_CITY_NAME_TABORY" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="69" CityLocaleName="LOC_CITY_NAME_SOVIETSK" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="69" CityLocaleName="LOC_CITY_NAME_KRASNOKAMSK" />
+		<Replace MapName="PlayEuropeAgain" X="104" Y="69" CityLocaleName="LOC_CITY_NAME_SOSVA" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="70" CityLocaleName="LOC_CITY_NAME_SOVIETSK" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="95" Y="70" CityLocaleName="LOC_CITY_NAME_GLAZOV" />
+		<Replace MapName="PlayEuropeAgain" X="102" Y="70" CityLocaleName="LOC_CITY_NAME_VERKHOTURYE" />
+
+		<Replace MapName="PlayEuropeAgain" X="92" Y="71" CityLocaleName="LOC_CITY_NAME_KIROV" />
+		<Replace MapName="PlayEuropeAgain" X="99" Y="71" CityLocaleName="LOC_CITY_NAME_SOLIKAMSK" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="71" CityLocaleName="LOC_CITY_NAME_PELYM" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="72" CityLocaleName="LOC_CITY_NAME_DAROVSKOY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="72" CityLocaleName="LOC_CITY_NAME_KIRS" />
+		<Replace MapName="PlayEuropeAgain" X="104" Y="72" CityLocaleName="LOC_CITY_NAME_MOROZKOVO" />
+
+		<Replace MapName="PlayEuropeAgain" X="94" Y="73" CityLocaleName="LOC_CITY_NAME_NAGORSK" />
+		<Replace MapName="PlayEuropeAgain" X="101" Y="73" CityLocaleName="LOC_CITY_NAME_SEROV" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="73" CityLocaleName="LOC_CITY_NAME_SUPRA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="92" Y="74" CityLocaleName="LOC_CITY_NAME_MURASHI" />
+		<Replace MapName="PlayEuropeAgain" X="96" Y="74" CityLocaleName="LOC_CITY_NAME_SEYVA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="74" CityLocaleName="LOC_CITY_NAME_SEYVA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="99" Y="74" CityLocaleName="LOC_CITY_NAME_NYROB" />
+		<Replace MapName="PlayEuropeAgain" X="103" Y="74" CityLocaleName="LOC_CITY_NAME_OUS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="104" Y="74" CityLocaleName="LOC_CITY_NAME_OUS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="74" CityLocaleName="LOC_CITY_NAME_YUGORSK" />
+
+		<Replace MapName="PlayEuropeAgain" X="93" Y="75" CityLocaleName="LOC_CITY_NAME_SINEGORYE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="94" Y="75" CityLocaleName="LOC_CITY_NAME_SINEGORYE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="95" Y="75" CityLocaleName="LOC_CITY_NAME_SINEGORYE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="96" Y="75" CityLocaleName="LOC_CITY_NAME_SEYVA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="100" Y="75" CityLocaleName="LOC_CITY_NAME_VIZHAY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="101" Y="75" CityLocaleName="LOC_CITY_NAME_VIZHAY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="102" Y="75" CityLocaleName="LOC_CITY_NAME_VIZHAY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="103" Y="75" CityLocaleName="LOC_CITY_NAME_OUS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="104" Y="75" CityLocaleName="LOC_CITY_NAME_OUS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="75" CityLocaleName="LOC_CITY_NAME_SUPRA" Area="0" />
+
 	</CityMap>
-	
+
 	<!-- RUSSIA (ARCTIC) -->
 	<CityMap>
-	
-	<Replace MapName="PlayEuropeAgain" X="74" Y="76" CityLocaleName="LOC_CITY_NAME_PUDOZH" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="76" Y="76" CityLocaleName="LOC_CITY_NAME_VERSHININO" />
-	<Replace MapName="PlayEuropeAgain" X="80" Y="76" CityLocaleName="LOC_CITY_NAME_KULOY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="81" Y="76" CityLocaleName="LOC_CITY_NAME_KULOY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="83" Y="76" CityLocaleName="LOC_CITY_NAME_LOYGA" />
-	<Replace MapName="PlayEuropeAgain" X="87" Y="76" CityLocaleName="LOC_CITY_NAME_KOTLAS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="88" Y="76" CityLocaleName="LOC_CITY_NAME_KOTLAS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="90" Y="76" CityLocaleName="LOC_CITY_NAME_UST_VYM" />
-	<Replace MapName="PlayEuropeAgain" X="94" Y="76" CityLocaleName="LOC_CITY_NAME_SYKTYVKAR" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="76" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="98" Y="76" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="99" Y="76" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="100" Y="76" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="105" Y="76" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="76" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="76" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="78" Y="77" CityLocaleName="LOC_CITY_NAME_SEVEROONEZHSK" />
-	<Replace MapName="PlayEuropeAgain" X="85" Y="77" CityLocaleName="LOC_CITY_NAME_KRASNOBORSK" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="77" CityLocaleName="LOC_CITY_NAME_SYKTYVKAR" />
-	<Replace MapName="PlayEuropeAgain" X="95" Y="77" CityLocaleName="LOC_CITY_NAME_YAKSHA" />
-	<Replace MapName="PlayEuropeAgain" X="102" Y="77" CityLocaleName="LOC_CITY_NAME_AGIRISH" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="105" Y="77" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="77" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="77" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="73" Y="78" CityLocaleName="LOC_CITY_NAME_PINDUSHI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="78" CityLocaleName="LOC_CITY_NAME_VERKHNEE_VOLOZERO" />
-	<Replace MapName="PlayEuropeAgain" X="81" Y="78" CityLocaleName="LOC_CITY_NAME_SHENKURSK" />
-	<Replace MapName="PlayEuropeAgain" X="88" Y="78" CityLocaleName="LOC_CITY_NAME_YARENGA" />
-	<Replace MapName="PlayEuropeAgain" X="94" Y="78" CityLocaleName="LOC_CITY_NAME_UST_ILYCH" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="76" Y="79" CityLocaleName="LOC_CITY_NAME_POSAD" />
-	<Replace MapName="PlayEuropeAgain" X="83" Y="79" CityLocaleName="LOC_CITY_NAME_ZELENNIK" />
-	<Replace MapName="PlayEuropeAgain" X="90" Y="79" CityLocaleName="LOC_CITY_NAME_YEMVA" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="79" CityLocaleName="LOC_CITY_NAME_VUKTYL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="98" Y="79" CityLocaleName="LOC_CITY_NAME_NYAKSIMVOL" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="79" Y="80" CityLocaleName="LOC_CITY_NAME_KHOLMOGORY" />
-	<Replace MapName="PlayEuropeAgain" X="86" Y="80" CityLocaleName="LOC_CITY_NAME_USOGORSK" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="80" CityLocaleName="LOC_CITY_NAME_VUKTYL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="80" CityLocaleName="LOC_CITY_NAME_IGRIM" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="74" Y="81" CityLocaleName="LOC_CITY_NAME_ONEGA" />
-	<Replace MapName="PlayEuropeAgain" X="81" Y="81" CityLocaleName="LOC_CITY_NAME_BEREZNIK" />
-	<Replace MapName="PlayEuropeAgain" X="88" Y="81" CityLocaleName="LOC_CITY_NAME_GLOTOVO" />
-	<Replace MapName="PlayEuropeAgain" X="94" Y="81" CityLocaleName="LOC_CITY_NAME_PECHORA" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="73" Y="82" CityLocaleName="LOC_CITY_NAME_MALENGA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="77" Y="82" CityLocaleName="LOC_CITY_NAME_ARKHANGELSK" />
-	<Replace MapName="PlayEuropeAgain" X="84" Y="82" CityLocaleName="LOC_CITY_NAME_KEBA" />
-	<Replace MapName="PlayEuropeAgain" X="91" Y="82" CityLocaleName="LOC_CITY_NAME_UKHTA" />
-	<Replace MapName="PlayEuropeAgain" X="102" Y="82" CityLocaleName="LOC_CITY_NAME_SOSVA" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="79" Y="83" CityLocaleName="LOC_CITY_NAME_PINEGRA" />
-	<Replace MapName="PlayEuropeAgain" X="86" Y="83" CityLocaleName="LOC_CITY_NAME_BOLSHAYA_PYSSA" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="83" CityLocaleName="LOC_CITY_NAME_UKHTA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="83" CityLocaleName="LOC_CITY_NAME_POLNOVAT" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="75" Y="84" CityLocaleName="LOC_CITY_NAME_SEVERODVINSK" />
-	<Replace MapName="PlayEuropeAgain" X="82" Y="84" CityLocaleName="LOC_CITY_NAME_YUROMA" />
-	<Replace MapName="PlayEuropeAgain" X="89" Y="84" CityLocaleName="LOC_CITY_NAME_VERKHNEMEZENSK" />
-	<Replace MapName="PlayEuropeAgain" X="98" Y="84" CityLocaleName="LOC_CITY_NAME_SARANPAUL" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="72" Y="85" CityLocaleName="LOC_CITY_NAME_LYAMTSA" />
-	<Replace MapName="PlayEuropeAgain" X="77" Y="85" CityLocaleName="LOC_CITY_NAME_POMORYE" />
-	<Replace MapName="PlayEuropeAgain" X="84" Y="85" CityLocaleName="LOC_CITY_NAME_KOYNAS" />
-	<Replace MapName="PlayEuropeAgain" X="91" Y="85" CityLocaleName="LOC_CITY_NAME_IZHMA" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="85" CityLocaleName="LOC_CITY_NAME_IZHMA" Area="0" /> <!-- OVERLAP -->
-	<Replace MapName="PlayEuropeAgain" X="105" Y="85" CityLocaleName="LOC_CITY_NAME_BERYOZOVO" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="80" Y="86" CityLocaleName="LOC_CITY_NAME_MEZEN" />
-	<Replace MapName="PlayEuropeAgain" X="87" Y="86" CityLocaleName="LOC_CITY_NAME_LARKINO" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="86" CityLocaleName="LOC_CITY_NAME_IZHMA" Area="0" /> <!-- OVERLAP -->
-	<Replace MapName="PlayEuropeAgain" X="94" Y="86" CityLocaleName="LOC_CITY_NAME_USINSK" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="75" Y="87" CityLocaleName="LOC_CITY_NAME_NIZHNNAYA_ZOLOTITSKA" />
-	<Replace MapName="PlayEuropeAgain" X="82" Y="87" CityLocaleName="LOC_CITY_NAME_BYCHYE" />
-	<Replace MapName="PlayEuropeAgain" X="89" Y="87" CityLocaleName="LOC_CITY_NAME_UST_TSILMA" />
-	<Replace MapName="PlayEuropeAgain" X="91" Y="87" CityLocaleName="LOC_CITY_NAME_UST_USA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="101" Y="87" CityLocaleName="LOC_CITY_NAME_MUZHI" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="87" CityLocaleName="LOC_CITY_NAME_GORKI" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="78" Y="88" CityLocaleName="LOC_CITY_NAME_KOYDA" />
-	<Replace MapName="PlayEuropeAgain" X="85" Y="88" CityLocaleName="LOC_CITY_NAME_VOLOKOVAYA" />
-	<Replace MapName="PlayEuropeAgain" X="91" Y="88" CityLocaleName="LOC_CITY_NAME_UST_USA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="88" CityLocaleName="LOC_CITY_NAME_UST_USA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="88" CityLocaleName="LOC_CITY_NAME_GORKI" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="80" Y="89" CityLocaleName="LOC_CITY_NAME_OKULOVSKIY" />
-	<Replace MapName="PlayEuropeAgain" X="87" Y="89" CityLocaleName="LOC_CITY_NAME_NOVY_BOR" />
-	<Replace MapName="PlayEuropeAgain" X="91" Y="89" CityLocaleName="LOC_CITY_NAME_UST_USA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="89" CityLocaleName="LOC_CITY_NAME_INTA" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="89" CityLocaleName="LOC_CITY_NAME_GORKI" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="83" Y="90" CityLocaleName="LOC_CITY_NAME_SNOPA" />
-	<Replace MapName="PlayEuropeAgain" X="90" Y="90" CityLocaleName="LOC_CITY_NAME_USTYE" />
-	<Replace MapName="PlayEuropeAgain" X="105" Y="90" CityLocaleName="LOC_CITY_NAME_SALEKHARD" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="85" Y="91" CityLocaleName="LOC_CITY_NAME_FORT_POUSTOZERSKIY" />
-	<Replace MapName="PlayEuropeAgain" X="93" Y="91" CityLocaleName="LOC_CITY_NAME_KHOREY_VER" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="81" Y="92" CityLocaleName="LOC_CITY_NAME_CHIZHA" />
-	<Replace MapName="PlayEuropeAgain" X="88" Y="92" CityLocaleName="LOC_CITY_NAME_NARYAN_MAR" />
-	<Replace MapName="PlayEuropeAgain" X="101" Y="92" CityLocaleName="LOC_CITY_NAME_KHARP" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="92" CityLocaleName="LOC_CITY_NAME_AKSARKA" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="83" Y="93" CityLocaleName="LOC_CITY_NAME_VOLONGA" />
-	<Replace MapName="PlayEuropeAgain" X="90" Y="93" CityLocaleName="LOC_CITY_NAME_KHARYAGINSKIY" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="93" CityLocaleName="LOC_CITY_NAME_AKSARKA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="93" CityLocaleName="LOC_CITY_NAME_AKSARKA" Area="0" />
 
-	<Replace MapName="PlayEuropeAgain" X="79" Y="94" CityLocaleName="LOC_CITY_NAME_KIYA" />
-	<Replace MapName="PlayEuropeAgain" X="86" Y="94" CityLocaleName="LOC_CITY_NAME_INDIGA" />
-	<Replace MapName="PlayEuropeAgain" X="92" Y="94" CityLocaleName="LOC_CITY_NAME_KHARYAGINSKIY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="94" CityLocaleName="LOC_CITY_NAME_VORKUTA" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="94" CityLocaleName="LOC_CITY_NAME_AKSARKA" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="81" Y="95" CityLocaleName="LOC_CITY_NAME_SHOYNA" />
-	<Replace MapName="PlayEuropeAgain" X="88" Y="95" CityLocaleName="LOC_CITY_NAME_KHODOVARIKHA" />
-	<Replace MapName="PlayEuropeAgain" X="93" Y="95" CityLocaleName="LOC_CITY_NAME_KARATAYKA" />
-	<Replace MapName="PlayEuropeAgain" X="104" Y="95" CityLocaleName="LOC_CITY_NAME_BELOYARSK" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="91" Y="96" CityLocaleName="LOC_CITY_NAME_CHYORNAYA" />
-	<Replace MapName="PlayEuropeAgain" X="95" Y="96" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="96" CityLocaleName="LOC_CITY_NAME_SALEMAL" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="85" Y="97" CityLocaleName="LOC_CITY_NAME_BUGRINO" />
-	<Replace MapName="PlayEuropeAgain" X="93" Y="97" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="94" Y="97" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="95" Y="97" CityLocaleName="LOC_CITY_NAME_UST_KARA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="96" Y="97" CityLocaleName="LOC_CITY_NAME_UST_KARA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="97" Y="97" CityLocaleName="LOC_CITY_NAME_UST_KARA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="100" Y="97" CityLocaleName="LOC_CITY_NAME_KHALMER_YU" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="106" Y="97" CityLocaleName="LOC_CITY_NAME_SALEMAL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="107" Y="97" CityLocaleName="LOC_CITY_NAME_SALEMAL" Area="0" />
-	
+		<Replace MapName="PlayEuropeAgain" X="74" Y="76" CityLocaleName="LOC_CITY_NAME_PUDOZH" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="76" Y="76" CityLocaleName="LOC_CITY_NAME_VERSHININO" />
+		<Replace MapName="PlayEuropeAgain" X="80" Y="76" CityLocaleName="LOC_CITY_NAME_KULOY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="81" Y="76" CityLocaleName="LOC_CITY_NAME_KULOY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="83" Y="76" CityLocaleName="LOC_CITY_NAME_LOYGA" />
+		<Replace MapName="PlayEuropeAgain" X="87" Y="76" CityLocaleName="LOC_CITY_NAME_KOTLAS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="88" Y="76" CityLocaleName="LOC_CITY_NAME_KOTLAS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="90" Y="76" CityLocaleName="LOC_CITY_NAME_UST_VYM" />
+		<Replace MapName="PlayEuropeAgain" X="94" Y="76" CityLocaleName="LOC_CITY_NAME_SYKTYVKAR" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="76" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="98" Y="76" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="99" Y="76" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="100" Y="76" CityLocaleName="LOC_CITY_NAME_VELS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="105" Y="76" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="76" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="76" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="78" Y="77" CityLocaleName="LOC_CITY_NAME_SEVEROONEZHSK" />
+		<Replace MapName="PlayEuropeAgain" X="85" Y="77" CityLocaleName="LOC_CITY_NAME_KRASNOBORSK" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="77" CityLocaleName="LOC_CITY_NAME_SYKTYVKAR" />
+		<Replace MapName="PlayEuropeAgain" X="95" Y="77" CityLocaleName="LOC_CITY_NAME_YAKSHA" />
+		<Replace MapName="PlayEuropeAgain" X="102" Y="77" CityLocaleName="LOC_CITY_NAME_AGIRISH" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="105" Y="77" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="77" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="77" CityLocaleName="LOC_CITY_NAME_NYAGAN" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="73" Y="78" CityLocaleName="LOC_CITY_NAME_PINDUSHI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="78" CityLocaleName="LOC_CITY_NAME_VERKHNEE_VOLOZERO" />
+		<Replace MapName="PlayEuropeAgain" X="81" Y="78" CityLocaleName="LOC_CITY_NAME_SHENKURSK" />
+		<Replace MapName="PlayEuropeAgain" X="88" Y="78" CityLocaleName="LOC_CITY_NAME_YARENGA" />
+		<Replace MapName="PlayEuropeAgain" X="94" Y="78" CityLocaleName="LOC_CITY_NAME_UST_ILYCH" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="76" Y="79" CityLocaleName="LOC_CITY_NAME_POSAD" />
+		<Replace MapName="PlayEuropeAgain" X="83" Y="79" CityLocaleName="LOC_CITY_NAME_ZELENNIK" />
+		<Replace MapName="PlayEuropeAgain" X="90" Y="79" CityLocaleName="LOC_CITY_NAME_YEMVA" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="79" CityLocaleName="LOC_CITY_NAME_VUKTYL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="98" Y="79" CityLocaleName="LOC_CITY_NAME_NYAKSIMVOL" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="79" Y="80" CityLocaleName="LOC_CITY_NAME_KHOLMOGORY" />
+		<Replace MapName="PlayEuropeAgain" X="86" Y="80" CityLocaleName="LOC_CITY_NAME_USOGORSK" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="80" CityLocaleName="LOC_CITY_NAME_VUKTYL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="80" CityLocaleName="LOC_CITY_NAME_IGRIM" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="74" Y="81" CityLocaleName="LOC_CITY_NAME_ONEGA" />
+		<Replace MapName="PlayEuropeAgain" X="81" Y="81" CityLocaleName="LOC_CITY_NAME_BEREZNIK" />
+		<Replace MapName="PlayEuropeAgain" X="88" Y="81" CityLocaleName="LOC_CITY_NAME_GLOTOVO" />
+		<Replace MapName="PlayEuropeAgain" X="94" Y="81" CityLocaleName="LOC_CITY_NAME_PECHORA" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="73" Y="82" CityLocaleName="LOC_CITY_NAME_MALENGA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="77" Y="82" CityLocaleName="LOC_CITY_NAME_ARKHANGELSK" />
+		<Replace MapName="PlayEuropeAgain" X="84" Y="82" CityLocaleName="LOC_CITY_NAME_KEBA" />
+		<Replace MapName="PlayEuropeAgain" X="91" Y="82" CityLocaleName="LOC_CITY_NAME_UKHTA" />
+		<Replace MapName="PlayEuropeAgain" X="102" Y="82" CityLocaleName="LOC_CITY_NAME_SOSVA" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="79" Y="83" CityLocaleName="LOC_CITY_NAME_PINEGRA" />
+		<Replace MapName="PlayEuropeAgain" X="86" Y="83" CityLocaleName="LOC_CITY_NAME_BOLSHAYA_PYSSA" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="83" CityLocaleName="LOC_CITY_NAME_UKHTA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="83" CityLocaleName="LOC_CITY_NAME_POLNOVAT" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="75" Y="84" CityLocaleName="LOC_CITY_NAME_SEVERODVINSK" />
+		<Replace MapName="PlayEuropeAgain" X="82" Y="84" CityLocaleName="LOC_CITY_NAME_YUROMA" />
+		<Replace MapName="PlayEuropeAgain" X="89" Y="84" CityLocaleName="LOC_CITY_NAME_VERKHNEMEZENSK" />
+		<Replace MapName="PlayEuropeAgain" X="98" Y="84" CityLocaleName="LOC_CITY_NAME_SARANPAUL" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="72" Y="85" CityLocaleName="LOC_CITY_NAME_LYAMTSA" />
+		<Replace MapName="PlayEuropeAgain" X="77" Y="85" CityLocaleName="LOC_CITY_NAME_POMORYE" />
+		<Replace MapName="PlayEuropeAgain" X="84" Y="85" CityLocaleName="LOC_CITY_NAME_KOYNAS" />
+		<Replace MapName="PlayEuropeAgain" X="91" Y="85" CityLocaleName="LOC_CITY_NAME_IZHMA" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="85" CityLocaleName="LOC_CITY_NAME_IZHMA" Area="0" /> <!-- OVERLAP -->
+		<Replace MapName="PlayEuropeAgain" X="105" Y="85" CityLocaleName="LOC_CITY_NAME_BERYOZOVO" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="80" Y="86" CityLocaleName="LOC_CITY_NAME_MEZEN" />
+		<Replace MapName="PlayEuropeAgain" X="87" Y="86" CityLocaleName="LOC_CITY_NAME_LARKINO" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="86" CityLocaleName="LOC_CITY_NAME_IZHMA" Area="0" /> <!-- OVERLAP -->
+		<Replace MapName="PlayEuropeAgain" X="94" Y="86" CityLocaleName="LOC_CITY_NAME_USINSK" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="75" Y="87" CityLocaleName="LOC_CITY_NAME_NIZHNNAYA_ZOLOTITSKA" />
+		<Replace MapName="PlayEuropeAgain" X="82" Y="87" CityLocaleName="LOC_CITY_NAME_BYCHYE" />
+		<Replace MapName="PlayEuropeAgain" X="89" Y="87" CityLocaleName="LOC_CITY_NAME_UST_TSILMA" />
+		<Replace MapName="PlayEuropeAgain" X="91" Y="87" CityLocaleName="LOC_CITY_NAME_UST_USA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="101" Y="87" CityLocaleName="LOC_CITY_NAME_MUZHI" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="87" CityLocaleName="LOC_CITY_NAME_GORKI" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="78" Y="88" CityLocaleName="LOC_CITY_NAME_KOYDA" />
+		<Replace MapName="PlayEuropeAgain" X="85" Y="88" CityLocaleName="LOC_CITY_NAME_VOLOKOVAYA" />
+		<Replace MapName="PlayEuropeAgain" X="91" Y="88" CityLocaleName="LOC_CITY_NAME_UST_USA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="88" CityLocaleName="LOC_CITY_NAME_UST_USA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="88" CityLocaleName="LOC_CITY_NAME_GORKI" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="80" Y="89" CityLocaleName="LOC_CITY_NAME_OKULOVSKIY" />
+		<Replace MapName="PlayEuropeAgain" X="87" Y="89" CityLocaleName="LOC_CITY_NAME_NOVY_BOR" />
+		<Replace MapName="PlayEuropeAgain" X="91" Y="89" CityLocaleName="LOC_CITY_NAME_UST_USA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="89" CityLocaleName="LOC_CITY_NAME_INTA" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="89" CityLocaleName="LOC_CITY_NAME_GORKI" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="83" Y="90" CityLocaleName="LOC_CITY_NAME_SNOPA" />
+		<Replace MapName="PlayEuropeAgain" X="90" Y="90" CityLocaleName="LOC_CITY_NAME_USTYE" />
+		<Replace MapName="PlayEuropeAgain" X="105" Y="90" CityLocaleName="LOC_CITY_NAME_SALEKHARD" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="85" Y="91" CityLocaleName="LOC_CITY_NAME_FORT_POUSTOZERSKIY" />
+		<Replace MapName="PlayEuropeAgain" X="93" Y="91" CityLocaleName="LOC_CITY_NAME_KHOREY_VER" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="81" Y="92" CityLocaleName="LOC_CITY_NAME_CHIZHA" />
+		<Replace MapName="PlayEuropeAgain" X="88" Y="92" CityLocaleName="LOC_CITY_NAME_NARYAN_MAR" />
+		<Replace MapName="PlayEuropeAgain" X="101" Y="92" CityLocaleName="LOC_CITY_NAME_KHARP" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="92" CityLocaleName="LOC_CITY_NAME_AKSARKA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="83" Y="93" CityLocaleName="LOC_CITY_NAME_VOLONGA" />
+		<Replace MapName="PlayEuropeAgain" X="90" Y="93" CityLocaleName="LOC_CITY_NAME_KHARYAGINSKIY" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="93" CityLocaleName="LOC_CITY_NAME_AKSARKA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="93" CityLocaleName="LOC_CITY_NAME_AKSARKA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="79" Y="94" CityLocaleName="LOC_CITY_NAME_KIYA" />
+		<Replace MapName="PlayEuropeAgain" X="86" Y="94" CityLocaleName="LOC_CITY_NAME_INDIGA" />
+		<Replace MapName="PlayEuropeAgain" X="92" Y="94" CityLocaleName="LOC_CITY_NAME_KHARYAGINSKIY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="94" CityLocaleName="LOC_CITY_NAME_VORKUTA" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="94" CityLocaleName="LOC_CITY_NAME_AKSARKA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="81" Y="95" CityLocaleName="LOC_CITY_NAME_SHOYNA" />
+		<Replace MapName="PlayEuropeAgain" X="88" Y="95" CityLocaleName="LOC_CITY_NAME_KHODOVARIKHA" />
+		<Replace MapName="PlayEuropeAgain" X="93" Y="95" CityLocaleName="LOC_CITY_NAME_KARATAYKA" />
+		<Replace MapName="PlayEuropeAgain" X="104" Y="95" CityLocaleName="LOC_CITY_NAME_BELOYARSK" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="91" Y="96" CityLocaleName="LOC_CITY_NAME_CHYORNAYA" />
+		<Replace MapName="PlayEuropeAgain" X="95" Y="96" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="96" CityLocaleName="LOC_CITY_NAME_SALEMAL" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="85" Y="97" CityLocaleName="LOC_CITY_NAME_BUGRINO" />
+		<Replace MapName="PlayEuropeAgain" X="93" Y="97" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="94" Y="97" CityLocaleName="LOC_CITY_NAME_KARATAYKA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="95" Y="97" CityLocaleName="LOC_CITY_NAME_UST_KARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="96" Y="97" CityLocaleName="LOC_CITY_NAME_UST_KARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="97" Y="97" CityLocaleName="LOC_CITY_NAME_UST_KARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="100" Y="97" CityLocaleName="LOC_CITY_NAME_KHALMER_YU" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="106" Y="97" CityLocaleName="LOC_CITY_NAME_SALEMAL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="107" Y="97" CityLocaleName="LOC_CITY_NAME_SALEMAL" Area="0" />
+
 	</CityMap>
-	
+
 	<!-- WESTERN AFRICA (MOROCCO, WESTERN SAHARA, MAURITANIA, WESTERN ALGERIA -->
 	<CityMap>
-	<Replace MapName="PlayEuropeAgain" X="1" Y="0" CityLocaleName="LOC_CITY_NAME_CHOUM" />
-	<Replace MapName="PlayEuropeAgain" X="4" Y="0" CityLocaleName="LOC_CITY_NAME_KEDIET_IJILL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="8" Y="0" CityLocaleName="LOC_CITY_NAME_OUADANE" />
-	<Replace MapName="PlayEuropeAgain" X="13" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
-	<Replace MapName="PlayEuropeAgain" X="14" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
-	<Replace MapName="PlayEuropeAgain" X="15" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
-	<Replace MapName="PlayEuropeAgain" X="16" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
-	<Replace MapName="PlayEuropeAgain" X="17" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
-	<Replace MapName="PlayEuropeAgain" X="16" Y="1" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
-	
-	<Replace MapName="PlayEuropeAgain" X="2" Y="1" CityLocaleName="LOC_CITY_NAME_ZOUERAT" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="2" Y="2" CityLocaleName="LOC_CITY_NAME_ZOUERAT" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="3" Y="2" CityLocaleName="LOC_CITY_NAME_ZOUERAT" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="4" Y="1" CityLocaleName="LOC_CITY_NAME_ATAR" />
-	<Replace MapName="PlayEuropeAgain" X="10" Y="1" CityLocaleName="LOC_CITY_NAME_EL_HANK" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="19" Y="2" CityLocaleName="LOC_CITY_NAME_TABALBALA" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="0" Y="3" CityLocaleName="LOC_CITY_NAME_FDERIK" />
-	<Replace MapName="PlayEuropeAgain" X="4" Y="3" CityLocaleName="LOC_CITY_NAME_ADRAR" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="4" Y="5" CityLocaleName="LOC_CITY_NAME_ADRAR" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="14" Y="3" CityLocaleName="LOC_CITY_NAME_ERG_IGUIDI" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="3" Y="4" CityLocaleName="LOC_CITY_NAME_TOURINE" />
-	<Replace MapName="PlayEuropeAgain" X="7" Y="4" CityLocaleName="LOC_CITY_NAME_BIR_LEULOU" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="17" Y="5" CityLocaleName="LOC_CITY_NAME_ZERHAMRA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="1" Y="6" CityLocaleName="LOC_CITY_NAME_BIR_MOGHREIN" />
-	<Replace MapName="PlayEuropeAgain" X="11" Y="6" CityLocaleName="LOC_CITY_NAME_AIN_BEN_TILI" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="20" Y="6" CityLocaleName="LOC_CITY_NAME_IGLI" />
-	
-	<Replace MapName="PlayEuropeAgain" X="6" Y="7" CityLocaleName="LOC_CITY_NAME_TIFARITI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="7" Y="7" CityLocaleName="LOC_CITY_NAME_TIFARITI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="8" Y="7" CityLocaleName="LOC_CITY_NAME_TIFARITI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="17" Y="7" CityLocaleName="LOC_CITY_NAME_HAMAGUIR" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="18" Y="7" CityLocaleName="LOC_CITY_NAME_HAMAGUIR" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="0" Y="8" CityLocaleName="LOC_CITY_NAME_BOUCRAA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="4" Y="8" CityLocaleName="LOC_CITY_NAME_TINDUF" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="9" Y="8" CityLocaleName="LOC_CITY_NAME_AL_MAHBES" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="15" Y="8" CityLocaleName="LOC_CITY_NAME_TIRIS_ZEMMOUR" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="20" Y="8" CityLocaleName="LOC_CITY_NAME_TAGHIT" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="21" Y="8" CityLocaleName="LOC_CITY_NAME_TAGHIT" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="20" Y="9" CityLocaleName="LOC_CITY_NAME_TAGHIT" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="1" Y="9" CityLocaleName="LOC_CITY_NAME_SAMARA" />
-	<Replace MapName="PlayEuropeAgain" X="7" Y="9" CityLocaleName="LOC_CITY_NAME_MAHBES" />
-	<Replace MapName="PlayEuropeAgain" X="12" Y="9" CityLocaleName="LOC_CITY_NAME_TINFOUCHY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="13" Y="10" CityLocaleName="LOC_CITY_NAME_TINFOUCHY" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="18" Y="9" CityLocaleName="LOC_CITY_NAME_ABADLA" Area="" />
-	
-	<Replace MapName="PlayEuropeAgain" X="0" Y="10" CityLocaleName="LOC_CITY_NAME_EL_AAIUN" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="6" Y="10" CityLocaleName="LOC_CITY_NAME_ICHT" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="17" Y="10" CityLocaleName="LOC_CITY_NAME_TOURZA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="16" Y="11" CityLocaleName="LOC_CITY_NAME_TOURZA" Area="0" />
 
-	<Replace MapName="PlayEuropeAgain" X="3" Y="11" CityLocaleName="LOC_CITY_NAME_ASSA" />
-	<Replace MapName="PlayEuropeAgain" X="10" Y="11" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="20" Y="11" CityLocaleName="LOC_CITY_NAME_BECHAR" />
-	
-	<Replace MapName="PlayEuropeAgain" X="1" Y="12" CityLocaleName="LOC_CITY_NAME_TAN_TAN" />
-	<Replace MapName="PlayEuropeAgain" X="5" Y="12" CityLocaleName="LOC_CITY_NAME_TAFRAOUTE" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="5" Y="13" CityLocaleName="LOC_CITY_NAME_TAFRAOUTE" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="7" Y="12" CityLocaleName="LOC_CITY_NAME_TATA" />
-	<Replace MapName="PlayEuropeAgain" X="18" Y="12" CityLocaleName="LOC_CITY_NAME_ERFOUD" />
-	
-	<Replace MapName="PlayEuropeAgain" X="2" Y="13" CityLocaleName="LOC_CITY_NAME_GUELMIM" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="1" Y="14" CityLocaleName="LOC_CITY_NAME_GUELMIM" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="2" Y="14" CityLocaleName="LOC_CITY_NAME_GUELMIM" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="3" Y="13" CityLocaleName="LOC_CITY_NAME_TIGHMERT" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="14" Y="13" CityLocaleName="LOC_CITY_NAME_KSAR_ES_SOUK" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="6" Y="14" CityLocaleName="LOC_CITY_NAME_TIMICHA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="8" Y="14" CityLocaleName="LOC_CITY_NAME_OUARZAZATE" />
-	<Replace MapName="PlayEuropeAgain" X="12" Y="14" CityLocaleName="LOC_CITY_NAME_GOULMIMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="12" Y="15" CityLocaleName="LOC_CITY_NAME_GOULMIMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="12" Y="16" CityLocaleName="LOC_CITY_NAME_GOULMIMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="17" Y="14" CityLocaleName="LOC_CITY_NAME_AOUFOUS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="18" Y="14" CityLocaleName="LOC_CITY_NAME_AOUFOUS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="20" Y="14" CityLocaleName="LOC_CITY_NAME_FIGUIG" />
-	
-	<Replace MapName="PlayEuropeAgain" X="1" Y="15" CityLocaleName="LOC_CITY_NAME_TIZNIT" />
-	<Replace MapName="PlayEuropeAgain" X="4" Y="15" CityLocaleName="LOC_CITY_NAME_TAROUDANNT" />
-	<Replace MapName="PlayEuropeAgain" X="10" Y="15" CityLocaleName="LOC_CITY_NAME_TINGHIR" />
-	<Replace MapName="PlayEuropeAgain" X="18" Y="15" CityLocaleName="LOC_CITY_NAME_BOUARFA" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="6" Y="16" CityLocaleName="LOC_CITY_NAME_IMLIL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="7" Y="16" CityLocaleName="LOC_CITY_NAME_IMLIL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="14" Y="16" CityLocaleName="LOC_CITY_NAME_MIDELT" />
-	<Replace MapName="PlayEuropeAgain" X="17" Y="16" CityLocaleName="LOC_CITY_NAME_ERRACHIDIA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="4" Y="17" CityLocaleName="LOC_CITY_NAME_CHICHAOUA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="7" Y="17" CityLocaleName="LOC_CITY_NAME_AZILAL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="8" Y="17" CityLocaleName="LOC_CITY_NAME_AZILAL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="9" Y="17" CityLocaleName="LOC_CITY_NAME_AZILAL" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="19" Y="17" CityLocaleName="LOC_CITY_NAME_TENDRARA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="3" Y="18" CityLocaleName="LOC_CITY_NAME_AGADIR" />
-	<Replace MapName="PlayEuropeAgain" X="6" Y="18" CityLocaleName="LOC_CITY_NAME_MARRAKECH" />
-	<Replace MapName="PlayEuropeAgain" X="12" Y="18" CityLocaleName="LOC_CITY_NAME_BENI_MELLAL" />
-	<Replace MapName="PlayEuropeAgain" X="16" Y="18" CityLocaleName="LOC_CITY_NAME_EL_MENZEL" />
-	
-	<Replace MapName="PlayEuropeAgain" X="4" Y="19" CityLocaleName="LOC_CITY_NAME_ESSAOUIRA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="4" Y="20" CityLocaleName="LOC_CITY_NAME_ESSAOUIRA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="8" Y="19" CityLocaleName="LOC_CITY_NAME_KHOURIBGA" Area="" />
-	
-	<Replace MapName="PlayEuropeAgain" X="5" Y="20" CityLocaleName="LOC_CITY_NAME_SAFI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="6" Y="20" CityLocaleName="LOC_CITY_NAME_SAFI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="7" Y="20" CityLocaleName="LOC_CITY_NAME_SETTAT" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="10" Y="20" CityLocaleName="LOC_CITY_NAME_KHENIFRA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="11" Y="20" CityLocaleName="LOC_CITY_NAME_KHENIFRA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="14" Y="20" CityLocaleName="LOC_CITY_NAME_AZROU" />
-	<Replace MapName="PlayEuropeAgain" X="20" Y="20" CityLocaleName="LOC_CITY_NAME_AIN_BNI_MATHAR" />
-	
-	<Replace MapName="PlayEuropeAgain" X="7" Y="21" CityLocaleName="LOC_CITY_NAME_BERRECHID" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="8" Y="21" CityLocaleName="LOC_CITY_NAME_BERRECHID" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="9" Y="21" CityLocaleName="LOC_CITY_NAME_OULMES" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="10" Y="21" CityLocaleName="LOC_CITY_NAME_OULMES" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="15" Y="21" CityLocaleName="LOC_CITY_NAME_SEFROU" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="16" Y="22" CityLocaleName="LOC_CITY_NAME_SEFROU" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="17" Y="21" CityLocaleName="LOC_CITY_NAME_GUERCIF" />
-	
-	<Replace MapName="PlayEuropeAgain" X="6" Y="22" CityLocaleName="LOC_CITY_NAME_EL_JADIDA" />
-	<Replace MapName="PlayEuropeAgain" X="10" Y="22" CityLocaleName="LOC_CITY_NAME_KHEMISSET" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="10" Y="23" CityLocaleName="LOC_CITY_NAME_KHEMISSET" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="12" Y="22" CityLocaleName="LOC_CITY_NAME_MEKNES" />
-	<Replace MapName="PlayEuropeAgain" X="15" Y="22" CityLocaleName="LOC_CITY_NAME_IMOUZZER_KANDAR" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="16" Y="23" CityLocaleName="LOC_CITY_NAME_IMOUZZER_KANDAR" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="8" Y="23" CityLocaleName="LOC_CITY_NAME_CASABLANCA" />
-	<Replace MapName="PlayEuropeAgain" X="20" Y="23" CityLocaleName="LOC_CITY_NAME_OUJDA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="10" Y="24" CityLocaleName="LOC_CITY_NAME_TEMARA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="14" Y="24" CityLocaleName="LOC_CITY_NAME_FES" />
-	<Replace MapName="PlayEuropeAgain" X="17" Y="24" CityLocaleName="LOC_CITY_NAME_TAZA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="11" Y="25" CityLocaleName="LOC_CITY_NAME_RABAT" />
-	<Replace MapName="PlayEuropeAgain" X="15" Y="25" CityLocaleName="LOC_CITY_NAME_TAOUNATE" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="13" Y="26" CityLocaleName="LOC_CITY_NAME_SALE" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="14" Y="26" CityLocaleName="LOC_CITY_NAME_KENITRA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="15" Y="26" CityLocaleName="LOC_CITY_NAME_CHEFCHAOUEN" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="17" Y="26" CityLocaleName="LOC_CITY_NAME_HOCEIMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="19" Y="26" CityLocaleName="LOC_CITY_NAME_NADOR" />
-	<Replace MapName="PlayEuropeAgain" X="20" Y="26" CityLocaleName="LOC_CITY_NAME_NADOR" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="16" Y="27" CityLocaleName="LOC_CITY_NAME_TETOUAN" />
-	
-	<Replace MapName="PlayEuropeAgain" X="14" Y="28" CityLocaleName="LOC_CITY_NAME_TANGIER" />
-	
+		<Replace MapName="PlayEuropeAgain" X="1" Y="0" CityLocaleName="LOC_CITY_NAME_CHOUM" />
+		<Replace MapName="PlayEuropeAgain" X="4" Y="0" CityLocaleName="LOC_CITY_NAME_KEDIET_IJILL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="8" Y="0" CityLocaleName="LOC_CITY_NAME_OUADANE" />
+		<Replace MapName="PlayEuropeAgain" X="13" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
+		<Replace MapName="PlayEuropeAgain" X="14" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
+		<Replace MapName="PlayEuropeAgain" X="15" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
+		<Replace MapName="PlayEuropeAgain" X="16" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
+		<Replace MapName="PlayEuropeAgain" X="17" Y="0" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
+		<Replace MapName="PlayEuropeAgain" X="16" Y="1" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="0" /> <!--FILL GAPS AT MAP EDGE -->
+
+		<Replace MapName="PlayEuropeAgain" X="2" Y="1" CityLocaleName="LOC_CITY_NAME_ZOUERAT" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="2" Y="2" CityLocaleName="LOC_CITY_NAME_ZOUERAT" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="3" Y="2" CityLocaleName="LOC_CITY_NAME_ZOUERAT" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="4" Y="1" CityLocaleName="LOC_CITY_NAME_ATAR" />
+		<Replace MapName="PlayEuropeAgain" X="10" Y="1" CityLocaleName="LOC_CITY_NAME_EL_HANK" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="19" Y="2" CityLocaleName="LOC_CITY_NAME_TABALBALA" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="0" Y="3" CityLocaleName="LOC_CITY_NAME_FDERIK" />
+		<Replace MapName="PlayEuropeAgain" X="4" Y="3" CityLocaleName="LOC_CITY_NAME_ADRAR" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="4" Y="5" CityLocaleName="LOC_CITY_NAME_ADRAR" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="3" CityLocaleName="LOC_CITY_NAME_ERG_IGUIDI" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="3" Y="4" CityLocaleName="LOC_CITY_NAME_TOURINE" />
+		<Replace MapName="PlayEuropeAgain" X="7" Y="4" CityLocaleName="LOC_CITY_NAME_BIR_LEULOU" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="17" Y="5" CityLocaleName="LOC_CITY_NAME_ZERHAMRA" />
+
+		<Replace MapName="PlayEuropeAgain" X="1" Y="6" CityLocaleName="LOC_CITY_NAME_BIR_MOGHREIN" />
+		<Replace MapName="PlayEuropeAgain" X="11" Y="6" CityLocaleName="LOC_CITY_NAME_AIN_BEN_TILI" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="6" CityLocaleName="LOC_CITY_NAME_IGLI" />
+
+		<Replace MapName="PlayEuropeAgain" X="6" Y="7" CityLocaleName="LOC_CITY_NAME_TIFARITI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="7" Y="7" CityLocaleName="LOC_CITY_NAME_TIFARITI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="8" Y="7" CityLocaleName="LOC_CITY_NAME_TIFARITI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="7" CityLocaleName="LOC_CITY_NAME_HAMAGUIR" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="7" CityLocaleName="LOC_CITY_NAME_HAMAGUIR" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="0" Y="8" CityLocaleName="LOC_CITY_NAME_BOUCRAA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="4" Y="8" CityLocaleName="LOC_CITY_NAME_TINDUF" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="9" Y="8" CityLocaleName="LOC_CITY_NAME_AL_MAHBES" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="8" CityLocaleName="LOC_CITY_NAME_TIRIS_ZEMMOUR" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="8" CityLocaleName="LOC_CITY_NAME_TAGHIT" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="21" Y="8" CityLocaleName="LOC_CITY_NAME_TAGHIT" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="9" CityLocaleName="LOC_CITY_NAME_TAGHIT" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="1" Y="9" CityLocaleName="LOC_CITY_NAME_SAMARA" />
+		<Replace MapName="PlayEuropeAgain" X="7" Y="9" CityLocaleName="LOC_CITY_NAME_MAHBES" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="9" CityLocaleName="LOC_CITY_NAME_TINFOUCHY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="13" Y="10" CityLocaleName="LOC_CITY_NAME_TINFOUCHY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="9" CityLocaleName="LOC_CITY_NAME_ABADLA" Area="" />
+
+		<Replace MapName="PlayEuropeAgain" X="0" Y="10" CityLocaleName="LOC_CITY_NAME_LAAYOUNE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="6" Y="10" CityLocaleName="LOC_CITY_NAME_ICHT" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="10" CityLocaleName="LOC_CITY_NAME_TOURZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="11" CityLocaleName="LOC_CITY_NAME_TOURZA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="3" Y="11" CityLocaleName="LOC_CITY_NAME_ASSA" />
+		<Replace MapName="PlayEuropeAgain" X="10" Y="11" CityLocaleName="LOC_CITY_NAME_OUM_EL_ASSEL" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="11" CityLocaleName="LOC_CITY_NAME_BECHAR" />
+
+		<Replace MapName="PlayEuropeAgain" X="1" Y="12" CityLocaleName="LOC_CITY_NAME_TAN_TAN" />
+		<Replace MapName="PlayEuropeAgain" X="5" Y="12" CityLocaleName="LOC_CITY_NAME_TAFRAOUTE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="5" Y="13" CityLocaleName="LOC_CITY_NAME_TAFRAOUTE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="7" Y="12" CityLocaleName="LOC_CITY_NAME_TATA" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="12" CityLocaleName="LOC_CITY_NAME_ERFOUD" />
+
+		<Replace MapName="PlayEuropeAgain" X="2" Y="13" CityLocaleName="LOC_CITY_NAME_GUELMIM" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="1" Y="14" CityLocaleName="LOC_CITY_NAME_GUELMIM" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="2" Y="14" CityLocaleName="LOC_CITY_NAME_GUELMIM" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="3" Y="13" CityLocaleName="LOC_CITY_NAME_TIGHMERT" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="13" CityLocaleName="LOC_CITY_NAME_KSAR_ES_SOUK" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="6" Y="14" CityLocaleName="LOC_CITY_NAME_TIMICHA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="8" Y="14" CityLocaleName="LOC_CITY_NAME_OUARZAZATE" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="14" CityLocaleName="LOC_CITY_NAME_GOULMIMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="15" CityLocaleName="LOC_CITY_NAME_GOULMIMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="16" CityLocaleName="LOC_CITY_NAME_GOULMIMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="14" CityLocaleName="LOC_CITY_NAME_AOUFOUS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="14" CityLocaleName="LOC_CITY_NAME_AOUFOUS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="14" CityLocaleName="LOC_CITY_NAME_FIGUIG" />
+
+		<Replace MapName="PlayEuropeAgain" X="1" Y="15" CityLocaleName="LOC_CITY_NAME_TIZNIT" />
+		<Replace MapName="PlayEuropeAgain" X="4" Y="15" CityLocaleName="LOC_CITY_NAME_TAROUDANNT" />
+		<Replace MapName="PlayEuropeAgain" X="10" Y="15" CityLocaleName="LOC_CITY_NAME_TINGHIR" />
+		<Replace MapName="PlayEuropeAgain" X="18" Y="15" CityLocaleName="LOC_CITY_NAME_BOUARFA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="6" Y="16" CityLocaleName="LOC_CITY_NAME_IMLIL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="7" Y="16" CityLocaleName="LOC_CITY_NAME_IMLIL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="16" CityLocaleName="LOC_CITY_NAME_MIDELT" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="16" CityLocaleName="LOC_CITY_NAME_ERRACHIDIA" />
+
+		<Replace MapName="PlayEuropeAgain" X="4" Y="17" CityLocaleName="LOC_CITY_NAME_CHICHAOUA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="7" Y="17" CityLocaleName="LOC_CITY_NAME_AZILAL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="8" Y="17" CityLocaleName="LOC_CITY_NAME_AZILAL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="9" Y="17" CityLocaleName="LOC_CITY_NAME_AZILAL" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="17" CityLocaleName="LOC_CITY_NAME_TENDRARA" />
+
+		<Replace MapName="PlayEuropeAgain" X="3" Y="18" CityLocaleName="LOC_CITY_NAME_AGADIR" />
+		<Replace MapName="PlayEuropeAgain" X="6" Y="18" CityLocaleName="LOC_CITY_NAME_MARRAKECH" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="18" CityLocaleName="LOC_CITY_NAME_BENI_MELLAL" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="18" CityLocaleName="LOC_CITY_NAME_EL_MENZEL" />
+
+		<Replace MapName="PlayEuropeAgain" X="4" Y="19" CityLocaleName="LOC_CITY_NAME_ESSAOUIRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="4" Y="20" CityLocaleName="LOC_CITY_NAME_ESSAOUIRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="8" Y="19" CityLocaleName="LOC_CITY_NAME_KHOURIBGA" Area="" />
+
+		<Replace MapName="PlayEuropeAgain" X="5" Y="20" CityLocaleName="LOC_CITY_NAME_SAFI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="6" Y="20" CityLocaleName="LOC_CITY_NAME_SAFI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="7" Y="20" CityLocaleName="LOC_CITY_NAME_SETTAT" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="10" Y="20" CityLocaleName="LOC_CITY_NAME_KHENIFRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="11" Y="20" CityLocaleName="LOC_CITY_NAME_KHENIFRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="20" CityLocaleName="LOC_CITY_NAME_AZROU" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="20" CityLocaleName="LOC_CITY_NAME_AIN_BNI_MATHAR" />
+
+		<Replace MapName="PlayEuropeAgain" X="7" Y="21" CityLocaleName="LOC_CITY_NAME_BERRECHID" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="8" Y="21" CityLocaleName="LOC_CITY_NAME_BERRECHID" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="9" Y="21" CityLocaleName="LOC_CITY_NAME_OULMES" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="10" Y="21" CityLocaleName="LOC_CITY_NAME_OULMES" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="21" CityLocaleName="LOC_CITY_NAME_SEFROU" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="22" CityLocaleName="LOC_CITY_NAME_SEFROU" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="21" CityLocaleName="LOC_CITY_NAME_GUERCIF" />
+
+		<Replace MapName="PlayEuropeAgain" X="6" Y="22" CityLocaleName="LOC_CITY_NAME_EL_JADIDA" />
+		<Replace MapName="PlayEuropeAgain" X="10" Y="22" CityLocaleName="LOC_CITY_NAME_KHEMISSET" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="10" Y="23" CityLocaleName="LOC_CITY_NAME_KHEMISSET" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="12" Y="22" CityLocaleName="LOC_CITY_NAME_MEKNES" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="22" CityLocaleName="LOC_CITY_NAME_IMOUZZER_KANDAR" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="23" CityLocaleName="LOC_CITY_NAME_IMOUZZER_KANDAR" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="8" Y="23" CityLocaleName="LOC_CITY_NAME_CASABLANCA" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="23" CityLocaleName="LOC_CITY_NAME_OUJDA" />
+
+		<Replace MapName="PlayEuropeAgain" X="10" Y="24" CityLocaleName="LOC_CITY_NAME_TEMARA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="24" CityLocaleName="LOC_CITY_NAME_FEZ" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="24" CityLocaleName="LOC_CITY_NAME_TAZA" />
+
+		<Replace MapName="PlayEuropeAgain" X="11" Y="25" CityLocaleName="LOC_CITY_NAME_RABAT" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="25" CityLocaleName="LOC_CITY_NAME_TAOUNATE" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="13" Y="26" CityLocaleName="LOC_CITY_NAME_SALE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="14" Y="26" CityLocaleName="LOC_CITY_NAME_KENITRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="15" Y="26" CityLocaleName="LOC_CITY_NAME_CHEFCHAOUEN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="17" Y="26" CityLocaleName="LOC_CITY_NAME_HOCEIMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="26" CityLocaleName="LOC_CITY_NAME_NADOR" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="26" CityLocaleName="LOC_CITY_NAME_NADOR" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="16" Y="27" CityLocaleName="LOC_CITY_NAME_TETOUAN" />
+
+		<Replace MapName="PlayEuropeAgain" X="14" Y="28" CityLocaleName="LOC_CITY_NAME_TANGIER" />
+
 	</CityMap>
-	
+
 	<!-- CENTRAL AFRICA (ALGERIA, TUNISIA, NORTH LIBYA) -->
 	<CityMap>
-	<Replace MapName="PlayEuropeAgain" X="22" Y="0" CityLocaleName="LOC_CITY_NAME_MGUIDEN" />
-	<Replace MapName="PlayEuropeAgain" X="27" Y="0" CityLocaleName="LOC_CITY_NAME_FOGGARET_EZ_ZOUA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="34" Y="1" CityLocaleName="LOC_CITY_NAME_HASSI_BEL_GUEBBOUR" Area="3" />
-	
-	<Replace MapName="PlayEuropeAgain" X="25" Y="2" CityLocaleName="LOC_CITY_NAME_EL_MENIA" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="29" Y="3" CityLocaleName="LOC_CITY_NAME_HASSI_MESSAOUD" Area="3" />
-	<Replace MapName="PlayEuropeAgain" X="39" Y="3" CityLocaleName="LOC_CITY_NAME_STAH" Area="3" />
-	
-	<Replace MapName="PlayEuropeAgain" X="22" Y="4" CityLocaleName="LOC_CITY_NAME_GRAND_ERG_OCCIDENTAL" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="25" Y="6" CityLocaleName="LOC_CITY_NAME_HASSI_FEHAL" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="37" Y="6" CityLocaleName="LOC_CITY_NAME_DEBDEB" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="42" Y="7" CityLocaleName="LOC_CITY_NAME_BORJ_EL_KHADRA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="29" Y="8" CityLocaleName="LOC_CITY_NAME_GASSI_EL_AGREB" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="34" Y="8" CityLocaleName="LOC_CITY_NAME_EL_BORMA" Area="3" />
-	<Replace MapName="PlayEuropeAgain" X="40" Y="8" CityLocaleName="LOC_CITY_NAME_GHADAMES" />
-	
-	<Replace MapName="PlayEuropeAgain" X="22" Y="9" CityLocaleName="LOC_CITY_NAME_BENOUD" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="25" Y="9" CityLocaleName="LOC_CITY_NAME_MANSOURA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="31" Y="10" CityLocaleName="LOC_CITY_NAME_TAMANGHASSET" />
-	<Replace MapName="PlayEuropeAgain" X="38" Y="10" CityLocaleName="LOC_CITY_NAME_SINAWIN" />
-	<Replace MapName="PlayEuropeAgain" X="42" Y="10" CityLocaleName="LOC_CITY_NAME_GHARYAN" />
-	<Replace MapName="PlayEuropeAgain" X="44" Y="10" CityLocaleName="LOC_CITY_NAME_BANI_WALID" />
-	
-	<Replace MapName="PlayEuropeAgain" X="40" Y="11" CityLocaleName="LOC_CITY_NAME_TABAQAH" />
-	
-	<Replace MapName="PlayEuropeAgain" X="25" Y="12" CityLocaleName="LOC_CITY_NAME_GHARDAIA" />
-	<Replace MapName="PlayEuropeAgain" X="28" Y="12" CityLocaleName="LOC_CITY_NAME_OUARGLA" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="35" Y="12" CityLocaleName="LOC_CITY_NAME_JEBIL" />
-	<Replace MapName="PlayEuropeAgain" X="43" Y="12" CityLocaleName="LOC_CITY_NAME_MSALLATA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="22" Y="13" CityLocaleName="LOC_CITY_NAME_MOGHRAR" />
-	<Replace MapName="PlayEuropeAgain" X="37" Y="13" CityLocaleName="LOC_CITY_NAME_TATAOUINE" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="40" Y="13" CityLocaleName="LOC_CITY_NAME_AL_JAWSH" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="41" Y="13" CityLocaleName="LOC_CITY_NAME_ALZINTAN" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="45" Y="13" CityLocaleName="LOC_CITY_NAME_MISRATA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="24" Y="14" CityLocaleName="LOC_CITY_NAME_EL_BADIYAH" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="23" Y="15" CityLocaleName="LOC_CITY_NAME_EL_BADIYAH" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="24" Y="16" CityLocaleName="LOC_CITY_NAME_EL_BADIYAH" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="32" Y="14" CityLocaleName="LOC_CITY_NAME_GRAND_ERG_ORIENTAL" Area="3" />
-	<Replace MapName="PlayEuropeAgain" X="41" Y="14" CityLocaleName="LOC_CITY_NAME_ALRIYAYNA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="44" Y="14" CityLocaleName="LOC_CITY_NAME_AL_KHUMS" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="25" Y="15" CityLocaleName="LOC_CITY_NAME_LAGHOUAT" />
-	<Replace MapName="PlayEuropeAgain" X="39" Y="15" CityLocaleName="LOC_CITY_NAME_ZUWARA" />
-	<Replace MapName="PlayEuropeAgain" X="42" Y="15" CityLocaleName="LOC_CITY_NAME_TRIPOLI" />
-	
-	<Replace MapName="PlayEuropeAgain" X="22" Y="16" CityLocaleName="LOC_CITY_NAME_AIN_SEFRA" />
-	<Replace MapName="PlayEuropeAgain" X="28" Y="16" CityLocaleName="LOC_CITY_NAME_EL_GUERRARA" />
-	<Replace MapName="PlayEuropeAgain" X="35" Y="16" CityLocaleName="LOC_CITY_NAME_TOZEUR" />
-	
-	<Replace MapName="PlayEuropeAgain" X="36" Y="17" CityLocaleName="LOC_CITY_NAME_GABES" />
-	
-	<Replace MapName="PlayEuropeAgain" X="21" Y="18" CityLocaleName="LOC_CITY_NAME_NAAMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="22" Y="18" CityLocaleName="LOC_CITY_NAME_NAAMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="24" Y="18" CityLocaleName="LOC_CITY_NAME_DJELFA" />
-	<Replace MapName="PlayEuropeAgain" X="26" Y="18" CityLocaleName="LOC_CITY_NAME_MESSAAD" />
-	<Replace MapName="PlayEuropeAgain" X="28" Y="18" CityLocaleName="LOC_CITY_NAME_TOLGA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="29" Y="18" CityLocaleName="LOC_CITY_NAME_TOLGA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="28" Y="19" CityLocaleName="LOC_CITY_NAME_TOLGA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="33" Y="18" CityLocaleName="LOC_CITY_NAME_TOUGGOURT" />
-	
-	<Replace MapName="PlayEuropeAgain" X="30" Y="19" CityLocaleName="LOC_CITY_NAME_BISKRA" />
-	<Replace MapName="PlayEuropeAgain" X="35" Y="19" CityLocaleName="LOC_CITY_NAME_SIDI_BOUZID" />
-	
-	<Replace MapName="PlayEuropeAgain" X="22" Y="20" CityLocaleName="LOC_CITY_NAME_MECHERIA" />
-	<Replace MapName="PlayEuropeAgain" X="27" Y="20" CityLocaleName="LOC_CITY_NAME_BOU_SAADA" />
-	<Replace MapName="PlayEuropeAgain" X="32" Y="20" CityLocaleName="LOC_CITY_NAME_AIN_BEIDA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="32" Y="21" CityLocaleName="LOC_CITY_NAME_AIN_BEIDA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="34" Y="20" CityLocaleName="LOC_CITY_NAME_TEBESSA" />
-	<Replace MapName="PlayEuropeAgain" X="38" Y="20" CityLocaleName="LOC_CITY_NAME_SFAX" />
-	
-	<Replace MapName="PlayEuropeAgain" X="24" Y="21" CityLocaleName="LOC_CITY_NAME_AIN_OUSSERA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="25" Y="21" CityLocaleName="LOC_CITY_NAME_HAD_SAHARY" Area="0" />	
-	<Replace MapName="PlayEuropeAgain" X="28" Y="21" CityLocaleName="LOC_CITY_NAME_BARIKA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="36" Y="21" CityLocaleName="LOC_CITY_NAME_AL_QAYRAWAN" />
-	
-	<Replace MapName="PlayEuropeAgain" X="23" Y="22" CityLocaleName="LOC_CITY_NAME_SAIDA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="26" Y="22" CityLocaleName="LOC_CITY_NAME_SIDI_AISSA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="29" Y="22" CityLocaleName="LOC_CITY_NAME_EL_EULMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="28" Y="23" CityLocaleName="LOC_CITY_NAME_EL_EULMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="31" Y="22" CityLocaleName="LOC_CITY_NAME_BATNA" />
-	<Replace MapName="PlayEuropeAgain" X="33" Y="22" CityLocaleName="LOC_CITY_NAME_GUELMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="34" Y="23" CityLocaleName="LOC_CITY_NAME_GUELMA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="34" Y="22" CityLocaleName="LOC_CITY_NAME_SOUK_AHRAS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="35" Y="22" CityLocaleName="LOC_CITY_NAME_SOUK_AHRAS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="37" Y="22" CityLocaleName="LOC_CITY_NAME_TUNIS" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="21" Y="23" CityLocaleName="LOC_CITY_NAME_TLEMCEN" />
-	<Replace MapName="PlayEuropeAgain" X="23" Y="23" CityLocaleName="LOC_CITY_NAME_TIARET" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="24" Y="23" CityLocaleName="LOC_CITY_NAME_MEDEA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="25" Y="24" CityLocaleName="LOC_CITY_NAME_MEDEA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="28" Y="23" CityLocaleName="LOC_CITY_NAME_MSILA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="33" Y="23" CityLocaleName="LOC_CITY_NAME_ALI_MENDJELI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="38" Y="23" CityLocaleName="LOC_CITY_NAME_TUNIS" />
-	
-	<Replace MapName="PlayEuropeAgain" X="31" Y="24" CityLocaleName="LOC_CITY_NAME_MILA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="35" Y="24" CityLocaleName="LOC_CITY_NAME_ANNABA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="23" Y="25" CityLocaleName="LOC_CITY_NAME_BLIDA" />
-	<Replace MapName="PlayEuropeAgain" X="26" Y="25" CityLocaleName="LOC_CITY_NAME_BORDJ_BOU_ARRERIDJ" />
-	<Replace MapName="PlayEuropeAgain" X="28" Y="25" CityLocaleName="LOC_CITY_NAME_SETIF" />
-	<Replace MapName="PlayEuropeAgain" X="30" Y="25" CityLocaleName="LOC_CITY_NAME_TAMALOUS" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="32" Y="25" CityLocaleName="LOC_CITY_NAME_CONSTANTINE" />
-	
-	<Replace MapName="PlayEuropeAgain" X="21" Y="26" CityLocaleName="LOC_CITY_NAME_ORAN" />
-	<Replace MapName="PlayEuropeAgain" X="24" Y="26" CityLocaleName="LOC_CITY_NAME_ALGIERS" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="24" Y="27" CityLocaleName="LOC_CITY_NAME_ALGIERS"  />
-	<Replace MapName="PlayEuropeAgain" X="27" Y="27" CityLocaleName="LOC_CITY_NAME_BEJAIA" />
-	<Replace MapName="PlayEuropeAgain" X="30" Y="27" CityLocaleName="LOC_CITY_NAME_COLLO" />
+
+		<Replace MapName="PlayEuropeAgain" X="22" Y="0" CityLocaleName="LOC_CITY_NAME_MGUIDEN" />
+		<Replace MapName="PlayEuropeAgain" X="27" Y="0" CityLocaleName="LOC_CITY_NAME_FOGGARET_EZ_ZOUA" />
+
+		<Replace MapName="PlayEuropeAgain" X="34" Y="1" CityLocaleName="LOC_CITY_NAME_HASSI_BEL_GUEBBOUR" Area="3" />
+
+		<Replace MapName="PlayEuropeAgain" X="25" Y="2" CityLocaleName="LOC_CITY_NAME_EL_MENIA" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="29" Y="3" CityLocaleName="LOC_CITY_NAME_HASSI_MESSAOUD" Area="3" />
+		<Replace MapName="PlayEuropeAgain" X="39" Y="3" CityLocaleName="LOC_CITY_NAME_STAH" Area="3" />
+
+		<Replace MapName="PlayEuropeAgain" X="22" Y="4" CityLocaleName="LOC_CITY_NAME_GRAND_ERG_OCCIDENTAL" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="25" Y="6" CityLocaleName="LOC_CITY_NAME_HASSI_FEHAL" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="37" Y="6" CityLocaleName="LOC_CITY_NAME_DEBDEB" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="42" Y="7" CityLocaleName="LOC_CITY_NAME_BORJ_EL_KHADRA" />
+
+		<Replace MapName="PlayEuropeAgain" X="29" Y="8" CityLocaleName="LOC_CITY_NAME_GASSI_EL_AGREB" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="34" Y="8" CityLocaleName="LOC_CITY_NAME_EL_BORMA" Area="3" />
+		<Replace MapName="PlayEuropeAgain" X="40" Y="8" CityLocaleName="LOC_CITY_NAME_GHADAMES" />
+
+		<Replace MapName="PlayEuropeAgain" X="22" Y="9" CityLocaleName="LOC_CITY_NAME_BENOUD" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="25" Y="9" CityLocaleName="LOC_CITY_NAME_MANSOURA" />
+
+		<Replace MapName="PlayEuropeAgain" X="31" Y="10" CityLocaleName="LOC_CITY_NAME_TAMANGHASSET" />
+		<Replace MapName="PlayEuropeAgain" X="38" Y="10" CityLocaleName="LOC_CITY_NAME_SINAWIN" />
+		<Replace MapName="PlayEuropeAgain" X="42" Y="10" CityLocaleName="LOC_CITY_NAME_GHARYAN" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="10" CityLocaleName="LOC_CITY_NAME_BANI_WALID" />
+
+		<Replace MapName="PlayEuropeAgain" X="40" Y="11" CityLocaleName="LOC_CITY_NAME_TABAQA" />
+
+		<Replace MapName="PlayEuropeAgain" X="25" Y="12" CityLocaleName="LOC_CITY_NAME_GHARDAIA" />
+		<Replace MapName="PlayEuropeAgain" X="28" Y="12" CityLocaleName="LOC_CITY_NAME_OUARGLA" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="35" Y="12" CityLocaleName="LOC_CITY_NAME_JEBIL" />
+		<Replace MapName="PlayEuropeAgain" X="43" Y="12" CityLocaleName="LOC_CITY_NAME_MSALLATA" />
+
+		<Replace MapName="PlayEuropeAgain" X="22" Y="13" CityLocaleName="LOC_CITY_NAME_MOGHRAR" />
+		<Replace MapName="PlayEuropeAgain" X="37" Y="13" CityLocaleName="LOC_CITY_NAME_TATAOUINE" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="40" Y="13" CityLocaleName="LOC_CITY_NAME_AL_JAWSH" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="41" Y="13" CityLocaleName="LOC_CITY_NAME_ALZINTAN" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="45" Y="13" CityLocaleName="LOC_CITY_NAME_MISRATA" />
+
+		<Replace MapName="PlayEuropeAgain" X="24" Y="14" CityLocaleName="LOC_CITY_NAME_EL_BADIYAH" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="23" Y="15" CityLocaleName="LOC_CITY_NAME_EL_BADIYAH" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="24" Y="16" CityLocaleName="LOC_CITY_NAME_EL_BADIYAH" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="32" Y="14" CityLocaleName="LOC_CITY_NAME_GRAND_ERG_ORIENTAL" Area="3" />
+		<Replace MapName="PlayEuropeAgain" X="41" Y="14" CityLocaleName="LOC_CITY_NAME_ALRIYAYNA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="44" Y="14" CityLocaleName="LOC_CITY_NAME_AL_KHUMS" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="25" Y="15" CityLocaleName="LOC_CITY_NAME_LAGHOUAT" />
+		<Replace MapName="PlayEuropeAgain" X="39" Y="15" CityLocaleName="LOC_CITY_NAME_ZUWARA" />
+		<Replace MapName="PlayEuropeAgain" X="42" Y="15" CityLocaleName="LOC_CITY_NAME_TRIPOLI" />
+
+		<Replace MapName="PlayEuropeAgain" X="22" Y="16" CityLocaleName="LOC_CITY_NAME_AIN_SEFRA" />
+		<Replace MapName="PlayEuropeAgain" X="28" Y="16" CityLocaleName="LOC_CITY_NAME_EL_GUERRARA" />
+		<Replace MapName="PlayEuropeAgain" X="35" Y="16" CityLocaleName="LOC_CITY_NAME_TOZEUR" />
+
+		<Replace MapName="PlayEuropeAgain" X="36" Y="17" CityLocaleName="LOC_CITY_NAME_GABES" />
+
+		<Replace MapName="PlayEuropeAgain" X="21" Y="18" CityLocaleName="LOC_CITY_NAME_NAAMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="22" Y="18" CityLocaleName="LOC_CITY_NAME_NAAMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="24" Y="18" CityLocaleName="LOC_CITY_NAME_DJELFA" />
+		<Replace MapName="PlayEuropeAgain" X="26" Y="18" CityLocaleName="LOC_CITY_NAME_MESSAAD" />
+		<Replace MapName="PlayEuropeAgain" X="28" Y="18" CityLocaleName="LOC_CITY_NAME_TOLGA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="29" Y="18" CityLocaleName="LOC_CITY_NAME_TOLGA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="28" Y="19" CityLocaleName="LOC_CITY_NAME_TOLGA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="33" Y="18" CityLocaleName="LOC_CITY_NAME_TOUGGOURT" />
+
+		<Replace MapName="PlayEuropeAgain" X="30" Y="19" CityLocaleName="LOC_CITY_NAME_BISKRA" />
+		<Replace MapName="PlayEuropeAgain" X="35" Y="19" CityLocaleName="LOC_CITY_NAME_SIDI_BOUZID" />
+
+		<Replace MapName="PlayEuropeAgain" X="22" Y="20" CityLocaleName="LOC_CITY_NAME_MECHERIA" />
+		<Replace MapName="PlayEuropeAgain" X="27" Y="20" CityLocaleName="LOC_CITY_NAME_BOU_SAADA" />
+		<Replace MapName="PlayEuropeAgain" X="32" Y="20" CityLocaleName="LOC_CITY_NAME_AIN_BEIDA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="32" Y="21" CityLocaleName="LOC_CITY_NAME_AIN_BEIDA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="34" Y="20" CityLocaleName="LOC_CITY_NAME_TEBESSA" />
+		<Replace MapName="PlayEuropeAgain" X="38" Y="20" CityLocaleName="LOC_CITY_NAME_SFAX" />
+
+		<Replace MapName="PlayEuropeAgain" X="24" Y="21" CityLocaleName="LOC_CITY_NAME_AIN_OUSSERA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="25" Y="21" CityLocaleName="LOC_CITY_NAME_HAD_SAHARY" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="28" Y="21" CityLocaleName="LOC_CITY_NAME_BARIKA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="36" Y="21" CityLocaleName="LOC_CITY_NAME_AL_QAYRAWAN" />
+
+		<Replace MapName="PlayEuropeAgain" X="23" Y="22" CityLocaleName="LOC_CITY_NAME_SAIDA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="26" Y="22" CityLocaleName="LOC_CITY_NAME_SIDI_AISSA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="29" Y="22" CityLocaleName="LOC_CITY_NAME_EL_EULMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="28" Y="23" CityLocaleName="LOC_CITY_NAME_EL_EULMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="31" Y="22" CityLocaleName="LOC_CITY_NAME_BATNA" />
+		<Replace MapName="PlayEuropeAgain" X="33" Y="22" CityLocaleName="LOC_CITY_NAME_GUELMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="34" Y="23" CityLocaleName="LOC_CITY_NAME_GUELMA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="34" Y="22" CityLocaleName="LOC_CITY_NAME_SOUK_AHRAS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="35" Y="22" CityLocaleName="LOC_CITY_NAME_SOUK_AHRAS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="37" Y="22" CityLocaleName="LOC_CITY_NAME_TUNIS" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="21" Y="23" CityLocaleName="LOC_CITY_NAME_TLEMCEN" />
+		<Replace MapName="PlayEuropeAgain" X="23" Y="23" CityLocaleName="LOC_CITY_NAME_TIARET" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="24" Y="23" CityLocaleName="LOC_CITY_NAME_MEDEA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="25" Y="24" CityLocaleName="LOC_CITY_NAME_MEDEA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="28" Y="23" CityLocaleName="LOC_CITY_NAME_MSILA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="33" Y="23" CityLocaleName="LOC_CITY_NAME_ALI_MENDJELI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="38" Y="23" CityLocaleName="LOC_CITY_NAME_TUNIS" />
+
+		<Replace MapName="PlayEuropeAgain" X="31" Y="24" CityLocaleName="LOC_CITY_NAME_MILA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="35" Y="24" CityLocaleName="LOC_CITY_NAME_ANNABA" />
+
+		<Replace MapName="PlayEuropeAgain" X="23" Y="25" CityLocaleName="LOC_CITY_NAME_BLIDA" />
+		<Replace MapName="PlayEuropeAgain" X="26" Y="25" CityLocaleName="LOC_CITY_NAME_BORDJ_BOU_ARRERIDJ" />
+		<Replace MapName="PlayEuropeAgain" X="28" Y="25" CityLocaleName="LOC_CITY_NAME_SETIF" />
+		<Replace MapName="PlayEuropeAgain" X="30" Y="25" CityLocaleName="LOC_CITY_NAME_SKIKDA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="32" Y="25" CityLocaleName="LOC_CITY_NAME_CONSTANTINE" />
+
+		<Replace MapName="PlayEuropeAgain" X="21" Y="26" CityLocaleName="LOC_CITY_NAME_ORAN" />
+		<Replace MapName="PlayEuropeAgain" X="24" Y="26" CityLocaleName="LOC_CITY_NAME_ALGIERS" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="24" Y="27" CityLocaleName="LOC_CITY_NAME_ALGIERS"  />
+		<Replace MapName="PlayEuropeAgain" X="27" Y="27" CityLocaleName="LOC_CITY_NAME_BEJAIA" />
+		<Replace MapName="PlayEuropeAgain" X="30" Y="27" CityLocaleName="LOC_CITY_NAME_COLLO" />
+
+  </CityMap>
+
+  <!-- LIBYA & EGYPT -->
+  <CityMap>
+
+		<Replace MapName="PlayEuropeAgain" X="56" Y="0" CityLocaleName="LOC_CITY_NAME_TAZIRBU" />
+		<Replace MapName="PlayEuropeAgain" X="69" Y="0" CityLocaleName="LOC_CITY_NAME_FARAFRA" />
+		<Replace MapName="PlayEuropeAgain" X="73" Y="0" CityLocaleName="LOC_CITY_NAME_TOD" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="0" CityLocaleName="LOC_CITY_NAME_TOD" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="77" Y="0" CityLocaleName="LOC_CITY_NAME_QUS" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="48" Y="1" CityLocaleName="LOC_CITY_NAME_AL_FUQAHA" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="52" Y="1" CityLocaleName="LOC_CITY_NAME_ZALTAN" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="64" Y="1" CityLocaleName="LOC_CITY_NAME_GILF_KEBIR_PLATEAU" Area="3" />
+		<Replace MapName="PlayEuropeAgain" X="73" Y="1" CityLocaleName="LOC_CITY_NAME_SOHAG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="2" CityLocaleName="LOC_CITY_NAME_SOHAG" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="75" Y="1" CityLocaleName="LOC_CITY_NAME_LUXOR" />
+		<Replace MapName="PlayEuropeAgain" X="78" Y="1" CityLocaleName="LOC_CITY_NAME_SAFAGA" />
+
+		<Replace MapName="PlayEuropeAgain" X="44" Y="2" CityLocaleName="LOC_CITY_NAME_SABHA" Area="3" />
+		<Replace MapName="PlayEuropeAgain" X="60" Y="2" CityLocaleName="LOC_CITY_NAME_KUFRA" Area="3" />
+		<Replace MapName="PlayEuropeAgain" X="71" Y="2" CityLocaleName="LOC_CITY_NAME_BAHARIYA_OASIS" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="55" Y="3" CityLocaleName="LOC_CITY_NAME_AWJILA" Area="2" />
+
+		<Replace MapName="PlayEuropeAgain" X="67" Y="4" CityLocaleName="LOC_CITY_NAME_WHITE_DESERT" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="4" CityLocaleName="LOC_CITY_NAME_ASYUT" />
+		<Replace MapName="PlayEuropeAgain" X="76" Y="4" CityLocaleName="LOC_CITY_NAME_EASTERN_DESERT" />
+		<Replace MapName="PlayEuropeAgain" X="78" Y="4" CityLocaleName="LOC_CITY_NAME_HURGHADA" />
+
+		<Replace MapName="PlayEuropeAgain" X="48" Y="5" CityLocaleName="LOC_CITY_NAME_HOUN" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="51" Y="5" CityLocaleName="LOC_CITY_NAME_MARADA" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="72" Y="5" CityLocaleName="LOC_CITY_NAME_MALLAWI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="73" Y="5" CityLocaleName="LOC_CITY_NAME_MALLAWI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="5" CityLocaleName="LOC_CITY_NAME_BENI_SUEF" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="75" Y="6" CityLocaleName="LOC_CITY_NAME_BENI_SUEF" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="58" Y="6" CityLocaleName="LOC_CITY_NAME_JALU" />
+		<Replace MapName="PlayEuropeAgain" X="69" Y="6" CityLocaleName="LOC_CITY_NAME_AL_HARRAH" />
+		<Replace MapName="PlayEuropeAgain" X="71" Y="6" CityLocaleName="LOC_CITY_NAME_FAIYUM" />
+		<Replace MapName="PlayEuropeAgain" X="73" Y="6" CityLocaleName="LOC_CITY_NAME_GIZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="6" CityLocaleName="LOC_CITY_NAME_GIZA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="72" Y="7" CityLocaleName="LOC_CITY_NAME_GIZA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="45" Y="7" CityLocaleName="LOC_CITY_NAME_ASH_SHWAYRIF" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="54" Y="7" CityLocaleName="LOC_CITY_NAME_AJDABIYA" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="60" Y="7" CityLocaleName="LOC_CITY_NAME_JAKHARRAH" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="63" Y="7" CityLocaleName="LOC_CITY_NAME_AL_JAGHBUB" Area="2" />
+		<Replace MapName="PlayEuropeAgain" X="76" Y="7" CityLocaleName="LOC_CITY_NAME_ZAAFARANA" />
+		<Replace MapName="PlayEuropeAgain" X="78" Y="7" CityLocaleName="LOC_CITY_NAME_EL_TOR" />
+		<Replace MapName="PlayEuropeAgain" X="80" Y="7" CityLocaleName="LOC_CITY_NAME_SHARM_EL_SHEIKH" />
+
+		<Replace MapName="PlayEuropeAgain" X="49" Y="8" CityLocaleName="LOC_CITY_NAME_AN_NAWFALIYAH" />
+		<Replace MapName="PlayEuropeAgain" X="58" Y="8" CityLocaleName="LOC_CITY_NAME_MECHILI" />
+		<Replace MapName="PlayEuropeAgain" X="67" Y="8" CityLocaleName="LOC_CITY_NAME_SIWA_OASIS" />
+		<Replace MapName="PlayEuropeAgain" X="71" Y="8" CityLocaleName="LOC_CITY_NAME_NAUCRATIS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="72" Y="8" CityLocaleName="LOC_CITY_NAME_NAUCRATIS" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="8" CityLocaleName="LOC_CITY_NAME_CAIRO" />
+
+		<Replace MapName="PlayEuropeAgain" X="46" Y="9" CityLocaleName="LOC_CITY_NAME_SIRTE" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="47" Y="10" CityLocaleName="LOC_CITY_NAME_SIRTE" />
+		<Replace MapName="PlayEuropeAgain" X="49" Y="9" CityLocaleName="LOC_CITY_NAME_BIN_JAWAD" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="50" Y="10" CityLocaleName="LOC_CITY_NAME_BIN_JAWAD" />
+		<Replace MapName="PlayEuropeAgain" X="51" Y="9" CityLocaleName="LOC_CITY_NAME_RAS_LANUF" />
+		<Replace MapName="PlayEuropeAgain" X="69" Y="9" CityLocaleName="LOC_CITY_NAME_MARINA_EL_ALAMEIN" />
+		<Replace MapName="PlayEuropeAgain" X="75" Y="9" CityLocaleName="LOC_CITY_NAME_ISMAILIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="76" Y="9" CityLocaleName="LOC_CITY_NAME_SUEZ" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="77" Y="9" CityLocaleName="LOC_CITY_NAME_SUEZ" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="79" Y="9" CityLocaleName="LOC_CITY_NAME_NEKHEL" />
+
+		<Replace MapName="PlayEuropeAgain" X="55" Y="10" CityLocaleName="LOC_CITY_NAME_QAMINIS" />
+		<Replace MapName="PlayEuropeAgain" X="57" Y="10" CityLocaleName="LOC_CITY_NAME_AL_MARJ" />
+		<Replace MapName="PlayEuropeAgain" X="59" Y="10" CityLocaleName="LOC_CITY_NAME_MARTUBA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="58" Y="11" CityLocaleName="LOC_CITY_NAME_MARTUBA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="64" Y="10" CityLocaleName="LOC_CITY_NAME_EL_SALLOUM" />
+		<Replace MapName="PlayEuropeAgain" X="66" Y="10" CityLocaleName="LOC_CITY_NAME_MARSA_MATRUH" />
+		<Replace MapName="PlayEuropeAgain" X="72" Y="10" CityLocaleName="LOC_CITY_NAME_ALEXANDRIA" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="10" CityLocaleName="LOC_CITY_NAME_EL_MAHALLAH_EL_KUBRA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="75" Y="10" CityLocaleName="LOC_CITY_NAME_MANSOURA" Area="0" />
+
+		<Replace MapName="PlayEuropeAgain" X="54" Y="11" CityLocaleName="LOC_CITY_NAME_BENGHAZI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="55" Y="11" CityLocaleName="LOC_CITY_NAME_BENGHAZI" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="55" Y="12" CityLocaleName="LOC_CITY_NAME_BENGHAZI" />
+		<Replace MapName="PlayEuropeAgain" X="61" Y="11" CityLocaleName="LOC_CITY_NAME_TOBRUK" />
+		<Replace MapName="PlayEuropeAgain" X="76" Y="11" CityLocaleName="LOC_CITY_NAME_PORT_SAID"  />
+
+		<Replace MapName="PlayEuropeAgain" X="60" Y="12" CityLocaleName="LOC_CITY_NAME_UMM_RIZAM" />
+		<Replace MapName="PlayEuropeAgain" X="74" Y="12" CityLocaleName="LOC_CITY_NAME_BALTIM" />
+		<Replace MapName="PlayEuropeAgain" X="79" Y="12" CityLocaleName="LOC_CITY_NAME_ARISH" />
+
+		<Replace MapName="PlayEuropeAgain" X="57" Y="13" CityLocaleName="LOC_CITY_NAME_BAYDA" />
+		<Replace MapName="PlayEuropeAgain" X="59" Y="13" CityLocaleName="LOC_CITY_NAME_DERNA" Area="0" />
+
 	</CityMap>
-	
-	<!-- LIBYA & EGYPT -->
-	<CityMap>
-	<Replace MapName="PlayEuropeAgain" X="56" Y="0" CityLocaleName="LOC_CITY_NAME_TAZIRBU" />
-	<Replace MapName="PlayEuropeAgain" X="69" Y="0" CityLocaleName="LOC_CITY_NAME_FARAFRA" />
-	<Replace MapName="PlayEuropeAgain" X="73" Y="0" CityLocaleName="LOC_CITY_NAME_TOD" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="0" CityLocaleName="LOC_CITY_NAME_TOD" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="77" Y="0" CityLocaleName="LOC_CITY_NAME_QUS" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="48" Y="1" CityLocaleName="LOC_CITY_NAME_AL_FUQAHA" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="52" Y="1" CityLocaleName="LOC_CITY_NAME_ZALTAN" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="64" Y="1" CityLocaleName="LOC_CITY_NAME_GILF_KEBIR_PLATEAU" Area="3" />
-	<Replace MapName="PlayEuropeAgain" X="73" Y="1" CityLocaleName="LOC_CITY_NAME_SOHAG" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="2" CityLocaleName="LOC_CITY_NAME_SOHAG" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="75" Y="1" CityLocaleName="LOC_CITY_NAME_LUXOR" />
-	<Replace MapName="PlayEuropeAgain" X="78" Y="1" CityLocaleName="LOC_CITY_NAME_SAFAGA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="44" Y="2" CityLocaleName="LOC_CITY_NAME_SABHA" Area="3" />
-	<Replace MapName="PlayEuropeAgain" X="60" Y="2" CityLocaleName="LOC_CITY_NAME_AL_JAWF" Area="3" />
-	<Replace MapName="PlayEuropeAgain" X="71" Y="2" CityLocaleName="LOC_CITY_NAME_BAHARIYA_OASIS" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="55" Y="3" CityLocaleName="LOC_CITY_NAME_AWJILAH" Area="2" />
-	
-	<Replace MapName="PlayEuropeAgain" X="67" Y="4" CityLocaleName="LOC_CITY_NAME_WHITE_DESERT" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="4" CityLocaleName="LOC_CITY_NAME_ASYUT" />
-	<Replace MapName="PlayEuropeAgain" X="76" Y="4" CityLocaleName="LOC_CITY_NAME_EASTERN_DESERT" />
-	<Replace MapName="PlayEuropeAgain" X="78" Y="4" CityLocaleName="LOC_CITY_NAME_HURGHADA" />
-	
-	<Replace MapName="PlayEuropeAgain" X="48" Y="5" CityLocaleName="LOC_CITY_NAME_HOUN" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="51" Y="5" CityLocaleName="LOC_CITY_NAME_MARADAH" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="72" Y="5" CityLocaleName="LOC_CITY_NAME_MALLAWI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="73" Y="5" CityLocaleName="LOC_CITY_NAME_MALLAWI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="5" CityLocaleName="LOC_CITY_NAME_BENI_SUEF" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="75" Y="6" CityLocaleName="LOC_CITY_NAME_BENI_SUEF" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="58" Y="6" CityLocaleName="LOC_CITY_NAME_JALU" />
-	<Replace MapName="PlayEuropeAgain" X="69" Y="6" CityLocaleName="LOC_CITY_NAME_AL_HARRAH" />
-	<Replace MapName="PlayEuropeAgain" X="71" Y="6" CityLocaleName="LOC_CITY_NAME_FAIYUM" />
-	<Replace MapName="PlayEuropeAgain" X="73" Y="6" CityLocaleName="LOC_CITY_NAME_GIZA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="6" CityLocaleName="LOC_CITY_NAME_GIZA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="72" Y="7" CityLocaleName="LOC_CITY_NAME_GIZA" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="45" Y="7" CityLocaleName="LOC_CITY_NAME_ASH_SHWAYRIF" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="54" Y="7" CityLocaleName="LOC_CITY_NAME_AJDABIYA" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="60" Y="7" CityLocaleName="LOC_CITY_NAME_JAKHARRAH" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="63" Y="7" CityLocaleName="LOC_CITY_NAME_AL_JAGHBUB" Area="2" />
-	<Replace MapName="PlayEuropeAgain" X="76" Y="7" CityLocaleName="LOC_CITY_NAME_ZAAFARANA" />
-	<Replace MapName="PlayEuropeAgain" X="78" Y="7" CityLocaleName="LOC_CITY_NAME_EL_TOR" />
-	<Replace MapName="PlayEuropeAgain" X="80" Y="7" CityLocaleName="LOC_CITY_NAME_SHARM_EL_SHEIKH" />
-	
-	<Replace MapName="PlayEuropeAgain" X="49" Y="8" CityLocaleName="LOC_CITY_NAME_AN_NAWFALIYAH" />
-	<Replace MapName="PlayEuropeAgain" X="58" Y="8" CityLocaleName="LOC_CITY_NAME_MECHILI" />
-	<Replace MapName="PlayEuropeAgain" X="67" Y="8" CityLocaleName="LOC_CITY_NAME_SIWA_OASIS" />
-	<Replace MapName="PlayEuropeAgain" X="71" Y="8" CityLocaleName="LOC_CITY_NAME_TANTA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="72" Y="8" CityLocaleName="LOC_CITY_NAME_TANTA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="8" CityLocaleName="LOC_CITY_NAME_CAIRO" />
-	
-	<Replace MapName="PlayEuropeAgain" X="46" Y="9" CityLocaleName="LOC_CITY_NAME_SIRTE" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="47" Y="10" CityLocaleName="LOC_CITY_NAME_SIRTE" />
-	<Replace MapName="PlayEuropeAgain" X="49" Y="9" CityLocaleName="LOC_CITY_NAME_BIN_JAWAD" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="50" Y="10" CityLocaleName="LOC_CITY_NAME_BIN_JAWAD" />
-	<Replace MapName="PlayEuropeAgain" X="51" Y="9" CityLocaleName="LOC_CITY_NAME_RAS_LANUF" />
-	<Replace MapName="PlayEuropeAgain" X="69" Y="9" CityLocaleName="LOC_CITY_NAME_MARINA_EL_ALAMEIN" />
-	<Replace MapName="PlayEuropeAgain" X="75" Y="9" CityLocaleName="LOC_CITY_NAME_ISMAILIA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="76" Y="9" CityLocaleName="LOC_CITY_NAME_SUEZ" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="77" Y="9" CityLocaleName="LOC_CITY_NAME_SUEZ" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="79" Y="9" CityLocaleName="LOC_CITY_NAME_NEKHEL" />
-	
-	<Replace MapName="PlayEuropeAgain" X="55" Y="10" CityLocaleName="LOC_CITY_NAME_QAMINIS" />
-	<Replace MapName="PlayEuropeAgain" X="57" Y="10" CityLocaleName="LOC_CITY_NAME_AL_MARJ" />
-	<Replace MapName="PlayEuropeAgain" X="59" Y="10" CityLocaleName="LOC_CITY_NAME_MARTUBA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="58" Y="11" CityLocaleName="LOC_CITY_NAME_MARTUBA" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="64" Y="10" CityLocaleName="LOC_CITY_NAME_EL_SALLOUM" />
-	<Replace MapName="PlayEuropeAgain" X="66" Y="10" CityLocaleName="LOC_CITY_NAME_MARSA_MATRUH" />
-	<Replace MapName="PlayEuropeAgain" X="72" Y="10" CityLocaleName="LOC_CITY_NAME_ALEXANDRIA" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="10" CityLocaleName="LOC_CITY_NAME_AL_MAHALLAH" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="75" Y="10" CityLocaleName="LOC_CITY_NAME_MANSOURA" Area="0" />
-	
-	<Replace MapName="PlayEuropeAgain" X="54" Y="11" CityLocaleName="LOC_CITY_NAME_BENGHAZI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="55" Y="11" CityLocaleName="LOC_CITY_NAME_BENGHAZI" Area="0" />
-	<Replace MapName="PlayEuropeAgain" X="55" Y="12" CityLocaleName="LOC_CITY_NAME_BENGHAZI" />
-	<Replace MapName="PlayEuropeAgain" X="61" Y="11" CityLocaleName="LOC_CITY_NAME_TOBRUK" />
-	<Replace MapName="PlayEuropeAgain" X="76" Y="11" CityLocaleName="LOC_CITY_NAME_PORT_SAID"  />
-	
-	<Replace MapName="PlayEuropeAgain" X="60" Y="12" CityLocaleName="LOC_CITY_NAME_UMM_RIZAM" />
-	<Replace MapName="PlayEuropeAgain" X="74" Y="12" CityLocaleName="LOC_CITY_NAME_BALTIM" />
-	<Replace MapName="PlayEuropeAgain" X="79" Y="12" CityLocaleName="LOC_CITY_NAME_ARISH" />
-	
-	<Replace MapName="PlayEuropeAgain" X="57" Y="13" CityLocaleName="LOC_CITY_NAME_AL_BAYDA" />
-	<Replace MapName="PlayEuropeAgain" X="59" Y="13" CityLocaleName="LOC_CITY_NAME_DERNA" Area="0" />
-	
-	</CityMap>
-	
+
 	<!-- UKRAINE, SOUTHERN RUSSIA, & KAZAKHSTAN -->
 	<CityMap>
-		
+
 		<Replace MapName="PlayEuropeAgain" X="107" Y="39" CityLocaleName="LOC_CITY_NAME_BEKDASH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="76" Y="40" CityLocaleName="LOC_CITY_NAME_SEVASTOPOL" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="74" Y="41" CityLocaleName="LOC_CITY_NAME_YEVPATORIYA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="41" CityLocaleName="LOC_CITY_NAME_FEODOSIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="41" CityLocaleName="LOC_CITY_NAME_FEODOSIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="41" CityLocaleName="LOC_CITY_NAME_KERCH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="41" CityLocaleName="LOC_CITY_NAME_KURYK" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="75" Y="42" CityLocaleName="LOC_CITY_NAME_KHERSON" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="42" CityLocaleName="LOC_CITY_NAME_SIMFEROPOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="42" CityLocaleName="LOC_CITY_NAME_DZHANKOI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="75" Y="43" CityLocaleName="LOC_CITY_NAME_KHERSON" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="43" CityLocaleName="LOC_CITY_NAME_DZHANKOI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="104" Y="43" CityLocaleName="LOC_CITY_NAME_AKTAU" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="72" Y="44" CityLocaleName="LOC_CITY_NAME_ODESSA" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="44" CityLocaleName="LOC_CITY_NAME_ODESSA" Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="74" Y="44" CityLocaleName="LOC_CITY_NAME_PARUTYNE" Area="0" />
@@ -2601,7 +2604,7 @@
 		<Replace MapName="PlayEuropeAgain" X="76" Y="44" CityLocaleName="LOC_CITY_NAME_KHERSON" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="44" CityLocaleName="LOC_CITY_NAME_MELITOPOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="44" CityLocaleName="LOC_CITY_NAME_ZHANAOZEN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="72" Y="45" CityLocaleName="LOC_CITY_NAME_ODESSA" Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="73" Y="45" CityLocaleName="LOC_CITY_NAME_MYKOLAIV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="45" CityLocaleName="LOC_CITY_NAME_KHERSON" Area="0" />
@@ -2621,7 +2624,7 @@
 		<Replace MapName="PlayEuropeAgain" X="102" Y="45" CityLocaleName="LOC_CITY_NAME_FORT_SHEVCHENKO" />
 		<Replace MapName="PlayEuropeAgain" X="104" Y="45" CityLocaleName="LOC_CITY_NAME_BAYANDY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="105" Y="45" CityLocaleName="LOC_CITY_NAME_BAYANDY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="46" CityLocaleName="LOC_CITY_NAME_YUZHNOUKRAINSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="46" CityLocaleName="LOC_CITY_NAME_YUZHNOUKRAINSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="46" CityLocaleName="LOC_CITY_NAME_KRYVYI_RIH" />
@@ -2636,7 +2639,7 @@
 		<Replace MapName="PlayEuropeAgain" X="96" Y="46" CityLocaleName="LOC_CITY_NAME_LAGAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="104" Y="46" CityLocaleName="LOC_CITY_NAME_KYZAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="105" Y="46" CityLocaleName="LOC_CITY_NAME_BAYANDY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="47" CityLocaleName="LOC_CITY_NAME_YUZHNOUKRAINSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="47" CityLocaleName="LOC_CITY_NAME_SMILA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="47" CityLocaleName="LOC_CITY_NAME_VOLNOVAKHA" Area="0" />
@@ -2645,7 +2648,7 @@
 		<Replace MapName="PlayEuropeAgain" X="93" Y="47" CityLocaleName="LOC_CITY_NAME_ELISTA" />
 		<Replace MapName="PlayEuropeAgain" X="104" Y="47" CityLocaleName="LOC_CITY_NAME_KYZAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="47" CityLocaleName="LOC_CITY_NAME_BEYNEU" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="48" CityLocaleName="LOC_CITY_NAME_UMAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="48" CityLocaleName="LOC_CITY_NAME_KROPVYNYTSKYI" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="48" CityLocaleName="LOC_CITY_NAME_SMILA" Area="0" />
@@ -2656,7 +2659,7 @@
 		<Replace MapName="PlayEuropeAgain" X="92" Y="48" CityLocaleName="LOC_CITY_NAME_BOLSHOI_TSARYN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="48" CityLocaleName="LOC_CITY_NAME_ASTRAKHAN" />
 		<Replace MapName="PlayEuropeAgain" X="105" Y="48" CityLocaleName="LOC_CITY_NAME_KYZAN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="49" CityLocaleName="LOC_CITY_NAME_UMAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="49" CityLocaleName="LOC_CITY_NAME_KREMENCHUK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="49" CityLocaleName="LOC_CITY_NAME_KRAMATORSK" Area="0" />
@@ -2669,7 +2672,7 @@
 		<Replace MapName="PlayEuropeAgain" X="105" Y="49" CityLocaleName="LOC_CITY_NAME_TENGIZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="49" CityLocaleName="LOC_CITY_NAME_BESBEY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="49" CityLocaleName="LOC_CITY_NAME_BESBEY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="50" CityLocaleName="LOC_CITY_NAME_UMAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="50" CityLocaleName="LOC_CITY_NAME_CHERKASY" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="50" CityLocaleName="LOC_CITY_NAME_POLTAVA" Area="0" />
@@ -2686,7 +2689,7 @@
 		<Replace MapName="PlayEuropeAgain" X="105" Y="50" CityLocaleName="LOC_CITY_NAME_TENGIZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="50" CityLocaleName="LOC_CITY_NAME_TENGIZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="50" CityLocaleName="LOC_CITY_NAME_BESBEY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="72" Y="51" CityLocaleName="LOC_CITY_NAME_KIEV" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="51" CityLocaleName="LOC_CITY_NAME_POLTAVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="51" CityLocaleName="LOC_CITY_NAME_POLTAVA" Area="0" />
@@ -2703,7 +2706,7 @@
 		<Replace MapName="PlayEuropeAgain" X="103" Y="51" CityLocaleName="LOC_CITY_NAME_KOSCHAGYL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="51" CityLocaleName="LOC_CITY_NAME_ASGIL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="51" CityLocaleName="LOC_CITY_NAME_ASGIL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="52" CityLocaleName="LOC_CITY_NAME_PRIPYAT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="52" CityLocaleName="LOC_CITY_NAME_PRYLUKY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="52" CityLocaleName="LOC_CITY_NAME_PRYLUKY" Area="0" />
@@ -2717,7 +2720,7 @@
 		<Replace MapName="PlayEuropeAgain" X="103" Y="52" CityLocaleName="LOC_CITY_NAME_KOSCHAGYL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="105" Y="52" CityLocaleName="LOC_CITY_NAME_KULSARY" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="52" CityLocaleName="LOC_CITY_NAME_ASGIL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="53" CityLocaleName="LOC_CITY_NAME_PRIPYAT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="53" CityLocaleName="LOC_CITY_NAME_CHERNOBYL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="53" CityLocaleName="LOC_CITY_NAME_CHERNIHIV" Area="0" />
@@ -2731,7 +2734,7 @@
 		<Replace MapName="PlayEuropeAgain" X="99" Y="53" CityLocaleName="LOC_CITY_NAME_CHAPAEV" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="53" CityLocaleName="LOC_CITY_NAME_EMBI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="53" CityLocaleName="LOC_CITY_NAME_ASGIL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="54" CityLocaleName="LOC_CITY_NAME_PRIPYAT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="54" CityLocaleName="LOC_CITY_NAME_CHERNOBYL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="54" CityLocaleName="LOC_CITY_NAME_CHERNIHIV" Area="0" />
@@ -2753,12 +2756,12 @@
 		<Replace MapName="PlayEuropeAgain" X="105" Y="54" CityLocaleName="LOC_CITY_NAME_EMBI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="54" CityLocaleName="LOC_CITY_NAME_EMBI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="54" CityLocaleName="LOC_CITY_NAME_EMBI" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- CAUCASUS -->
 	<CityMap>
-		
+
 		<Replace MapName="PlayEuropeAgain" X="87" Y="34" CityLocaleName="LOC_CITY_NAME_RIZE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="34" CityLocaleName="LOC_CITY_NAME_RIZE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="34" CityLocaleName="LOC_CITY_NAME_ARTVIN" Area="0" />
@@ -2769,7 +2772,7 @@
 		<Replace MapName="PlayEuropeAgain" X="99" Y="34" CityLocaleName="LOC_CITY_NAME_BEYLAGAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="100" Y="34" CityLocaleName="LOC_CITY_NAME_SABIRABAD" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="101" Y="34" CityLocaleName="LOC_CITY_NAME_SHIRVAN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="88" Y="35" CityLocaleName="LOC_CITY_NAME_BATUMI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="35" CityLocaleName="LOC_CITY_NAME_AKHALTSIKHE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="35" CityLocaleName="LOC_CITY_NAME_AKHALTSIKHE" Area="0" />
@@ -2782,7 +2785,7 @@
 		<Replace MapName="PlayEuropeAgain" X="99" Y="35" CityLocaleName="LOC_CITY_NAME_KURDAMIR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="100" Y="35" CityLocaleName="LOC_CITY_NAME_SHIRVAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="101" Y="35" CityLocaleName="LOC_CITY_NAME_ALAT" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="88" Y="36" CityLocaleName="LOC_CITY_NAME_POTI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="36" CityLocaleName="LOC_CITY_NAME_LANCHKHUTI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="36" CityLocaleName="LOC_CITY_NAME_VANI" Area="0" />
@@ -2795,7 +2798,7 @@
 		<Replace MapName="PlayEuropeAgain" X="98" Y="36" CityLocaleName="LOC_CITY_NAME_MINGECEVIR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="99" Y="36" CityLocaleName="LOC_CITY_NAME_ISMAILLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="100" Y="36" CityLocaleName="LOC_CITY_NAME_SHAMAKHI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="88" Y="37" CityLocaleName="LOC_CITY_NAME_POTI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="37" CityLocaleName="LOC_CITY_NAME_SAMTREDIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="37" CityLocaleName="LOC_CITY_NAME_KUTAISI" Area="0" />
@@ -2805,7 +2808,7 @@
 		<Replace MapName="PlayEuropeAgain" X="95" Y="37" CityLocaleName="LOC_CITY_NAME_GAZAKH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="97" Y="37" CityLocaleName="LOC_CITY_NAME_SHEKI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="101" Y="37" CityLocaleName="LOC_CITY_NAME_BAKU" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="87" Y="38" CityLocaleName="LOC_CITY_NAME_SOKHUMI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="38" CityLocaleName="LOC_CITY_NAME_OCHAMCHIRA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="38" CityLocaleName="LOC_CITY_NAME_ZUGDIDI" Area="0" />
@@ -2815,7 +2818,7 @@
 		<Replace MapName="PlayEuropeAgain" X="94" Y="38" CityLocaleName="LOC_CITY_NAME_TBILISI" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="38" CityLocaleName="LOC_CITY_NAME_ZAQATALA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="100" Y="38" CityLocaleName="LOC_CITY_NAME_SHAMAKHI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="85" Y="39" CityLocaleName="LOC_CITY_NAME_SOCHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="39" CityLocaleName="LOC_CITY_NAME_SOCHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="39" CityLocaleName="LOC_CITY_NAME_GALI" Area="0" />
@@ -2827,7 +2830,7 @@
 		<Replace MapName="PlayEuropeAgain" X="99" Y="39" CityLocaleName="LOC_CITY_NAME_SUMQAYIT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="100" Y="39" CityLocaleName="LOC_CITY_NAME_SUMQAYIT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="101" Y="39" CityLocaleName="LOC_CITY_NAME_SUMQAYIT" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="84" Y="40" CityLocaleName="LOC_CITY_NAME_TUAPSE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="40" CityLocaleName="LOC_CITY_NAME_SOCHI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="40" CityLocaleName="LOC_CITY_NAME_ONI" Area="0" />
@@ -2837,7 +2840,7 @@
 		<Replace MapName="PlayEuropeAgain" X="97" Y="40" CityLocaleName="LOC_CITY_NAME_KHUNZAKH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="98" Y="40" CityLocaleName="LOC_CITY_NAME_MURGUK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="99" Y="40" CityLocaleName="LOC_CITY_NAME_DERBENT" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="80" Y="41" CityLocaleName="LOC_CITY_NAME_TAMAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="41" CityLocaleName="LOC_CITY_NAME_ANAPA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="82" Y="41" CityLocaleName="LOC_CITY_NAME_NOVOROSSIYSK" Area="0" />
@@ -2851,7 +2854,7 @@
 		<Replace MapName="PlayEuropeAgain" X="96" Y="41" CityLocaleName="LOC_CITY_NAME_BUYNAKSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="97" Y="41" CityLocaleName="LOC_CITY_NAME_KADIRKENT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="98" Y="41" CityLocaleName="LOC_CITY_NAME_DERBENT" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="42" CityLocaleName="LOC_CITY_NAME_KAVKAZ" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="82" Y="42" CityLocaleName="LOC_CITY_NAME_TEMRYUK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="42" CityLocaleName="LOC_CITY_NAME_KRASNODAR" Area="0" />
@@ -2865,7 +2868,7 @@
 		<Replace MapName="PlayEuropeAgain" X="96" Y="42" CityLocaleName="LOC_CITY_NAME_KHASAVYURT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="97" Y="42" CityLocaleName="LOC_CITY_NAME_BUYNAKSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="98" Y="42" CityLocaleName="LOC_CITY_NAME_IZBERBASH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="43" CityLocaleName="LOC_CITY_NAME_PRIMORSKO_AKHATARSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="43" CityLocaleName="LOC_CITY_NAME_TIMASHEVSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="43" CityLocaleName="LOC_CITY_NAME_MAYKOP" Area="0" />
@@ -2880,7 +2883,7 @@
 		<Replace MapName="PlayEuropeAgain" X="95" Y="43" CityLocaleName="LOC_CITY_NAME_KIZLYAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="43" CityLocaleName="LOC_CITY_NAME_KIZILYURT" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="97" Y="43" CityLocaleName="LOC_CITY_NAME_KASPIYSK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="44" CityLocaleName="LOC_CITY_NAME_YEYSK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="44" CityLocaleName="LOC_CITY_NAME_KANEVSKAYA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="44" CityLocaleName="LOC_CITY_NAME_KORENOVSK" Area="0" />
@@ -2896,31 +2899,31 @@
 		<Replace MapName="PlayEuropeAgain" X="95" Y="44" CityLocaleName="LOC_CITY_NAME_KIZLYAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="44" CityLocaleName="LOC_CITY_NAME_KIZLYAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="97" Y="44" CityLocaleName="LOC_CITY_NAME_MAKHACHKALA" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- ANATOLIA & CYPRUS -->
 	<CityMap>
-		
+
 		<Replace MapName="PlayEuropeAgain" X="76" Y="18" CityLocaleName="LOC_CITY_NAME_PAPHOS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="18" CityLocaleName="LOC_CITY_NAME_LIMASSOL" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="18" CityLocaleName="LOC_CITY_NAME_LIMASSOL" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="76" Y="19" CityLocaleName="LOC_CITY_NAME_POLI_CRYSOCHOUS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="19" CityLocaleName="LOC_CITY_NAME_NICOSIA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="19" CityLocaleName="LOC_CITY_NAME_NICOSIA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="79" Y="20" CityLocaleName="LOC_CITY_NAME_NICOSIA" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="21" CityLocaleName="LOC_CITY_NAME_MARMARIS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="21" CityLocaleName="LOC_CITY_NAME_ALANYA" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="22" CityLocaleName="LOC_CITY_NAME_BODRUM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="22" CityLocaleName="LOC_CITY_NAME_MARMARIS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="22" CityLocaleName="LOC_CITY_NAME_FETHIYE" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="22" CityLocaleName="LOC_CITY_NAME_ANTALYA" Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="78" Y="22" CityLocaleName="LOC_CITY_NAME_MERSIN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="23" CityLocaleName="LOC_CITY_NAME_BODRUM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="23" CityLocaleName="LOC_CITY_NAME_BODRUM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="23" CityLocaleName="LOC_CITY_NAME_ACIPAYAM" Area="0" />
@@ -2929,19 +2932,19 @@
 		<Replace MapName="PlayEuropeAgain" X="74" Y="23" CityLocaleName="LOC_CITY_NAME_SEYDISEHIR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="23" CityLocaleName="LOC_CITY_NAME_SEYDISEHIR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="23" CityLocaleName="LOC_CITY_NAME_ADANA" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="24" CityLocaleName="LOC_CITY_NAME_AYDIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="24" CityLocaleName="LOC_CITY_NAME_SEYDISEHIR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="24" CityLocaleName="LOC_CITY_NAME_NIGDE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="24" CityLocaleName="LOC_CITY_NAME_NIGDE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="66" Y="25" CityLocaleName="LOC_CITY_NAME_IZMIR" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="25" CityLocaleName="LOC_CITY_NAME_DENIZLI" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="25" CityLocaleName="LOC_CITY_NAME_AYFONKARAHISAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="25" CityLocaleName="LOC_CITY_NAME_AYFONKARAHISAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="25" CityLocaleName="LOC_CITY_NAME_KONYA" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="25" CityLocaleName="LOC_CITY_NAME_NIGDE" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="26" CityLocaleName="LOC_CITY_NAME_BALIKESIR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="26" CityLocaleName="LOC_CITY_NAME_AYFONKARAHISAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="26" CityLocaleName="LOC_CITY_NAME_AYFONKARAHISAR" Area="0" />
@@ -2949,29 +2952,29 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="26" CityLocaleName="LOC_CITY_NAME_AKSARAY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="26" CityLocaleName="LOC_CITY_NAME_AKSARAY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="26" CityLocaleName="LOC_CITY_NAME_DEVELI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="27" CityLocaleName="LOC_CITY_NAME_BALIKESIR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="27" CityLocaleName="LOC_CITY_NAME_BALIKESIR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="27" CityLocaleName="LOC_CITY_NAME_TAVSANLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="27" CityLocaleName="LOC_CITY_NAME_TAVSANLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="27" CityLocaleName="LOC_CITY_NAME_KULU" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="27" CityLocaleName="LOC_CITY_NAME_AKSARAY" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="66" Y="28" CityLocaleName="LOC_CITY_NAME_CANAKKALE" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="28" CityLocaleName="LOC_CITY_NAME_BANDIRMA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="28" CityLocaleName="LOC_CITY_NAME_ESKISEHIR" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="28" CityLocaleName="LOC_CITY_NAME_KIRSEHIR" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="28" CityLocaleName="LOC_CITY_NAME_KAYSERI" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="69" Y="29" CityLocaleName="LOC_CITY_NAME_BURSA" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="29" CityLocaleName="LOC_CITY_NAME_ANKARA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="29" CityLocaleName="LOC_CITY_NAME_YOZGAT" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="71" Y="30" CityLocaleName="LOC_CITY_NAME_ADAPAZARI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="30" CityLocaleName="LOC_CITY_NAME_ADAPAZARI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="30" CityLocaleName="LOC_CITY_NAME_BEYPAZARI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="30" CityLocaleName="LOC_CITY_NAME_TOKAT" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="70" Y="31" CityLocaleName="LOC_CITY_NAME_YALOVA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="31" CityLocaleName="LOC_CITY_NAME_ADAPAZARI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="31" CityLocaleName="LOC_CITY_NAME_ADAPAZARI" Area="0" />
@@ -2981,24 +2984,24 @@
 		<Replace MapName="PlayEuropeAgain" X="77" Y="31" CityLocaleName="LOC_CITY_NAME_CORUM" Area="0" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="78" Y="31" CityLocaleName="LOC_CITY_NAME_AMASYA" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="31" CityLocaleName="LOC_CITY_NAME_TOKAT" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="70" Y="32" CityLocaleName="LOC_CITY_NAME_KADIKOY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="32" CityLocaleName="LOC_CITY_NAME_KARASU" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="32" CityLocaleName="LOC_CITY_NAME_EREGLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="32" CityLocaleName="LOC_CITY_NAME_EREGLI" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="74" Y="33" CityLocaleName="LOC_CITY_NAME_ZONGULDAK" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="33" CityLocaleName="LOC_CITY_NAME_KASTAMONU" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="33" CityLocaleName="LOC_CITY_NAME_SAMSUN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="76" Y="34" CityLocaleName="LOC_CITY_NAME_CIDE" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="34" CityLocaleName="LOC_CITY_NAME_SINOP" />
-		
+
 	</CityMap>
-	
+
 	<!-- MIDDLE EAST (NORTH) -->
 	<CityMap>
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="22" CityLocaleName="LOC_CITY_NAME_ISKENDERUN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="22" CityLocaleName="LOC_CITY_NAME_NIZIP" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="22" CityLocaleName="LOC_CITY_NAME_KOBANE" Area="0" />
@@ -3011,7 +3014,7 @@
 		<Replace MapName="PlayEuropeAgain" X="93" Y="22" CityLocaleName="LOC_CITY_NAME_NUSAYBIN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="22" CityLocaleName="LOC_CITY_NAME_DERECIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="97" Y="22" CityLocaleName="LOC_CITY_NAME_DERECIK" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="23" CityLocaleName="LOC_CITY_NAME_GAZIANTEP" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="23" CityLocaleName="LOC_CITY_NAME_NIZIP" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="23" CityLocaleName="LOC_CITY_NAME_VIRANSEHIR" Area="0" />
@@ -3020,22 +3023,22 @@
 		<Replace MapName="PlayEuropeAgain" X="94" Y="23" CityLocaleName="LOC_CITY_NAME_CIZRE" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="23" CityLocaleName="LOC_CITY_NAME_DERECIK" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="98" Y="23" CityLocaleName="LOC_CITY_NAME_SORAN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="24" CityLocaleName="LOC_CITY_NAME_KAHRAMANMARAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="24" CityLocaleName="LOC_CITY_NAME_GOLBASI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="24" CityLocaleName="LOC_CITY_NAME_ADIYAMAN" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="24" CityLocaleName="LOC_CITY_NAME_BATMAN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="25" CityLocaleName="LOC_CITY_NAME_KAHRAMANMARAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="25" CityLocaleName="LOC_CITY_NAME_GOLBASI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="25" CityLocaleName="LOC_CITY_NAME_GOLBASI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="25" CityLocaleName="LOC_CITY_NAME_DIYARBAKIR" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="25" CityLocaleName="LOC_CITY_NAME_PIRANSHAHR" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="26" CityLocaleName="LOC_CITY_NAME_ELBISTAN" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="26" CityLocaleName="LOC_CITY_NAME_SIIRT" />
 		<Replace MapName="PlayEuropeAgain" X="99" Y="26" CityLocaleName="LOC_CITY_NAME_QOSHACHAY" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="27" CityLocaleName="LOC_CITY_NAME_SARKISLA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="27" CityLocaleName="LOC_CITY_NAME_MALATYA" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="27" CityLocaleName="LOC_CITY_NAME_MALATYA" Area="0" /> <!-- OVERLAP -->
@@ -3043,13 +3046,13 @@
 		<Replace MapName="PlayEuropeAgain" X="89" Y="27" CityLocaleName="LOC_CITY_NAME_ERGANI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="91" Y="27" CityLocaleName="LOC_CITY_NAME_MUS" />
 		<Replace MapName="PlayEuropeAgain" X="97" Y="27" CityLocaleName="LOC_CITY_NAME_NAQADEH" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="28" CityLocaleName="LOC_CITY_NAME_SARKISLA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="28" CityLocaleName="LOC_CITY_NAME_SARKISLA" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="28" CityLocaleName="LOC_CITY_NAME_ULAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="28" CityLocaleName="LOC_CITY_NAME_SALMAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="28" CityLocaleName="LOC_CITY_NAME_URMIA" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="29" CityLocaleName="LOC_CITY_NAME_ULAS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="29" CityLocaleName="LOC_CITY_NAME_TERCAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="29" CityLocaleName="LOC_CITY_NAME_TERCAN" Area="0" />
@@ -3057,7 +3060,7 @@
 		<Replace MapName="PlayEuropeAgain" X="91" Y="29" CityLocaleName="LOC_CITY_NAME_TATVAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="29" CityLocaleName="LOC_CITY_NAME_KHOY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="99" Y="29" CityLocaleName="LOC_CITY_NAME_TABRIZ" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="30" CityLocaleName="LOC_CITY_NAME_SIVAS" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="30" CityLocaleName="LOC_CITY_NAME_ERZINCAN" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="30" CityLocaleName="LOC_CITY_NAME_TERCAN" Area="0" />
@@ -3066,13 +3069,13 @@
 		<Replace MapName="PlayEuropeAgain" X="93" Y="30" CityLocaleName="LOC_CITY_NAME_VAN" />
 		<Replace MapName="PlayEuropeAgain" X="95" Y="30" CityLocaleName="LOC_CITY_NAME_KHOY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="98" Y="30" CityLocaleName="LOC_CITY_NAME_MARAND" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="31" CityLocaleName="LOC_CITY_NAME_SEBINKARAHISAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="31" CityLocaleName="LOC_CITY_NAME_PAZARYOLU" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="91" Y="31" CityLocaleName="LOC_CITY_NAME_TATVAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="31" CityLocaleName="LOC_CITY_NAME_KHOY" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="31" CityLocaleName="LOC_CITY_NAME_NAKHCHIVAN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="32" CityLocaleName="LOC_CITY_NAME_GIRESUN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="32" CityLocaleName="LOC_CITY_NAME_GIRESUN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="32" CityLocaleName="LOC_CITY_NAME_BAYBURT" />
@@ -3080,7 +3083,7 @@
 		<Replace MapName="PlayEuropeAgain" X="92" Y="32" CityLocaleName="LOC_CITY_NAME_KARS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="32" CityLocaleName="LOC_CITY_NAME_KARS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="99" Y="32" CityLocaleName="LOC_CITY_NAME_XANKENDI" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="84" Y="33" CityLocaleName="LOC_CITY_NAME_TRABZON" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="33" CityLocaleName="LOC_CITY_NAME_NARMAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="91" Y="33" CityLocaleName="LOC_CITY_NAME_KARS" Area="0" />
@@ -3088,12 +3091,12 @@
 		<Replace MapName="PlayEuropeAgain" X="94" Y="33" CityLocaleName="LOC_CITY_NAME_YEREVAN" />
 		<Replace MapName="PlayEuropeAgain" X="96" Y="33" CityLocaleName="LOC_CITY_NAME_VARDENIS" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="97" Y="33" CityLocaleName="LOC_CITY_NAME_ZULFUQARLI" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- IRAN/PERSIA -->
 	<CityMap>
-		
+
 		<Replace MapName="PlayEuropeAgain" X="100" Y="22" CityLocaleName="LOC_CITY_NAME_BANEH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="101" Y="22" CityLocaleName="LOC_CITY_NAME_BANEH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="102" Y="22" CityLocaleName="LOC_CITY_NAME_MARIVAN" Area="0" />
@@ -3102,46 +3105,46 @@
 		<Replace MapName="PlayEuropeAgain" X="105" Y="22" CityLocaleName="LOC_CITY_NAME_SAVEH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="22" CityLocaleName="LOC_CITY_NAME_QOM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="22" CityLocaleName="LOC_CITY_NAME_QOM" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="102" Y="23" CityLocaleName="LOC_CITY_NAME_MARIVAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="105" Y="23" CityLocaleName="LOC_CITY_NAME_SAVEH" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="23" CityLocaleName="LOC_CITY_NAME_QOM" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="107" Y="23" CityLocaleName="LOC_CITY_NAME_QOM" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="101" Y="24" CityLocaleName="LOC_CITY_NAME_SAQQEZ" />
 		<Replace MapName="PlayEuropeAgain" X="104" Y="24" CityLocaleName="LOC_CITY_NAME_BIJAR" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="102" Y="25" CityLocaleName="LOC_CITY_NAME_ABHAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="106" Y="25" CityLocaleName="LOC_CITY_NAME_TEHRAN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="101" Y="26" CityLocaleName="LOC_CITY_NAME_BUQAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="102" Y="26" CityLocaleName="LOC_CITY_NAME_ABHAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="103" Y="26" CityLocaleName="LOC_CITY_NAME_ABHAR" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="100" Y="27" CityLocaleName="LOC_CITY_NAME_BUQAN" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="104" Y="27" CityLocaleName="LOC_CITY_NAME_KARAJ" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="102" Y="28" CityLocaleName="LOC_CITY_NAME_QAZVIN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="106" Y="29" CityLocaleName="LOC_CITY_NAME_CHALUS" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="104" Y="30" CityLocaleName="LOC_CITY_NAME_LAHIJAN" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="101" Y="31" CityLocaleName="LOC_CITY_NAME_RASHT" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="100" Y="32" CityLocaleName="LOC_CITY_NAME_MASALLI" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="101" Y="32" CityLocaleName="LOC_CITY_NAME_LANKARAN" Area="0" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="100" Y="33" CityLocaleName="LOC_CITY_NAME_BILASUVAR" Area="0" />
 		<Replace MapName="PlayEuropeAgain" X="101" Y="33" CityLocaleName="LOC_CITY_NAME_NEFTCHALA" Area="0" />
-		
+
 	</CityMap>
-	
+
 	<!-- MIDDLE EAST (SOUTH) -->
 	<CityMap>
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="18" CityLocaleName="LOC_CITY_NAME_DAMASCUS" />
-		
+
 	</CityMap>
-	
+
 </GameData>

--- a/Maps/PlayEuropeAgain/CityMap_Arabia.xml
+++ b/Maps/PlayEuropeAgain/CityMap_Arabia.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameData>
-	
-	<!-- 
-	
-	"Play Europe Again"
-	
-	-->
+
+	<!-- +++++++++++++++++++++++++++++++++++++++ -->
+	<!-- "Play Europe Again" City Map for Arabia -->
+	<!-- +++++++++++++++++++++++++++++++++++++++ -->
 
 	<CityMap>
-	
+
 		<!-- FRANCE -->
-        	<Replace MapName="PlayEuropeAgain" X="35" Y="40" CityLocaleName="LOC_CITY_NAME_FRAXINET" Civilization="CIVILIZATION_ARABIA" Area="0" />
-        	
-        	<!-- IBERIA -->
-        	<Replace MapName="PlayEuropeAgain" X="22" Y="36" CityLocaleName="LOC_CITY_NAME_VALENCIA" Civilization="CIVILIZATION_ARABIA" Area="0" />
-		<Replace MapName="PlayEuropeAgain" X="16" Y="41" CityLocaleName="LOC_CITY_NAME_VALLADOLID" Civilization="CIVILIZATION_ARABIA" Area="0" />
+		<Replace MapName="PlayEuropeAgain" X="35" Y="40" CityLocaleName="LOC_CITY_NAME_FRAXINET" Area="0" Civilization="CIVILIZATION_ARABIA" />
+
+		<!-- IBERIA -->
+		<Replace MapName="PlayEuropeAgain" X="22" Y="36" CityLocaleName="LOC_CITY_NAME_VALENCIA" Area="0" Civilization="CIVILIZATION_ARABIA" />
+		<Replace MapName="PlayEuropeAgain" X="16" Y="41" CityLocaleName="LOC_CITY_NAME_VALLADOLID" Area="0" Civilization="CIVILIZATION_ARABIA" />
 		<Replace MapName="PlayEuropeAgain" X="14" Y="42" CityLocaleName="LOC_CITY_NAME_PORTO" Area="0" Civilization="CIVILIZATION_ARABIA" />
+
 	</CityMap>
-	
+
 </GameData>

--- a/Maps/PlayEuropeAgain/CityMap_Greece.xml
+++ b/Maps/PlayEuropeAgain/CityMap_Greece.xml
@@ -1,61 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameData>
-	
-	<!-- 
-	
-	"Play Europe Again"
-	
-	-->
+
+	<!-- +++++++++++++++++++++++++++++++++++++++ -->
+	<!-- "Play Europe Again" City Map for Greece -->
+	<!-- +++++++++++++++++++++++++++++++++++++++ -->
 
 	<CityMap>
-		
+
 		<!-- GREEK MAINLAND -->
 		<Replace MapName="PlayEuropeAgain" X="58" Y="20" CityLocaleName="LOC_CITY_NAME_PYLOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="20" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="57" Y="21" CityLocaleName="LOC_CITY_NAME_PYLOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="21" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="21" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="21" CityLocaleName="LOC_CITY_NAME_EPIDAUROS_LIMERA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="57" Y="22" CityLocaleName="LOC_CITY_NAME_OLYMPIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="22" CityLocaleName="LOC_CITY_NAME_MEGALOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="22" CityLocaleName="LOC_CITY_NAME_ARGOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="22" CityLocaleName="LOC_CITY_NAME_MYCENAE" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="23" CityLocaleName="LOC_CITY_NAME_ELIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="23" CityLocaleName="LOC_CITY_NAME_PATRAS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="23" CityLocaleName="LOC_CITY_NAME_SICYON" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="23" CityLocaleName="LOC_CITY_NAME_CORINTH" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="23" CityLocaleName="LOC_CITY_NAME_MYCENAE" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="60" Y="24" CityLocaleName="LOC_CITY_NAME_CORINTH" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="25" CityLocaleName="LOC_CITY_NAME_CALYDON" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="25" CityLocaleName="LOC_CITY_NAME_DELPHI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="25" CityLocaleName="LOC_CITY_NAME_DELPHI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="25" CityLocaleName="LOC_CITY_NAME_THEBES" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="25" CityLocaleName="LOC_CITY_NAME_ATHENS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="25" CityLocaleName="LOC_CITY_NAME_ATHENS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="26" CityLocaleName="LOC_CITY_NAME_ANAKTORION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="26" CityLocaleName="LOC_CITY_NAME_THERMOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="26" CityLocaleName="LOC_CITY_NAME_DELPHI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="26" CityLocaleName="LOC_CITY_NAME_THEBES" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="26" CityLocaleName="LOC_CITY_NAME_THERMOPYLAI" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="27" CityLocaleName="LOC_CITY_NAME_AMBRACIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="27" CityLocaleName="LOC_CITY_NAME_CYNOSCEPHALAE" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="27" CityLocaleName="LOC_CITY_NAME_PHARSALOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="27" CityLocaleName="LOC_CITY_NAME_LARISSA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="27" CityLocaleName="LOC_CITY_NAME_IOLCOS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="28" CityLocaleName="LOC_CITY_NAME_PHOENICE" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="28" CityLocaleName="LOC_CITY_NAME_HADRIANOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="28" CityLocaleName="LOC_CITY_NAME_ARGOS_ORESTIKON" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="28" CityLocaleName="LOC_CITY_NAME_AIGAI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="28" CityLocaleName="LOC_CITY_NAME_PYDNA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="29" CityLocaleName="LOC_CITY_NAME_APOLLONIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="29" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="29" CityLocaleName="LOC_CITY_NAME_PELION" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -64,7 +62,7 @@
 		<Replace MapName="PlayEuropeAgain" X="59" Y="29" CityLocaleName="LOC_CITY_NAME_THESSALONIKI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="29" CityLocaleName="LOC_CITY_NAME_THESSALONIKI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="29" CityLocaleName="LOC_CITY_NAME_OLYNTHOS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="30" CityLocaleName="LOC_CITY_NAME_APOLLONIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="30" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="30" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -74,8 +72,8 @@
 		<Replace MapName="PlayEuropeAgain" X="60" Y="30" CityLocaleName="LOC_CITY_NAME_IDOMENI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="30" CityLocaleName="LOC_CITY_NAME_AMPHIPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="30" CityLocaleName="LOC_CITY_NAME_AINOS" Area="0" Civilization="CIVILIZATION_GREECE" />
-        	<Replace MapName="PlayEuropeAgain" X="66" Y="30" CityLocaleName="LOC_CITY_NAME_LYSIMACHIA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+		<Replace MapName="PlayEuropeAgain" X="66" Y="30" CityLocaleName="LOC_CITY_NAME_LYSIMACHIA" Area="0" Civilization="CIVILIZATION_GREECE" />
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="31" CityLocaleName="LOC_CITY_NAME_EPIDAMNOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="31" CityLocaleName="LOC_CITY_NAME_KORDION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="31" CityLocaleName="LOC_CITY_NAME_LYCHNIDOS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -88,7 +86,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="31" CityLocaleName="LOC_CITY_NAME_MOSYNOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="31" CityLocaleName="LOC_CITY_NAME_DORISKOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="31" CityLocaleName="LOC_CITY_NAME_DORISKOS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="32" CityLocaleName="LOC_CITY_NAME_EPIDAMNOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="32" CityLocaleName="LOC_CITY_NAME_LYCHNIDOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="32" CityLocaleName="LOC_CITY_NAME_LYCHNIDOS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -102,48 +100,54 @@
 		<Replace MapName="PlayEuropeAgain" X="67" Y="32" CityLocaleName="LOC_CITY_NAME_PERINTHOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="32" CityLocaleName="LOC_CITY_NAME_BYZANTIUM" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="32" CityLocaleName="LOC_CITY_NAME_BYZANTIUM" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<!-- AEGEAN ISLANDS -->
 		<Replace MapName="PlayEuropeAgain" X="60" Y="18" CityLocaleName="LOC_CITY_NAME_KYDONIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="18" CityLocaleName="LOC_CITY_NAME_KNOSSOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="18" CityLocaleName="LOC_CITY_NAME_KNOSSOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="18" CityLocaleName="LOC_CITY_NAME_HIERAPYTNA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="20" CityLocaleName="LOC_CITY_NAME_THERA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="64" Y="21" CityLocaleName="LOC_CITY_NAME_KOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="21" CityLocaleName="LOC_CITY_NAME_RHODES" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="23" CityLocaleName="LOC_CITY_NAME_PALEOPOLI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="23" CityLocaleName="LOC_CITY_NAME_SAMOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="23" CityLocaleName="LOC_CITY_NAME_SAMOS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="63" Y="26" CityLocaleName="LOC_CITY_NAME_SKYROS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="29" CityLocaleName="LOC_CITY_NAME_HEPHAISTIA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
+		<!-- WESTERN AFRICA (MOROCCO, WESTERN SAHARA, MAURITANIA, & WESTERN ALGERIA) -->
+		<Replace MapName="PlayEuropeAgain" X="19" Y="26" CityLocaleName="LOC_CITY_NAME_MELILLA" Civilization="CIVILIZATION_GREECE" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="26" CityLocaleName="LOC_CITY_NAME_MELILLA" Area="0" Civilization="CIVILIZATION_GREECE" />
+
 		<!-- LIBYA & EGYPT -->
+		<Replace MapName="PlayEuropeAgain" X="78" Y="4" CityLocaleName="LOC_CITY_NAME_EL_QUSEIR" Civilization="CIVILIZATION_GREECE" />
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="13" CityLocaleName="LOC_CITY_NAME_ARSINOE_CYRENAICA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="13" CityLocaleName="LOC_CITY_NAME_PTOLEMAIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="13" CityLocaleName="LOC_CITY_NAME_APOLLONIA_CYRENAICA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<!-- ANATOLIA & CYPRUS -->
 		<Replace MapName="PlayEuropeAgain" X="76" Y="18" CityLocaleName="LOC_CITY_NAME_PAPHOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="18" CityLocaleName="LOC_CITY_NAME_KITION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="18" CityLocaleName="LOC_CITY_NAME_KITION" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="76" Y="19" CityLocaleName="LOC_CITY_NAME_MARION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="19" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="19" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="79" Y="20" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="21" CityLocaleName="LOC_CITY_NAME_PHYSKOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="21" CityLocaleName="LOC_CITY_NAME_MYRA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="21" CityLocaleName="LOC_CITY_NAME_MYRA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="21" CityLocaleName="LOC_CITY_NAME_ANEMOURION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="21" CityLocaleName="LOC_CITY_NAME_KELENDERIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="21" CityLocaleName="LOC_CITY_NAME_KORYKOS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="22" CityLocaleName="LOC_CITY_NAME_HALIKARNASSOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="22" CityLocaleName="LOC_CITY_NAME_KAUNOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="22" CityLocaleName="LOC_CITY_NAME_TELMESSOS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -155,7 +159,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="22" CityLocaleName="LOC_CITY_NAME_ELAIUSSA_SEBASTE" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="22" CityLocaleName="LOC_CITY_NAME_MALLOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="22" CityLocaleName="LOC_CITY_NAME_AIGEAI" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="23" CityLocaleName="LOC_CITY_NAME_MILETOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="23" CityLocaleName="LOC_CITY_NAME_MYLASA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="23" CityLocaleName="LOC_CITY_NAME_STRATONIKEIA" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -169,7 +173,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="23" CityLocaleName="LOC_CITY_NAME_TARSOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="23" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_IN_CILICIA" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="23" CityLocaleName="LOC_CITY_NAME_MOPSOUHESTIA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="24" CityLocaleName="LOC_CITY_NAME_EPHESOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="24" CityLocaleName="LOC_CITY_NAME_ALABANDA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="24" CityLocaleName="LOC_CITY_NAME_PYTHOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -179,7 +183,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="24" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="24" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="24" CityLocaleName="LOC_CITY_NAME_ANAZARBOS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="65" Y="25" CityLocaleName="LOC_CITY_NAME_ERYTHRAI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="25" CityLocaleName="LOC_CITY_NAME_COLOPHON" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="25" CityLocaleName="LOC_CITY_NAME_EPHESOS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -191,7 +195,7 @@
 		<Replace MapName="PlayEuropeAgain" X="73" Y="25" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_PISIDAE" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="25" CityLocaleName="LOC_CITY_NAME_IKONION" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="25" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="66" Y="26" CityLocaleName="LOC_CITY_NAME_SMYRNA" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="26" CityLocaleName="LOC_CITY_NAME_SARDEIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="26" CityLocaleName="LOC_CITY_NAME_SARDEIS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -204,14 +208,14 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="26" CityLocaleName="LOC_CITY_NAME_ARCHELAIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="26" CityLocaleName="LOC_CITY_NAME_ARCHELAIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="26" CityLocaleName="LOC_CITY_NAME_NAZIANZUS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="27" CityLocaleName="LOC_CITY_NAME_PERGAMON" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="27" CityLocaleName="LOC_CITY_NAME_PERGAMON" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="27" CityLocaleName="LOC_CITY_NAME_PHILADELPHIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="27" CityLocaleName="LOC_CITY_NAME_PHILADELPHIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="27" CityLocaleName="LOC_CITY_NAME_LAODIKEIA_KATAKEKAUMENE" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="27" CityLocaleName="LOC_CITY_NAME_ARCHELAIS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="66" Y="28" CityLocaleName="LOC_CITY_NAME_TROY" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="28" CityLocaleName="LOC_CITY_NAME_CYZICUS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="28" CityLocaleName="LOC_CITY_NAME_CYZICUS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -221,21 +225,21 @@
 		<Replace MapName="PlayEuropeAgain" X="72" Y="28" CityLocaleName="LOC_CITY_NAME_PESSINOUS" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="28" CityLocaleName="LOC_CITY_NAME_MOKISSOS" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="28" CityLocaleName="LOC_CITY_NAME_EUSEBIA_AT_THE_ARGAEUS" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="29" CityLocaleName="LOC_CITY_NAME_APAMEIA_MYRLEIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="29" CityLocaleName="LOC_CITY_NAME_NIKAIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="29" CityLocaleName="LOC_CITY_NAME_NIKAIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="29" CityLocaleName="LOC_CITY_NAME_DORYLAION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="29" CityLocaleName="LOC_CITY_NAME_GORDION" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="29" CityLocaleName="LOC_CITY_NAME_SEBASTEIA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="69" Y="30" CityLocaleName="LOC_CITY_NAME_KIOS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="30" CityLocaleName="LOC_CITY_NAME_PYLAI" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="30" CityLocaleName="LOC_CITY_NAME_NIKOMEDEIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="30" CityLocaleName="LOC_CITY_NAME_DORYLAION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="30" CityLocaleName="LOC_CITY_NAME_BITHYNION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="30" CityLocaleName="LOC_CITY_NAME_EUPATORIA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="70" Y="31" CityLocaleName="LOC_CITY_NAME_NIKOMEDEIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="31" CityLocaleName="LOC_CITY_NAME_NIKOMEDEIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="31" CityLocaleName="LOC_CITY_NAME_PRUSIAS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -245,25 +249,25 @@
 		<Replace MapName="PlayEuropeAgain" X="77" Y="31" CityLocaleName="LOC_CITY_NAME_GANGRA" Area="0" Civilization="CIVILIZATION_GREECE" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="78" Y="31" CityLocaleName="LOC_CITY_NAME_AMASEIA" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="31" CityLocaleName="LOC_CITY_NAME_EUPATORIA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="70" Y="32" CityLocaleName="LOC_CITY_NAME_CHALCEDON" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="32" CityLocaleName="LOC_CITY_NAME_CALPE" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="32" CityLocaleName="LOC_CITY_NAME_PRUSIAS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="32" CityLocaleName="LOC_CITY_NAME_PRUSIAS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="32" CityLocaleName="LOC_CITY_NAME_BITHYNION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="32" CityLocaleName="LOC_CITY_NAME_HADRIANOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="73" Y="33" CityLocaleName="LOC_CITY_NAME_HERAKLEIA_PONTIKE" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="33" CityLocaleName="LOC_CITY_NAME_PTERIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="33" CityLocaleName="LOC_CITY_NAME_AMISOS" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="75" Y="34" CityLocaleName="LOC_CITY_NAME_AMASTRIS" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="34" CityLocaleName="LOC_CITY_NAME_IONOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="34" CityLocaleName="LOC_CITY_NAME_SINOPE" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<!-- MIDDLE EAST (NORTH) -->
 		<Replace MapName="PlayEuropeAgain" X="82" Y="22" CityLocaleName="LOC_CITY_NAME_ISSUS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="22" CityLocaleName="LOC_CITY_NAME_EUROPOS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -275,7 +279,7 @@
 		<Replace MapName="PlayEuropeAgain" X="91" Y="22" CityLocaleName="LOC_CITY_NAME_DARAS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="22" CityLocaleName="LOC_CITY_NAME_NISIBIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="22" CityLocaleName="LOC_CITY_NAME_NISIBIS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="23" CityLocaleName="LOC_CITY_NAME_DOLICHE" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="23" CityLocaleName="LOC_CITY_NAME_ZEUGMA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="23" CityLocaleName="LOC_CITY_NAME_ANTIOCHEIA_ARABIS" Area="0" Civilization="CIVILIZATION_GREECE" />
@@ -285,53 +289,53 @@
 		<Replace MapName="PlayEuropeAgain" X="92" Y="23" CityLocaleName="LOC_CITY_NAME_DARAS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="23" CityLocaleName="LOC_CITY_NAME_DARAS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="23" CityLocaleName="LOC_CITY_NAME_BETHZABDE" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="24" CityLocaleName="LOC_CITY_NAME_GERMANIKEIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="24" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="24" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="24" CityLocaleName="LOC_CITY_NAME_EDESSA" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="24" CityLocaleName="LOC_CITY_NAME_MARIDA" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="24" CityLocaleName="LOC_CITY_NAME_DARAS" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="25" CityLocaleName="LOC_CITY_NAME_FLAVIOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="25" CityLocaleName="LOC_CITY_NAME_ADATHA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="25" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="25" CityLocaleName="LOC_CITY_NAME_AMIDA" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="25" CityLocaleName="LOC_CITY_NAME_KEPHA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="25" CityLocaleName="LOC_CITY_NAME_KEPHA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="26" CityLocaleName="LOC_CITY_NAME_KOMANA" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="27" CityLocaleName="LOC_CITY_NAME_ARIARATHEIA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="27" CityLocaleName="LOC_CITY_NAME_MELITENE" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="27" CityLocaleName="LOC_CITY_NAME_MELITENE" Area="0" Civilization="CIVILIZATION_GREECE" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="87" Y="27" CityLocaleName="LOC_CITY_NAME_CHARPETE" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="91" Y="27" CityLocaleName="LOC_CITY_NAME_TIGRANOKERTA" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="84" Y="28" CityLocaleName="LOC_CITY_NAME_EUSPENA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="29" CityLocaleName="LOC_CITY_NAME_SEBASTEIA" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="29" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="29" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="29" CityLocaleName="LOC_CITY_NAME_ROMANOUPOLIS" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="85" Y="30" CityLocaleName="LOC_CITY_NAME_ACILISENE" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="30" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="30" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="30" CityLocaleName="LOC_CITY_NAME_KOMANA_PONTIKA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="82" Y="30" CityLocaleName="LOC_CITY_NAME_KOMANA_PONTIKA" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="31" CityLocaleName="LOC_CITY_NAME_NIKOPOLIS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="31" CityLocaleName="LOC_CITY_NAME_SATALA" Area="0" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="32" CityLocaleName="LOC_CITY_NAME_POLEMONION" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="32" CityLocaleName="LOC_CITY_NAME_KERASOUS" Area="0" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="32" CityLocaleName="LOC_CITY_NAME_BAIBERDON" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="32" CityLocaleName="LOC_CITY_NAME_THEODOSIOPOLIS" Civilization="CIVILIZATION_GREECE" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="84" Y="33" CityLocaleName="LOC_CITY_NAME_TRAPEZOUS" Civilization="CIVILIZATION_GREECE" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="33" CityLocaleName="LOC_CITY_NAME_ARTAXATA" Civilization="CIVILIZATION_GREECE" />
-		
+
 	</CityMap>
-	
+
 </GameData>

--- a/Maps/PlayEuropeAgain/CityMap_Macedon.xml
+++ b/Maps/PlayEuropeAgain/CityMap_Macedon.xml
@@ -1,61 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameData>
-	
-	<!-- 
-	
-	"Play Europe Again"
-	
-	-->
+
+	<!-- ++++++++++++++++++++++++++++++++++++++++ -->
+	<!-- "Play Europe Again" City Map for Macedon -->
+	<!-- ++++++++++++++++++++++++++++++++++++++++ -->
 
 	<CityMap>
-		
+
 		<!-- GREEK MAINLAND -->
 		<Replace MapName="PlayEuropeAgain" X="58" Y="20" CityLocaleName="LOC_CITY_NAME_PYLOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="20" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="57" Y="21" CityLocaleName="LOC_CITY_NAME_PYLOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="21" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="21" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="21" CityLocaleName="LOC_CITY_NAME_EPIDAUROS_LIMERA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="57" Y="22" CityLocaleName="LOC_CITY_NAME_OLYMPIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="22" CityLocaleName="LOC_CITY_NAME_MEGALOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="22" CityLocaleName="LOC_CITY_NAME_ARGOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="22" CityLocaleName="LOC_CITY_NAME_MYCENAE" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="23" CityLocaleName="LOC_CITY_NAME_ELIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="23" CityLocaleName="LOC_CITY_NAME_PATRAS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="23" CityLocaleName="LOC_CITY_NAME_SICYON" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="23" CityLocaleName="LOC_CITY_NAME_CORINTH" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="23" CityLocaleName="LOC_CITY_NAME_MYCENAE" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="60" Y="24" CityLocaleName="LOC_CITY_NAME_CORINTH" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="25" CityLocaleName="LOC_CITY_NAME_CALYDON" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="25" CityLocaleName="LOC_CITY_NAME_DELPHI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="25" CityLocaleName="LOC_CITY_NAME_DELPHI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="25" CityLocaleName="LOC_CITY_NAME_THEBES" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="25" CityLocaleName="LOC_CITY_NAME_ATHENS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="25" CityLocaleName="LOC_CITY_NAME_ATHENS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="26" CityLocaleName="LOC_CITY_NAME_ANAKTORION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="26" CityLocaleName="LOC_CITY_NAME_THERMOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="26" CityLocaleName="LOC_CITY_NAME_DELPHI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="26" CityLocaleName="LOC_CITY_NAME_THEBES" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="26" CityLocaleName="LOC_CITY_NAME_THERMOPYLAI" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="27" CityLocaleName="LOC_CITY_NAME_AMBRACIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="27" CityLocaleName="LOC_CITY_NAME_CYNOSCEPHALAE" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="27" CityLocaleName="LOC_CITY_NAME_PHARSALOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="27" CityLocaleName="LOC_CITY_NAME_LARISSA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="27" CityLocaleName="LOC_CITY_NAME_IOLCOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="28" CityLocaleName="LOC_CITY_NAME_PHOENICE" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="28" CityLocaleName="LOC_CITY_NAME_HADRIANOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="28" CityLocaleName="LOC_CITY_NAME_ARGOS_ORESTIKON" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="28" CityLocaleName="LOC_CITY_NAME_AIGAI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="28" CityLocaleName="LOC_CITY_NAME_PYDNA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="29" CityLocaleName="LOC_CITY_NAME_APOLLONIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="29" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="29" CityLocaleName="LOC_CITY_NAME_PELION" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -64,7 +62,7 @@
 		<Replace MapName="PlayEuropeAgain" X="59" Y="29" CityLocaleName="LOC_CITY_NAME_THESSALONIKI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="29" CityLocaleName="LOC_CITY_NAME_THESSALONIKI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="29" CityLocaleName="LOC_CITY_NAME_OLYNTHOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="30" CityLocaleName="LOC_CITY_NAME_APOLLONIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="30" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="30" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -75,7 +73,7 @@
 		<Replace MapName="PlayEuropeAgain" X="61" Y="30" CityLocaleName="LOC_CITY_NAME_AMPHIPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="30" CityLocaleName="LOC_CITY_NAME_AINOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="30" CityLocaleName="LOC_CITY_NAME_LYSIMACHIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="31" CityLocaleName="LOC_CITY_NAME_EPIDAMNOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="31" CityLocaleName="LOC_CITY_NAME_KORDION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="31" CityLocaleName="LOC_CITY_NAME_LYCHNIDOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -88,7 +86,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="31" CityLocaleName="LOC_CITY_NAME_MOSYNOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="31" CityLocaleName="LOC_CITY_NAME_DORISKOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="31" CityLocaleName="LOC_CITY_NAME_DORISKOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="32" CityLocaleName="LOC_CITY_NAME_EPIDAMNOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="32" CityLocaleName="LOC_CITY_NAME_LYCHNIDOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="32" CityLocaleName="LOC_CITY_NAME_LYCHNIDOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -102,48 +100,54 @@
 		<Replace MapName="PlayEuropeAgain" X="67" Y="32" CityLocaleName="LOC_CITY_NAME_PERINTHOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="32" CityLocaleName="LOC_CITY_NAME_BYZANTIUM" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="32" CityLocaleName="LOC_CITY_NAME_BYZANTIUM" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<!-- AEGEAN ISLANDS -->
 		<Replace MapName="PlayEuropeAgain" X="60" Y="18" CityLocaleName="LOC_CITY_NAME_KYDONIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="18" CityLocaleName="LOC_CITY_NAME_KNOSSOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="18" CityLocaleName="LOC_CITY_NAME_KNOSSOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="18" CityLocaleName="LOC_CITY_NAME_HIERAPYTNA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="20" CityLocaleName="LOC_CITY_NAME_THERA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="64" Y="21" CityLocaleName="LOC_CITY_NAME_KOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="21" CityLocaleName="LOC_CITY_NAME_RHODES" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="23" CityLocaleName="LOC_CITY_NAME_PALEOPOLI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="23" CityLocaleName="LOC_CITY_NAME_SAMOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="23" CityLocaleName="LOC_CITY_NAME_SAMOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="63" Y="26" CityLocaleName="LOC_CITY_NAME_SKYROS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="29" CityLocaleName="LOC_CITY_NAME_HEPHAISTIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
+		<!-- WESTERN AFRICA (MOROCCO, WESTERN SAHARA, MAURITANIA, & WESTERN ALGERIA) -->
+		<Replace MapName="PlayEuropeAgain" X="19" Y="26" CityLocaleName="LOC_CITY_NAME_MELILLA" Civilization="CIVILIZATION_MACEDON" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="26" CityLocaleName="LOC_CITY_NAME_MELILLA" Area="0" Civilization="CIVILIZATION_MACEDON" />
+
 		<!-- LIBYA & EGYPT -->
+		<Replace MapName="PlayEuropeAgain" X="78" Y="4" CityLocaleName="LOC_CITY_NAME_EL_QUSEIR" Civilization="CIVILIZATION_MACEDON" />
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="13" CityLocaleName="LOC_CITY_NAME_ARSINOE_CYRENAICA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="13" CityLocaleName="LOC_CITY_NAME_PTOLEMAIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="13" CityLocaleName="LOC_CITY_NAME_APOLLONIA_CYRENAICA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<!-- ANATOLIA & CYPRUS -->
 		<Replace MapName="PlayEuropeAgain" X="76" Y="18" CityLocaleName="LOC_CITY_NAME_PAPHOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="18" CityLocaleName="LOC_CITY_NAME_KITION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="18" CityLocaleName="LOC_CITY_NAME_KITION" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="76" Y="19" CityLocaleName="LOC_CITY_NAME_MARION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="19" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="19" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="79" Y="20" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="21" CityLocaleName="LOC_CITY_NAME_PHYSKOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="21" CityLocaleName="LOC_CITY_NAME_MYRA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="21" CityLocaleName="LOC_CITY_NAME_MYRA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="21" CityLocaleName="LOC_CITY_NAME_ANEMOURION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="21" CityLocaleName="LOC_CITY_NAME_KELENDERIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="21" CityLocaleName="LOC_CITY_NAME_KORYKOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="22" CityLocaleName="LOC_CITY_NAME_HALIKARNASSOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="22" CityLocaleName="LOC_CITY_NAME_KAUNOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="22" CityLocaleName="LOC_CITY_NAME_TELMESSOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -155,7 +159,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="22" CityLocaleName="LOC_CITY_NAME_ELAIUSSA_SEBASTE" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="22" CityLocaleName="LOC_CITY_NAME_MALLOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="22" CityLocaleName="LOC_CITY_NAME_AIGEAI" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="23" CityLocaleName="LOC_CITY_NAME_MILETOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="23" CityLocaleName="LOC_CITY_NAME_MYLASA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="23" CityLocaleName="LOC_CITY_NAME_STRATONIKEIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -169,7 +173,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="23" CityLocaleName="LOC_CITY_NAME_TARSOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="23" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_IN_CILICIA" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="23" CityLocaleName="LOC_CITY_NAME_MOPSOUHESTIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="24" CityLocaleName="LOC_CITY_NAME_EPHESOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="24" CityLocaleName="LOC_CITY_NAME_ALABANDA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="24" CityLocaleName="LOC_CITY_NAME_PYTHOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -179,7 +183,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="24" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="24" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="24" CityLocaleName="LOC_CITY_NAME_ANAZARBOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="65" Y="25" CityLocaleName="LOC_CITY_NAME_ERYTHRAI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="25" CityLocaleName="LOC_CITY_NAME_COLOPHON" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="25" CityLocaleName="LOC_CITY_NAME_EPHESOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -191,7 +195,7 @@
 		<Replace MapName="PlayEuropeAgain" X="73" Y="25" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_PISIDAE" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="25" CityLocaleName="LOC_CITY_NAME_IKONION" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="25" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="66" Y="26" CityLocaleName="LOC_CITY_NAME_SMYRNA" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="26" CityLocaleName="LOC_CITY_NAME_SARDEIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="26" CityLocaleName="LOC_CITY_NAME_SARDEIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -204,14 +208,14 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="26" CityLocaleName="LOC_CITY_NAME_ARCHELAIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="26" CityLocaleName="LOC_CITY_NAME_ARCHELAIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="26" CityLocaleName="LOC_CITY_NAME_NAZIANZUS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="27" CityLocaleName="LOC_CITY_NAME_PERGAMON" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="27" CityLocaleName="LOC_CITY_NAME_PERGAMON" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="27" CityLocaleName="LOC_CITY_NAME_PHILADELPHIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="27" CityLocaleName="LOC_CITY_NAME_PHILADELPHIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="27" CityLocaleName="LOC_CITY_NAME_LAODIKEIA_KATAKEKAUMENE" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="27" CityLocaleName="LOC_CITY_NAME_ARCHELAIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="66" Y="28" CityLocaleName="LOC_CITY_NAME_TROY" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="28" CityLocaleName="LOC_CITY_NAME_CYZICUS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="28" CityLocaleName="LOC_CITY_NAME_CYZICUS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -221,21 +225,21 @@
 		<Replace MapName="PlayEuropeAgain" X="72" Y="28" CityLocaleName="LOC_CITY_NAME_PESSINOUS" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="28" CityLocaleName="LOC_CITY_NAME_MOKISSOS" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="28" CityLocaleName="LOC_CITY_NAME_EUSEBIA_AT_THE_ARGAEUS" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="29" CityLocaleName="LOC_CITY_NAME_APAMEIA_MYRLEIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="29" CityLocaleName="LOC_CITY_NAME_NIKAIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="29" CityLocaleName="LOC_CITY_NAME_NIKAIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="29" CityLocaleName="LOC_CITY_NAME_DORYLAION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="29" CityLocaleName="LOC_CITY_NAME_GORDION" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="29" CityLocaleName="LOC_CITY_NAME_SEBASTEIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="69" Y="30" CityLocaleName="LOC_CITY_NAME_KIOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="30" CityLocaleName="LOC_CITY_NAME_PYLAI" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="30" CityLocaleName="LOC_CITY_NAME_NIKOMEDEIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="30" CityLocaleName="LOC_CITY_NAME_DORYLAION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="30" CityLocaleName="LOC_CITY_NAME_BITHYNION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="30" CityLocaleName="LOC_CITY_NAME_EUPATORIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="70" Y="31" CityLocaleName="LOC_CITY_NAME_NIKOMEDEIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="31" CityLocaleName="LOC_CITY_NAME_NIKOMEDEIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="31" CityLocaleName="LOC_CITY_NAME_PRUSIAS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -245,25 +249,25 @@
 		<Replace MapName="PlayEuropeAgain" X="77" Y="31" CityLocaleName="LOC_CITY_NAME_GANGRA" Area="0" Civilization="CIVILIZATION_MACEDON" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="78" Y="31" CityLocaleName="LOC_CITY_NAME_AMASEIA" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="31" CityLocaleName="LOC_CITY_NAME_EUPATORIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="70" Y="32" CityLocaleName="LOC_CITY_NAME_CHALCEDON" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="32" CityLocaleName="LOC_CITY_NAME_CALPE" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="32" CityLocaleName="LOC_CITY_NAME_PRUSIAS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="32" CityLocaleName="LOC_CITY_NAME_PRUSIAS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="32" CityLocaleName="LOC_CITY_NAME_BITHYNION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="32" CityLocaleName="LOC_CITY_NAME_HADRIANOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="73" Y="33" CityLocaleName="LOC_CITY_NAME_HERAKLEIA_PONTIKE" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="33" CityLocaleName="LOC_CITY_NAME_PTERIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="33" CityLocaleName="LOC_CITY_NAME_AMISOS" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="75" Y="34" CityLocaleName="LOC_CITY_NAME_AMASTRIS" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="34" CityLocaleName="LOC_CITY_NAME_IONOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="34" CityLocaleName="LOC_CITY_NAME_SINOPE" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<!-- MIDDLE EAST (NORTH) -->
 		<Replace MapName="PlayEuropeAgain" X="82" Y="22" CityLocaleName="LOC_CITY_NAME_ISSUS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="22" CityLocaleName="LOC_CITY_NAME_EUROPOS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -275,7 +279,7 @@
 		<Replace MapName="PlayEuropeAgain" X="91" Y="22" CityLocaleName="LOC_CITY_NAME_DARAS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="22" CityLocaleName="LOC_CITY_NAME_NISIBIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="22" CityLocaleName="LOC_CITY_NAME_NISIBIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="23" CityLocaleName="LOC_CITY_NAME_DOLICHE" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="23" CityLocaleName="LOC_CITY_NAME_ZEUGMA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="23" CityLocaleName="LOC_CITY_NAME_ANTIOCHEIA_ARABIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
@@ -285,53 +289,53 @@
 		<Replace MapName="PlayEuropeAgain" X="92" Y="23" CityLocaleName="LOC_CITY_NAME_DARAS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="23" CityLocaleName="LOC_CITY_NAME_DARAS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="23" CityLocaleName="LOC_CITY_NAME_BETHZABDE" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="24" CityLocaleName="LOC_CITY_NAME_GERMANIKEIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="24" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="24" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="24" CityLocaleName="LOC_CITY_NAME_EDESSA" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="24" CityLocaleName="LOC_CITY_NAME_MARIDA" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="24" CityLocaleName="LOC_CITY_NAME_DARAS" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="25" CityLocaleName="LOC_CITY_NAME_FLAVIOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="25" CityLocaleName="LOC_CITY_NAME_ADATHA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="25" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="25" CityLocaleName="LOC_CITY_NAME_AMIDA" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="25" CityLocaleName="LOC_CITY_NAME_KEPHA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="25" CityLocaleName="LOC_CITY_NAME_KEPHA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="26" CityLocaleName="LOC_CITY_NAME_KOMANA" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="27" CityLocaleName="LOC_CITY_NAME_ARIARATHEIA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="27" CityLocaleName="LOC_CITY_NAME_MELITENE" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="27" CityLocaleName="LOC_CITY_NAME_MELITENE" Area="0" Civilization="CIVILIZATION_MACEDON" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="87" Y="27" CityLocaleName="LOC_CITY_NAME_CHARPETE" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="91" Y="27" CityLocaleName="LOC_CITY_NAME_TIGRANOKERTA" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="84" Y="28" CityLocaleName="LOC_CITY_NAME_EUSPENA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="29" CityLocaleName="LOC_CITY_NAME_SEBASTEIA" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="29" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="29" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="29" CityLocaleName="LOC_CITY_NAME_ROMANOUPOLIS" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="85" Y="30" CityLocaleName="LOC_CITY_NAME_ACILISENE" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="30" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="30" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="30" CityLocaleName="LOC_CITY_NAME_KOMANA_PONTIKA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="82" Y="30" CityLocaleName="LOC_CITY_NAME_KOMANA_PONTIKA" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="31" CityLocaleName="LOC_CITY_NAME_NIKOPOLIS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="31" CityLocaleName="LOC_CITY_NAME_SATALA" Area="0" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="32" CityLocaleName="LOC_CITY_NAME_POLEMONION" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="32" CityLocaleName="LOC_CITY_NAME_KERASOUS" Area="0" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="32" CityLocaleName="LOC_CITY_NAME_BAIBERDON" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="32" CityLocaleName="LOC_CITY_NAME_THEODOSIOPOLIS" Civilization="CIVILIZATION_MACEDON" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="84" Y="33" CityLocaleName="LOC_CITY_NAME_TRAPEZOUS" Civilization="CIVILIZATION_MACEDON" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="33" CityLocaleName="LOC_CITY_NAME_ARTAXATA" Civilization="CIVILIZATION_MACEDON" />
-		
+
 	</CityMap>
-	
+
 </GameData>

--- a/Maps/PlayEuropeAgain/CityMap_Rome.xml
+++ b/Maps/PlayEuropeAgain/CityMap_Rome.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameData>
-	
-	<!-- 
-	
-	"Play Europe Again"
-	
-	-->
-	
+
+	<!-- +++++++++++++++++++++++++++++++++++++ -->
+	<!-- "Play Europe Again" City Map for Rome -->
+	<!-- +++++++++++++++++++++++++++++++++++++ -->
+
 	<CityMap>
-		
+
 		<!-- IBERIA -->
 		<Replace MapName="PlayEuropeAgain" X="14" Y="30" CityLocaleName="LOC_CITY_NAME_BAELO_CLAUDIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="14" Y="33" CityLocaleName="LOC_CITY_NAME_ITALICA" Civilization="CIVILIZATION_ROME" />
@@ -20,59 +18,59 @@
 		<Replace MapName="PlayEuropeAgain" X="23" Y="38" CityLocaleName="LOC_CITY_NAME_BILBILIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="13" Y="42" CityLocaleName="LOC_CITY_NAME_BRAGA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="15" Y="42" CityLocaleName="LOC_CITY_NAME_AQUAE_FLAVIAE" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- ITALY -->
 		<Replace MapName="PlayEuropeAgain" X="45" Y="40" CityLocaleName="LOC_CITY_NAME_RAVENNA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="44" Y="41" CityLocaleName="LOC_CITY_NAME_ATRIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="46" Y="42" CityLocaleName="LOC_CITY_NAME_IULIA_CONCORDIA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- GREEK MAINLAND -->
 		<Replace MapName="PlayEuropeAgain" X="58" Y="20" CityLocaleName="LOC_CITY_NAME_METHONE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="20" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="57" Y="21" CityLocaleName="LOC_CITY_NAME_MESSENE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="21" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="21" CityLocaleName="LOC_CITY_NAME_SPARTA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="21" CityLocaleName="LOC_CITY_NAME_EPIDAUROS_LIMERA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="57" Y="22" CityLocaleName="LOC_CITY_NAME_OLYMPIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="22" CityLocaleName="LOC_CITY_NAME_MEGALOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="22" CityLocaleName="LOC_CITY_NAME_ARGOS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="22" CityLocaleName="LOC_CITY_NAME_ARGOS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="23" CityLocaleName="LOC_CITY_NAME_ELIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="23" CityLocaleName="LOC_CITY_NAME_PATRAE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="23" CityLocaleName="LOC_CITY_NAME_PATRAE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="23" CityLocaleName="LOC_CITY_NAME_CORINTHUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="23" CityLocaleName="LOC_CITY_NAME_EPIDAURUS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="60" Y="24" CityLocaleName="LOC_CITY_NAME_CORINTHUS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="25" CityLocaleName="LOC_CITY_NAME_ACTIA_NICOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="25" CityLocaleName="LOC_CITY_NAME_NAUPACTUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="25" CityLocaleName="LOC_CITY_NAME_DELPHI" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="25" CityLocaleName="LOC_CITY_NAME_THESPIAE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="25" CityLocaleName="LOC_CITY_NAME_ATHENAE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="25" CityLocaleName="LOC_CITY_NAME_ATHENAE" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="56" Y="26" CityLocaleName="LOC_CITY_NAME_ACTIA_NICOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="26" CityLocaleName="LOC_CITY_NAME_THERMUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="26" CityLocaleName="LOC_CITY_NAME_DELPHI" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="26" CityLocaleName="LOC_CITY_NAME_AMPHISSA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="26" CityLocaleName="LOC_CITY_NAME_THERMOPYLAE" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="27" CityLocaleName="LOC_CITY_NAME_AMBRACIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="27" CityLocaleName="LOC_CITY_NAME_CYNOSCEPHALAE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="27" CityLocaleName="LOC_CITY_NAME_PHARSALUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="27" CityLocaleName="LOC_CITY_NAME_LARISSA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="27" CityLocaleName="LOC_CITY_NAME_PAGASAE" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="28" CityLocaleName="LOC_CITY_NAME_PHOENICE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="28" CityLocaleName="LOC_CITY_NAME_HADRIANOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="28" CityLocaleName="LOC_CITY_NAME_DIOCLETIANOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="28" CityLocaleName="LOC_CITY_NAME_BERRHOEA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="59" Y="28" CityLocaleName="LOC_CITY_NAME_PYDNA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="29" CityLocaleName="LOC_CITY_NAME_APOLLONIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="29" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="29" CityLocaleName="LOC_CITY_NAME_PELIUM" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -81,7 +79,7 @@
 		<Replace MapName="PlayEuropeAgain" X="59" Y="29" CityLocaleName="LOC_CITY_NAME_THESSALONICA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="60" Y="29" CityLocaleName="LOC_CITY_NAME_THESSALONICA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="29" CityLocaleName="LOC_CITY_NAME_OLYNTHUS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="30" CityLocaleName="LOC_CITY_NAME_APOLLONIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="30" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="30" CityLocaleName="LOC_CITY_NAME_BYLLIS" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -92,7 +90,7 @@
 		<Replace MapName="PlayEuropeAgain" X="61" Y="30" CityLocaleName="LOC_CITY_NAME_AMPHIPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="30" CityLocaleName="LOC_CITY_NAME_AENUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="30" CityLocaleName="LOC_CITY_NAME_RHAEDESTUS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="54" Y="31" CityLocaleName="LOC_CITY_NAME_DYRRACHIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="31" CityLocaleName="LOC_CITY_NAME_OHRID" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="31" CityLocaleName="LOC_CITY_NAME_OHRID" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -105,7 +103,7 @@
 		<Replace MapName="PlayEuropeAgain" X="64" Y="31" CityLocaleName="LOC_CITY_NAME_MAXIMIANOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="31" CityLocaleName="LOC_CITY_NAME_DORISKOS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="31" CityLocaleName="LOC_CITY_NAME_DORISKOS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="32" CityLocaleName="LOC_CITY_NAME_DYRRACHIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="32" CityLocaleName="LOC_CITY_NAME_OHRID" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="57" Y="32" CityLocaleName="LOC_CITY_NAME_OHRID" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -119,48 +117,48 @@
 		<Replace MapName="PlayEuropeAgain" X="67" Y="32" CityLocaleName="LOC_CITY_NAME_PERINTHUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="32" CityLocaleName="LOC_CITY_NAME_SELYMBRIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="32" CityLocaleName="LOC_CITY_NAME_CONSTANTINOPLE" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- AEGEAN ISLANDS -->
 		<Replace MapName="PlayEuropeAgain" X="60" Y="18" CityLocaleName="LOC_CITY_NAME_CYDONIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="61" Y="18" CityLocaleName="LOC_CITY_NAME_CNOSSOS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="18" CityLocaleName="LOC_CITY_NAME_GORTYNA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="18" CityLocaleName="LOC_CITY_NAME_HIERAPYTNA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="20" CityLocaleName="LOC_CITY_NAME_THERA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="64" Y="21" CityLocaleName="LOC_CITY_NAME_COS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="21" CityLocaleName="LOC_CITY_NAME_RHODES" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="62" Y="23" CityLocaleName="LOC_CITY_NAME_ANDROS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="64" Y="23" CityLocaleName="LOC_CITY_NAME_SAMOS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="65" Y="23" CityLocaleName="LOC_CITY_NAME_SAMOS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="63" Y="26" CityLocaleName="LOC_CITY_NAME_SKYROS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="63" Y="29" CityLocaleName="LOC_CITY_NAME_HEPHAESTIA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- BALKANS -->
 		<Replace MapName="PlayEuropeAgain" X="56" Y="39" CityLocaleName="LOC_CITY_NAME_NOVI_SAD" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="62" Y="41" CityLocaleName="LOC_CITY_NAME_ALBA_IULIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="54" Y="42" CityLocaleName="LOC_CITY_NAME_PECS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- ANATOLIA & CYPRUS -->
 		<Replace MapName="PlayEuropeAgain" X="76" Y="18" CityLocaleName="LOC_CITY_NAME_PAPHUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="18" CityLocaleName="LOC_CITY_NAME_CITIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="18" CityLocaleName="LOC_CITY_NAME_CITIUM" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="76" Y="19" CityLocaleName="LOC_CITY_NAME_ARSINOE_CYPRUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="19" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="19" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="79" Y="20" CityLocaleName="LOC_CITY_NAME_SALAMIS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="21" CityLocaleName="LOC_CITY_NAME_CNIDUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="21" CityLocaleName="LOC_CITY_NAME_MYRA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="21" CityLocaleName="LOC_CITY_NAME_MYRA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="21" CityLocaleName="LOC_CITY_NAME_ANEMURIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="21" CityLocaleName="LOC_CITY_NAME_CELENDERIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="21" CityLocaleName="LOC_CITY_NAME_CORYCUS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="22" CityLocaleName="LOC_CITY_NAME_HALICARNASSUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="22" CityLocaleName="LOC_CITY_NAME_CAUNUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="22" CityLocaleName="LOC_CITY_NAME_TELMESSUS" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -172,7 +170,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="22" CityLocaleName="LOC_CITY_NAME_ELAEOUSA_SEBASTE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="22" CityLocaleName="LOC_CITY_NAME_MALLUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="22" CityLocaleName="LOC_CITY_NAME_AEGEAE" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="23" CityLocaleName="LOC_CITY_NAME_MILETUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="23" CityLocaleName="LOC_CITY_NAME_MYLASA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="23" CityLocaleName="LOC_CITY_NAME_STRATONICEA" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -186,7 +184,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="23" CityLocaleName="LOC_CITY_NAME_TARSUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="23" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_AD_SARUM" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="23" CityLocaleName="LOC_CITY_NAME_MOPSUESTIA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="67" Y="24" CityLocaleName="LOC_CITY_NAME_EPHESUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="24" CityLocaleName="LOC_CITY_NAME_ALABANDA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="24" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_AD_MAEANDRUM" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -196,7 +194,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="24" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="24" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="81" Y="24" CityLocaleName="LOC_CITY_NAME_JUSTINOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="65" Y="25" CityLocaleName="LOC_CITY_NAME_ERYTHRAE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="25" CityLocaleName="LOC_CITY_NAME_LEBEDUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="25" CityLocaleName="LOC_CITY_NAME_EPHESUS" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -208,7 +206,7 @@
 		<Replace MapName="PlayEuropeAgain" X="73" Y="25" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_CAESAREA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="25" CityLocaleName="LOC_CITY_NAME_ICONIUM" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="25" CityLocaleName="LOC_CITY_NAME_TYANA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="66" Y="26" CityLocaleName="LOC_CITY_NAME_SMYRNA" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="26" CityLocaleName="LOC_CITY_NAME_SARDIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="68" Y="26" CityLocaleName="LOC_CITY_NAME_SARDIS" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -221,7 +219,7 @@
 		<Replace MapName="PlayEuropeAgain" X="78" Y="26" CityLocaleName="LOC_CITY_NAME_GARSAURA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="79" Y="26" CityLocaleName="LOC_CITY_NAME_GARSAURA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="26" CityLocaleName="LOC_CITY_NAME_NAZIANZUS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="65" Y="27" CityLocaleName="LOC_CITY_NAME_PHOCAEA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="27" CityLocaleName="LOC_CITY_NAME_PERGAMUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="27" CityLocaleName="LOC_CITY_NAME_PERGAMUM" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -230,7 +228,7 @@
 		<Replace MapName="PlayEuropeAgain" X="70" Y="27" CityLocaleName="LOC_CITY_NAME_PHILADELPHIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="27" CityLocaleName="LOC_CITY_NAME_CLAUDIOLAODICEA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="27" CityLocaleName="LOC_CITY_NAME_GARSAURA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="65" Y="28" CityLocaleName="LOC_CITY_NAME_ILIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="66" Y="28" CityLocaleName="LOC_CITY_NAME_PARIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="67" Y="28" CityLocaleName="LOC_CITY_NAME_CYZICUS" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -241,21 +239,21 @@
 		<Replace MapName="PlayEuropeAgain" X="72" Y="28" CityLocaleName="LOC_CITY_NAME_PESSINUS" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="28" CityLocaleName="LOC_CITY_NAME_MACISSUS" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="28" CityLocaleName="LOC_CITY_NAME_CAESAREA_IN_CAPPADOCIA" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="68" Y="29" CityLocaleName="LOC_CITY_NAME_APAMEA_MYRLEA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="69" Y="29" CityLocaleName="LOC_CITY_NAME_NICAEA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="29" CityLocaleName="LOC_CITY_NAME_NICAEA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="29" CityLocaleName="LOC_CITY_NAME_DORYLAEUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="29" CityLocaleName="LOC_CITY_NAME_GORDIUM" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="29" CityLocaleName="LOC_CITY_NAME_SEBASTIA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="69" Y="30" CityLocaleName="LOC_CITY_NAME_PRUSIAS_AD_MARE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="70" Y="30" CityLocaleName="LOC_CITY_NAME_PYLAE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="30" CityLocaleName="LOC_CITY_NAME_NICOMEDIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="30" CityLocaleName="LOC_CITY_NAME_DORYLAEUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="30" CityLocaleName="LOC_CITY_NAME_BITHYNIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="30" CityLocaleName="LOC_CITY_NAME_EUPATORIA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="70" Y="31" CityLocaleName="LOC_CITY_NAME_NICOMEDIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="31" CityLocaleName="LOC_CITY_NAME_NICOMEDIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="31" CityLocaleName="LOC_CITY_NAME_PRUSIAS_AD_HYPIUM" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -265,25 +263,25 @@
 		<Replace MapName="PlayEuropeAgain" X="77" Y="31" CityLocaleName="LOC_CITY_NAME_GANGRA" Area="0" Civilization="CIVILIZATION_ROME" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="78" Y="31" CityLocaleName="LOC_CITY_NAME_AMASIA" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="31" CityLocaleName="LOC_CITY_NAME_EUPATORIA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="70" Y="32" CityLocaleName="LOC_CITY_NAME_CHALCEDON" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="71" Y="32" CityLocaleName="LOC_CITY_NAME_CALPE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="72" Y="32" CityLocaleName="LOC_CITY_NAME_PRUSIAS_AD_HYPIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="73" Y="32" CityLocaleName="LOC_CITY_NAME_PRUSIAS_AD_HYPIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="74" Y="32" CityLocaleName="LOC_CITY_NAME_BITHYNIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="32" CityLocaleName="LOC_CITY_NAME_HADRIANOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="73" Y="33" CityLocaleName="LOC_CITY_NAME_HERACLEA_PONTICA" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="75" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="77" Y="33" CityLocaleName="LOC_CITY_NAME_POMPEIOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="33" CityLocaleName="LOC_CITY_NAME_PTERIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="80" Y="33" CityLocaleName="LOC_CITY_NAME_AMISUS" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="75" Y="34" CityLocaleName="LOC_CITY_NAME_AMASTRIS" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="76" Y="34" CityLocaleName="LOC_CITY_NAME_IONOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="78" Y="34" CityLocaleName="LOC_CITY_NAME_SINOPE" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- FRANCE -->
 		<Replace MapName="PlayEuropeAgain" X="29" Y="41" CityLocaleName="LOC_CITY_NAME_NARBONNE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="42" CityLocaleName="LOC_CITY_NAME_NARBONNE" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -294,7 +292,7 @@
 		<Replace MapName="PlayEuropeAgain" X="24" Y="54" CityLocaleName="LOC_CITY_NAME_DARIORITUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="30" Y="54" CityLocaleName="LOC_CITY_NAME_AUGUSTODURUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="29" Y="55" CityLocaleName="LOC_CITY_NAME_AUGUSTODURUM" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- GERMANY (INCLUDING BENELUX & HELVETIA, EXCLUDING DENMARK, CZECHIA, & AUSTRIA) -->
 		<Replace MapName="PlayEuropeAgain" X="36" Y="47" CityLocaleName="LOC_CITY_NAME_IULIA_EQUESTRIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="39" Y="48" CityLocaleName="LOC_CITY_NAME_VINDONISSA" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -307,11 +305,11 @@
 		<Replace MapName="PlayEuropeAgain" X="40" Y="53" CityLocaleName="LOC_CITY_NAME_VICUS_AUGUSTANUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="41" Y="53" CityLocaleName="LOC_CITY_NAME_VICUS_AUGUSTANUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="39" Y="56" CityLocaleName="LOC_CITY_NAME_DUESSELDORF" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- CENTRAL & EASTERN EUROPE (AUSTRIA, CZECHIA, POLAND, HUNGARY, SLOVAKIA, BELARUS, WESTERN UKRAINE, MOLDOVA, NORTHERN ROMANIA, & SOUTHERN LITHUANIA) -->
 		<Replace MapName="PlayEuropeAgain" X="54" Y="43" CityLocaleName="LOC_CITY_NAME_INTERCISA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="55" Y="43" CityLocaleName="LOC_CITY_NAME_INTERCISA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- GREAT BRITAIN -->
 		<Replace MapName="PlayEuropeAgain" X="26" Y="59" CityLocaleName="LOC_CITY_NAME_DURNOVARIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="59" CityLocaleName="LOC_CITY_NAME_DURNOVARIA" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -329,20 +327,30 @@
 		<Replace MapName="PlayEuropeAgain" X="27" Y="71" CityLocaleName="LOC_CITY_NAME_VELUNIATE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="27" Y="72" CityLocaleName="LOC_CITY_NAME_VALLUM_ANTONINI" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="28" Y="72" CityLocaleName="LOC_CITY_NAME_VELUNIATE" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- WESTERN AFRICA (MOROCCO, WESTERN SAHARA, MAURITANIA, & WESTERN ALGERIA) -->
 		<Replace MapName="PlayEuropeAgain" X="13" Y="26" CityLocaleName="LOC_CITY_NAME_LIXUS" Area="0" Civilization="CIVILIZATION_ROME" />
+		<Replace MapName="PlayEuropeAgain" X="19" Y="26" CityLocaleName="LOC_CITY_NAME_MELILLA" Civilization="CIVILIZATION_ROME" />
+		<Replace MapName="PlayEuropeAgain" X="20" Y="26" CityLocaleName="LOC_CITY_NAME_MELILLA" Area="0" Civilization="CIVILIZATION_ROME" />
+
 		<Replace MapName="PlayEuropeAgain" X="14" Y="27" CityLocaleName="LOC_CITY_NAME_LIXUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="15" Y="27" CityLocaleName="LOC_CITY_NAME_IULIA_CONSTANTIA_ZILIL" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
+		<!-- CENTRAL AFRICA (ALGERIA, TUNISIA, NORTH LIBYA) -->
+		<Replace MapName="PlayEuropeAgain" X="23" Y="25" CityLocaleName="LOC_CITY_NAME_AQUAE_CALIDAE" Civilization="CIVILIZATION_ROME" />
+
+		<Replace MapName="PlayEuropeAgain" X="21" Y="26" CityLocaleName="LOC_CITY_NAME_SIGA" Civilization="CIVILIZATION_ROME" />
+
 		<!-- LIBYA & EGYPT -->
+		<Replace MapName="PlayEuropeAgain" X="78" Y="4" CityLocaleName="LOC_CITY_NAME_EL_QUSEIR" Civilization="CIVILIZATION_ROME" />
+
 		<Replace MapName="PlayEuropeAgain" X="55" Y="13" CityLocaleName="LOC_CITY_NAME_ARSINOE_CYRENAICA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="56" Y="13" CityLocaleName="LOC_CITY_NAME_PTOLEMAIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="58" Y="13" CityLocaleName="LOC_CITY_NAME_APOLLONIA_CYRENAICA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<!-- MIDDLE EAST (NORTH) -->
 		<Replace MapName="PlayEuropeAgain" X="82" Y="21" CityLocaleName="LOC_CITY_NAME_ALEXANDRIA_AD_ISSUM" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="22" CityLocaleName="LOC_CITY_NAME_ISSUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="22" CityLocaleName="LOC_CITY_NAME_EUROPUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="22" CityLocaleName="LOC_CITY_NAME_BATNAE" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -354,7 +362,7 @@
 		<Replace MapName="PlayEuropeAgain" X="92" Y="22" CityLocaleName="LOC_CITY_NAME_RESAINA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="22" CityLocaleName="LOC_CITY_NAME_ANASTASIOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="22" CityLocaleName="LOC_CITY_NAME_NISIBIS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="23" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_AD_TAURUM" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="23" CityLocaleName="LOC_CITY_NAME_ZEUGMA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="23" CityLocaleName="LOC_CITY_NAME_ANTIOCHIA_ARABIS" Area="0" Civilization="CIVILIZATION_ROME" />
@@ -364,58 +372,58 @@
 		<Replace MapName="PlayEuropeAgain" X="92" Y="23" CityLocaleName="LOC_CITY_NAME_ANASTASIOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="23" CityLocaleName="LOC_CITY_NAME_ANASTASIOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="23" CityLocaleName="LOC_CITY_NAME_BETHZABDE" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="24" CityLocaleName="LOC_CITY_NAME_GERMANICIA_CAESAREA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="24" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="24" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="24" CityLocaleName="LOC_CITY_NAME_EDESSA" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="24" CityLocaleName="LOC_CITY_NAME_MARIDA" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="24" CityLocaleName="LOC_CITY_NAME_ANASTASIOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="25" CityLocaleName="LOC_CITY_NAME_FLAVIOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="25" CityLocaleName="LOC_CITY_NAME_ADATHA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="25" CityLocaleName="LOC_CITY_NAME_SAMOSATA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="25" CityLocaleName="LOC_CITY_NAME_AMIDA" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="25" CityLocaleName="LOC_CITY_NAME_CEPHA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="25" CityLocaleName="LOC_CITY_NAME_CEPHA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="83" Y="26" CityLocaleName="LOC_CITY_NAME_COMANA_CHRYSE" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="27" CityLocaleName="LOC_CITY_NAME_ARIARATHEIA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="85" Y="27" CityLocaleName="LOC_CITY_NAME_MELITENE" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="27" CityLocaleName="LOC_CITY_NAME_MELITENE" Area="0" Civilization="CIVILIZATION_ROME" /> <!-- OVERLAP -->
 		<Replace MapName="PlayEuropeAgain" X="87" Y="27" CityLocaleName="LOC_CITY_NAME_CHARPETE" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="27" CityLocaleName="LOC_CITY_NAME_MAIPA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="91" Y="27" CityLocaleName="LOC_CITY_NAME_TIGRANOCERTA" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="84" Y="28" CityLocaleName="LOC_CITY_NAME_EUSPENA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="29" CityLocaleName="LOC_CITY_NAME_SEBASTIA" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="86" Y="29" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="29" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="89" Y="29" CityLocaleName="LOC_CITY_NAME_ROMANOUPOLIS" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="85" Y="30" CityLocaleName="LOC_CITY_NAME_ACILISENE" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="30" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="30" CityLocaleName="LOC_CITY_NAME_ARASAMOSATA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="81" Y="31" CityLocaleName="LOC_CITY_NAME_COMANA_PONTICA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="82" Y="31" CityLocaleName="LOC_CITY_NAME_COMANA_PONTICA" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="84" Y="31" CityLocaleName="LOC_CITY_NAME_NICOPOLIS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="88" Y="31" CityLocaleName="LOC_CITY_NAME_SATALA" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="82" Y="32" CityLocaleName="LOC_CITY_NAME_POLEMONIUM" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="83" Y="32" CityLocaleName="LOC_CITY_NAME_CERASUS" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="87" Y="32" CityLocaleName="LOC_CITY_NAME_SINORIA" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="90" Y="32" CityLocaleName="LOC_CITY_NAME_THEODOSIOPOLIS" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="32" CityLocaleName="LOC_CITY_NAME_CHORZENE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="93" Y="32" CityLocaleName="LOC_CITY_NAME_CHORZENE" Area="0" Civilization="CIVILIZATION_ROME" />
-		
+
 		<Replace MapName="PlayEuropeAgain" X="84" Y="33" CityLocaleName="LOC_CITY_NAME_TRAPEZUS" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="91" Y="33" CityLocaleName="LOC_CITY_NAME_CHORZENE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="92" Y="33" CityLocaleName="LOC_CITY_NAME_CHORZENE" Area="0" Civilization="CIVILIZATION_ROME" />
 		<Replace MapName="PlayEuropeAgain" X="94" Y="33" CityLocaleName="LOC_CITY_NAME_ARTAXATA" Civilization="CIVILIZATION_ROME" />
-		
+
 	</CityMap>
-	
+
 </GameData>

--- a/Yet (not) Another Maps Pack.modinfo
+++ b/Yet (not) Another Maps Pack.modinfo
@@ -46,6 +46,11 @@
 			<File>Gameplay/GamePlay.xml</File>
 			<File>Maps/GiantEarth/Map.xml</File>
 			<File>Maps/GiantEarth/CityMap.xml</File>
+			<File>Maps/GiantEarth/CityMap_Egypt.xml</File>
+			<File>Maps/GiantEarth/CityMap_Greece.xml</File>
+			<File>Maps/GiantEarth/CityMap_Nubia.xml</File>
+			<File>Maps/GiantEarth/CityMap_Rome.xml</File>
+			<File>Maps/GiantEarth/CityMap_Spain.xml</File>
 			<File>Maps/GreatestEarthMap/Map.xml</File>
 			<File>Maps/GreatestEarthMap/CityMap.xml</File>
 			<File>Maps/PlayEuropeAgain/Map.xml</File>
@@ -125,6 +130,11 @@
 		<File>Gameplay/GamePlayText_pt_BR.xml</File>
 		<File>Maps/GiantEarth/Map.xml</File>
 		<File>Maps/GiantEarth/CityMap.xml</File>
+		<File>Maps/GiantEarth/CityMap_Egypt.xml</File>
+		<File>Maps/GiantEarth/CityMap_Greece.xml</File>
+		<File>Maps/GiantEarth/CityMap_Nubia.xml</File>
+		<File>Maps/GiantEarth/CityMap_Rome.xml</File>
+		<File>Maps/GiantEarth/CityMap_Spain.xml</File>
 		<File>Maps/GreatestEarthMap/Map.xml</File>
 		<File>Maps/GreatestEarthMap/CityMap.xml</File>
 		<File>Maps/PlayEuropeAgain/Map.xml</File>


### PR DESCRIPTION
I've added four new sections above the equator in Africa, completing the city map there. I've also started using [Atom](https://atom.io), which is great, and [GitHub Desktop](https://desktop.github.com), which is okay (bit of a learning curve). Atom has a package which strips away any excess trailing white-space automatically, so you will see that all that has been deleted from the files which I was working on. Other minor changes to GEM include adding Cyprus (which for some reason was missing) and adding civ-specific city map files for Egypt, Greece, Nubia, Rome, and Spain. I also took the opportunity to tidy up the CityMap.xml file for PEA while I made a few small changes there so that it meshes nicely with its GEM equivalent.