### PR TITLE
Added Civ Specific City Maps for Korea and Japan

### DIFF
--- a/Gameplay/GamePlayText.xml
+++ b/Gameplay/GamePlayText.xml
@@ -6681,6 +6681,49 @@
 		<Replace Tag="LOC_CITY_NAME_SUIHUA" Text="Suihua" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DAXINGANLING" Text="Daxing'anling" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MAGDAGACHI" Text="Magdagachi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAELYEON" Text="Daelyeon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SHIMYANG" Text="Shimyang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEONBYEON" Text="Yeonbyeon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PAEKSAN" Text="Paeksan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YOWON" Text="Yowon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HABIBIN" Text="Habibin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JANGCHUN" Text="Jangchun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MODANGANG" Text="Modangang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAMOKSA" Text="Kamoksa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GYESEO" Text="Gyeseo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SSANGAPSAN" Text="Ssangapsan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HAKGANG" Text="Hakgang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_IJUN" Text="Ijun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SUWA" Text="Suwa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAEHEUNGANLYEONG" Text="Daeheunganlyeong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JEJEHABI" Text="Jejehabi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JONGWON" Text="Jongwon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PAEKSEONG" Text="Paekseong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DANGSAN" Text="Dangsan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TONGRYO" Text="Tongryo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUSHIN" Text="Bushin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JEOKBONG" Text="Jeokbong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEHA" Text="Yeha" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUKGYUNG" Text="Bukgyung" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOJEONG" Text="Bojeong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHEONJIN" Text="Cheonjin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEOKGAJANG" Text="Seokgajang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JANGJA" Text="Jangja" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JEONGJU" Text="Jeongju" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GAEBONG" Text="Gaebong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YUBANG" Text="Yubang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JENAM" Text="Jenam" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHEONGDO" Text="Cheongdo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEONDAE" Text="Yeondae" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JENYEONG" Text="Jenyeong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PAENGSEONG" Text="Paengseong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_IMEUN" Text="Imeun" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YEOMSEONG" Text="Yeomseong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SANGHAE" Text="Sanghae" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAMGYEONG" Text="Namgyeong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAIREN" Text="Dairen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAIHOKU" Text="Taihoku" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAKAO" Text="Takao" Language="en_US" />
 
 	</LocalizedText>
 
@@ -6750,6 +6793,48 @@
 		<Replace Tag="LOC_CITY_NAME_SAPPORO" Text="Sapporo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ASAHIKAWA" Text="Asahikawa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KUSHIRO" Text="Kushiro" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DONGGYEONG" Text="Donggyeong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CHEONYEOP" Text="Cheonyeop" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GYEONGDO" Text="Gyeongdo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JONGBON" Text="Jongbon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAEJIN" Text="Daejin" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GWANGBYEONG" Text="Gwangbyeong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MYEONGGO" Text="Myeonggo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DAEPAN" Text="Daepan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAYANG" Text="Nayang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HWAGASAN" Text="Hwagasan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GYE" Text="Gye" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SHINHO" Text="Shinho" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MUHAK" Text="Muhak" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DOCHWI" Text="Dochwi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HUINAK" Text="Huinak" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GANGSAN" Text="Gangsan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SONGGANG" Text="Songgang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GWANGDO" Text="Gwangdo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SANKU" Text="Sanku" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUKGYUJU" Text="Bukgyuju" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BUGANG" Text="Bugang" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GOMBON" Text="Gombon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GUNGGI" Text="Gunggi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NOKYEDO" Text="Nokyedo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GOJONG" Text="Gojong" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SONGSAN" Text="Songsan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SAISHU" Text="Saishu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOSHU" Text="Koshu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FUSAN" Text="Fusan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KEIJO" Text="Keijo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAIKYU" Text="Taikyu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_URUSAN" Text="Urusan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JINSEN" Text="Jinsen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TAIDEN" Text="Taiden" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HOKO" Text="Hoko" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KORYO" Text="Koryo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_HEIJO" Text="Heijo" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_JUNGAWA" Text="Jungawa" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KANKO" Text="Kanko" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KAISEN" Text="Kaisen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_KOKAI" Text="Kokai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SEISHIN" Text="Seishin" Language="en_US" />
 
 	</LocalizedText>
 

--- a/Maps/GiantEarth/CityMap_Japan.xml
+++ b/Maps/GiantEarth/CityMap_Japan.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+
+	<!-- +++++++++++++++++++++++++++++++++++ -->
+	<!-- "Giant Earth Map" City Map for Japan -->
+	<!-- +++++++++++++++++++++++++++++++++++ -->
+
+
+
+	<!-- +++++++++++++++ -->
+	<!-- Asia City Map -->
+	<!-- +++++++++++++++ -->
+
+
+	<!-- KOREA -->
+	<CityMap>
+
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_SAISHU" X="89" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KOSHU" X="89" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_FUSAN" X="90" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_ZENSHU" X="90" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_FUSAN" X="91" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KEIJO" X="89" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_TAIKYU" X="90" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_URUSAN" X="91" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_JINSEN" X="89" Y="62" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_TAIDEN" X="90" Y="62" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_HOKO" X="91" Y="62" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_JINSEN" X="88" Y="63" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_JINSEN" X="89" Y="63" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KORYO" X="90" Y="63" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_HEIJO" X="89" Y="64" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_HEIJO" X="88" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_JUNGAWA" X="89" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KANKO" X="91" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KAISEN" X="89" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KOKAI" X="90" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KANKO" X="91" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KANKO" X="92" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_KOKAI" X="89" Y="67" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_SEISHIN" X="92" Y="67" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_SEISHIN" X="93" Y="68" MapName="GiantEarth"/>
+
+	</CityMap>
+
+	<!-- CHINA -->
+	<CityMap>
+
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_DAIREN" X="87" Y="64" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_DAIREN" X="87" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_DAIREN" X="87" Y="66" MapName="GiantEarth"/>
+
+	</CityMap>
+
+	<!-- TAIWAN -->
+	<CityMap>
+
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_TAIHOKU" X="87" Y="49" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_TAIHOKU" X="88" Y="49" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_JAPAN" Area="0" CityLocaleName="LOC_CITY_NAME_TAKAO" X="88" Y="48" MapName="GiantEarth"/>
+
+
+	</CityMap>
+
+</GameData>

--- a/Maps/GiantEarth/CityMap_Korea.xml
+++ b/Maps/GiantEarth/CityMap_Korea.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+
+	<!-- +++++++++++++++++++++++++++++++++++ -->
+	<!-- "Giant Earth Map" City Map for Korea -->
+	<!-- +++++++++++++++++++++++++++++++++++ -->
+
+
+
+	<!-- +++++++++++++++ -->
+	<!-- Asia City Map -->
+	<!-- +++++++++++++++ -->
+
+
+	<!-- CHINA -->
+	<CityMap>
+
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAELYEON" X="87" Y="64" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAELYEON" X="87" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAELYEON" X="87" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SHIMYANG" X="88" Y="66" MapName="GiantEarth"/> 
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SHIMYANG" X="87" Y="67" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SHIMYANG" X="88" Y="67" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SHIMYANG" X="86" Y="67" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YEONBYEON" X="91" Y="68" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YEONBYEON" X="91" Y="69" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YEONBYEON" X="92" Y="69" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_PAEKSAN" X="90" Y="68" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YOWON" X="89" Y="68" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HABIBIN" X="88" Y="69" MapName="GiantEarth"/> 
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HABIBIN" X="89" Y="69" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HABIBIN" X="88" Y="70" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HABIBIN" X="89" Y="70" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HABIBIN" X="90" Y="70" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HABIBIN" X="88" Y="71" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HABIBIN" X="89" Y="71" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JANGCHUN" X="87" Y="68" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JANGCHUN" X="88" Y="68" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JANGCHUN" X="87" Y="69" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_MODANGANG" X="93" Y="70" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_MODANGANG" X="92" Y="70" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_KAMOKSA" X="91" Y="70" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GYESEO" X="93" Y="71" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SSANGAPSAN" X="92" Y="71" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HAKGANG" X="91" Y="71" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_IJUN" X="90" Y="71" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_IJUN" X="90" Y="72" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SUWA" X="89" Y="72" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SUWA" X="89" Y="73" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEHEUNGANLYEONG" X="87" Y="73" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEHEUNGANLYEONG" X="88" Y="73" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEHEUNGANLYEONG" X="87" Y="74" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEHEUNGANLYEONG" X="88" Y="74" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEHEUNGANLYEONG" X="89" Y="74" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEHEUNGANLYEONG" X="87" Y="75" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEKYUNG" X="87" Y="72" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEKYUNG" X="88" Y="72" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JEJEHABI" X="86" Y="72" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JONGWON" X="87" Y="71" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JONGWON" X="87" Y="70" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_PAEKSEONG" X="86" Y="71" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DANGSAN" X="86" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DANGSAN" X="85" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DANGSAN" X="85" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DANGSAN" X="84" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_TONGRYO" X="86" Y="69" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUSHIN" X="86" Y="68" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JEOKBONG" X="85" Y="67" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JEOKBONG" X="85" Y="68" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YEHA" X="84" Y="67" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YEHA" X="84" Y="68" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUKGYUNG" X="83" Y="67" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUKGYUNG" X="84" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUKGYUNG" X="83" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUKGYUNG" X="82" Y="66" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUKGYUNG" X="83" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUKGYUNG" X="82" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BOJEONG" X="81" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BOJEONG" X="81" Y="64" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BOJEONG" X="82" Y="64" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BOJEONG" X="81" Y="63" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONJIN" X="84" Y="64" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONJIN" X="83" Y="64" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONJIN" X="83" Y="63" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONJIN" X="82" Y="63" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONJIN" X="84" Y="62" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONJIN" X="83" Y="62" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SEOKGAJANG" X="79" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SEOKGAJANG" X="80" Y="65" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SEOKGAJANG" X="80" Y="64" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SEOKGAJANG" X="79" Y="63" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SEOKGAJANG" X="80" Y="63" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JANGJA" X="81" Y="62" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JEONGJU" X="80" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JEONGJU" X="81" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JEONGJU" X="81" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JEONGJU" X="82" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JEONGJU" X="81" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GAEBONG" X="82" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YUBANG" X="84" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YUBANG" X="85" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JENAM" X="83" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JENAM" X="84" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONGDO" X="85" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONGDO" X="86" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YEONDAE" X="86" Y="61" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JENYEONG" X="83" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JENYEONG" X="82" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_PAENGSEONG" X="83" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_PAENGSEONG" X="83" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_PAENGSEONG" X="84" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_IMEUN" X="84" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YEOMSEONG" X="85" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_YEOMSEONG" X="86" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SANGHAE" X="86" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SANGHAE" X="86" Y="56" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SANGHAE" X="87" Y="56" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SANGHAE" X="86" Y="55" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_NAMGYEONG" X="85" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_NAMGYEONG" X="84" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_NAMGYEONG" X="85" Y="56" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_NAMGYEONG" X="84" Y="56" MapName="GiantEarth"/>
+
+	</CityMap>
+
+	<!-- JAPAN -->
+	<CityMap>
+
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DONGGYEONG" X="100" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DONGGYEONG" X="99" Y="60" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DONGGYEONG" X="98" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONYEOP" X="100" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_CHEONYEOP" X="100" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GYEONGDO" X="96" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GYEONGDO" X="96" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_JONGBON" X="97" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEJIN" X="97" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEJIN" X="97" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GWANGBYEONG" X="98" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_MYEONGGO" X="98" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_MYEONGGO" X="99" Y="56" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEPAN" X="96" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DAEPAN" X="97" Y="56" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_NAYANG" X="98" Y="56" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HWAGASAN" X="97" Y="55" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GYE" X="96" Y="55" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SHINHO" X="95" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SHINHO" X="95" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_MUHAK" X="95" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DOCHWI" X="94" Y="59" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_DOCHWI" X="94" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_HUINAK" X="94" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GANGSAN" X="93" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SONGGANG" X="93" Y="58" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GWANGDO" X="92" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GWANGDO" X="92" Y="56" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SANKU" X="91" Y="57" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUKGYUJU" X="91" Y="56" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUKGYUJU" X="90" Y="55" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUGANG" X="90" Y="54" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_BUGANG" X="91" Y="54" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GOMBON" X="90" Y="53" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GOMBON" X="90" Y="52" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GUNGGI" X="91" Y="53" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_NOKYEDO" X="91" Y="52" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GOJONG" X="94" Y="55" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_GOJONG" X="94" Y="54" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SONGSAN" X="93" Y="54" MapName="GiantEarth"/>
+		<Replace Civilization="CIVILIZATION_KOREA" Area="0" CityLocaleName="LOC_CITY_NAME_SONGSAN" X="93" Y="52" MapName="GiantEarth"/>
+
+	</CityMap>
+
+</GameData>

--- a/Yet (not) Another Maps Pack.modinfo
+++ b/Yet (not) Another Maps Pack.modinfo
@@ -52,6 +52,8 @@
 			<File>Maps/GiantEarth/CityMap.xml</File>
 			<File>Maps/GiantEarth/CityMap_Egypt.xml</File>
 			<File>Maps/GiantEarth/CityMap_Greece.xml</File>
+			<File>Maps/GiantEarth/CityMap_Japan.xml</File>
+			<File>Maps/GiantEarth/CityMap_Korea.xml</File>
 			<File>Maps/GiantEarth/CityMap_Nubia.xml</File>
 			<File>Maps/GiantEarth/CityMap_Rome.xml</File>
 			<File>Maps/GiantEarth/CityMap_Spain.xml</File>
@@ -179,6 +181,8 @@
 		<File>Maps/GiantEarth/CityMap.xml</File>
 		<File>Maps/GiantEarth/CityMap_Egypt.xml</File>
 		<File>Maps/GiantEarth/CityMap_Greece.xml</File>
+		<File>Maps/GiantEarth/CityMap_Japan.xml</File>
+		<File>Maps/GiantEarth/CityMap_Korea.xml</File>
 		<File>Maps/GiantEarth/CityMap_Nubia.xml</File>
 		<File>Maps/GiantEarth/CityMap_Rome.xml</File>
 		<File>Maps/GiantEarth/CityMap_Spain.xml</File>


### PR DESCRIPTION
The Korean City Map covers all of Northeastern China (And some of the central east coast) as well as the southern half of Japan. The Japanese City Map covers all of its colonial holdings (Taiwan, Korea, and Dailan in China)