### PR TITLE
Changes

### DIFF
--- a/Gameplay/GamePlayText.xml
+++ b/Gameplay/GamePlayText.xml
@@ -218,6 +218,8 @@
 		<Replace Tag="LOC_CITY_NAME_BARCELONA_CHINA" Text="Basailuona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARCELONA_FRANCE" Text="Barcelone" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARCELONA_GREECE" Text="Varkelóni" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARCELONA_MACEDON" Text="Varkelóni" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARCELONA_BYZANTIUM" Text="Varkelóni" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARCELONA_HUNGARY" Text="Barcelóna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARCELONA_JAPAN" Text="Baruserona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARCELONA_ROME" Text="Barcino" Language="en_US" />
@@ -242,6 +244,8 @@
 		<Replace Tag="LOC_CITY_NAME_CADIZ_CHINA" Text="Jiādesī" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CADIZ_FRANCE" Text="Cadix" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CADIZ_GREECE" Text="Gádeira" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CADIZ_MACEDON" Text="Gádeira" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CADIZ_BYZANTIUM" Text="Gádeira" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CADIZ_JAPAN" Text="Kadisu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CADIZ_POLAND" Text="Kadyks" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CADIZ_ROME" Text="Gades" Language="en_US" />
@@ -297,6 +301,8 @@
 		<Replace Tag="LOC_CITY_NAME_GRANADA" Text="Granada" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRANADA_ARABIA" Text="Ġarnātah" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRANADA_GREECE" Text="Elibúrgē" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GRANADA_MACEDON" Text="Elibúrgē" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GRANADA_BYZANTIUM" Text="Elibúrgē" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRANADA_ROME" Text="Iliberitanum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GUADALAJARA" Text="Guadalajara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GUADALAJARA_ARABIA" Text="Wādī-al-Hajāra" Language="en_US" />
@@ -334,6 +340,8 @@
 		<Replace Tag="LOC_CITY_NAME_LISBOA_FRANCE" Text="Lisbonne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LISBOA_GERMANY" Text="Lissabon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LISBOA_GREECE" Text="Lissavóna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LISBOA_MACEDON" Text="Lissavóna" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LISBOA_BYZANTIUM" Text="Lissavóna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LISBOA_HUNGARY" Text="Lisszabon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LISBOA_JAPAN" Text="Risubon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LISBOA_LISBON" Text="Lisboa" Language="en_US" />
@@ -480,6 +488,7 @@
 		<Replace Tag="LOC_CITY_NAME_ALENCON_FRANCE" Text="Alençon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALENCON_ROME" Text="Noeodunum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMIENS" Text="Amiens" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AMIENS_GAUL" Text="Samarobriva" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMIENS_ROME" Text="Samarobriva Ambianorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ANGOULEME" Text="Angouleme" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ANGOULEME_FRANCE" Text="Angoulême" Language="en_US" />
@@ -488,18 +497,22 @@
 		<Replace Tag="LOC_CITY_NAME_ARLES" Text="Arles" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARLES_ROME" Text="Arelate" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARRAS" Text="Arras" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ARRAS_GAUL" Text="Nemetocenna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARRAS_ROME" Text="Nemetacum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AUGUSTODURUM" Text="Augustodurum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AUXERRE" Text="Auxerre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AUXERRE_ROME" Text="Autissiodorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AVIGNON" Text="Avignon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AVIGNON_GREECE" Text="Aouennion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AVIGNON_MACEDON" Text="Aouennion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AVIGNON_BYZANTIUM" Text="Aouennion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AVIGNON_ROME" Text="Avennio Cavarum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAYONNE" Text="Bayonne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAYONNE_ROME" Text="Aquæ Tarbellicæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BAYONNE_SPAIN" Text="Bayona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BESANCON" Text="Besancon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BESANCON_FRANCE" Text="Besançon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BESANCON_GAUL" Text="Vesontio" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BESANCON_GERMANY" Text="Bisanz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BESANCON_ROME" Text="Vesontio" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLOIS" Text="Blois" Language="en_US" />
@@ -508,12 +521,15 @@
 		<Replace Tag="LOC_CITY_NAME_BORDEAUX_ROME" Text="Burdigala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BORDEAUX_SPAIN" Text="Burdeos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOURGES" Text="Bourges" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BOURGES_GAUL" Text="Avaricon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BOURGES_ROME" Text="Avaricum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BREST" Text="Brest" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BREST_ROME" Text="Gesocribate" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAEN" Text="Caen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAEN_GAUL" Text="Catumagos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAEN_ROME" Text="Noviomagus Lexoviorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CALAIS" Text="Calais" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CALAIS_GAUL" Text="Tervanna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CALAIS_ROME" Text="Gesoriacum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARCASSONNE" Text="Carcassonne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARCASSONNE_ROME" Text="Carcasum" Language="en_US" />
@@ -524,9 +540,11 @@
 		<Replace Tag="LOC_CITY_NAME_CHERBOURG_OCTEVILLE" Text="Cherbourg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CHERBOURG_OCTEVILLE_ROME" Text="Coriallum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COUTANCES" Text="Coutances" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_COUTANCES_GAUL" Text="Crociatonum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COUTANCES_ROME" Text="Constantia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DARIORITUM" Text="Darioritum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DIJON" Text="Dijon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DIJON_GAUL" Text="Bibracte" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DIJON_GERMANY" Text="Dision" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DIJON_ROME" Text="Castrum Divionense" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUNKERQUE" Text="Dunkerque" Language="en_US" />
@@ -538,13 +556,16 @@
 		<Replace Tag="LOC_CITY_NAME_LA_ROCHELLE" Text="La Rochelle" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LA_ROCHELLE_ROME" Text="Mediolanum Santonum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LE_HAVRE" Text="Le Havre" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LE_HAVRE_GAUL" Text="Noviomagos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LE_HAVRE_ROME" Text="Iuliobona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LE_MANS" Text="Le Mans" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LE_MANS_GAUL" Text="Autricum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LE_MANS_ROME" Text="Vindinium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LILLE" Text="Lille" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LILLE_GERMANY" Text="Ryssel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LILLE_ROME" Text="Turnacum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIMOGES" Text="Limoges" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LIMOGES_GAUL" Text="Uxellodunum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIMOGES_ROME" Text="Augustoritum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LONS_LE_SAUNIER" Text="Lons-le-Saunier" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LONS_LE_SAUNIER_ROME" Text="Ledo" Language="en_US" />
@@ -552,6 +573,7 @@
 		<Replace Tag="LOC_CITY_NAME_LOURDES_ROME" Text="Tarba" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LYON" Text="Lyon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LYON_ENGLAND" Text="Lyons" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LYON_GAUL" Text="Lugudunon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LYON_POLAND" Text="Lwów Francuski" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LYON_ROME" Text="Lugdunum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LYON_SPAIN" Text="León de Francia" Language="en_US" />
@@ -560,11 +582,14 @@
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_ENGLAND" Text="Marseilles" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_GERMANY" Text="Massilien" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_GREECE" Text="Massalia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARSEILLE_MACEDON" Text="Massalia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARSEILLE_BYZANTIUM" Text="Massalia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_POLAND" Text="Marsylia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_ROME" Text="Massalia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_RUSSIA" Text="Marsel'" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSEILLE_SPAIN" Text="Marsella" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_METZ" Text="Metz" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_METZ_GAUL" Text="Divodurum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_METZ_ROME" Text="Divodurum Mediomatricum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTPELLIER" Text="Montpellier" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTPELLIER_ROME" Text="Bæterræ" Language="en_US" />
@@ -574,33 +599,44 @@
 		<Replace Tag="LOC_CITY_NAME_MULHOUSE_GERMANY" Text="Mülhausen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MULHOUSE_ROME" Text="Uruncis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NANTES" Text="Nantes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NANTES_GAUL" Text="Namnetes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NANTES_GREECE" Text="Kondēoúikon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NANTES_MACEDON" Text="Kondēoúikon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NANTES_BYZANTIUM" Text="Kondēoúikon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NANTES_ROME" Text="Portus Namnetum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NARBONNE" Text="Narbonne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NARBONNE_ROME" Text="Narbo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NICE" Text="Nice" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NICE_GREECE" Text="Nikaia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NICE_MACEDON" Text="Nikaia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NICE_BYZANTIUM" Text="Nikaia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NICE_HUNGARY" Text="Nizza" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NICE_ROME" Text="Cemenelum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NIMES" Text="Nimes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NIMES_ROME" Text="Nemausus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOVIOMAGUS_NEMETUM" Text="Noviomagus Nemetum" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ORLEANS" Text="Orleans" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ORLEANS_FRANCE" Text="Orléans" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ORLEANS" Text="Orléans" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ORLEANS_ENGLAND" Text="Orleans" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ORLEANS_GAUL" Text="Cenabum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ORLEANS_ROME" Text="Aurelianum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARIS" Text="Paris" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARIS_ARABIA" Text="Bārīs" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PARIS_GAUL" Text="Lutetia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARIS_GREECE" Text="Parísii" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PARIS_MACEDON" Text="Parísii" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PARIS_BYZANTIUM" Text="Parísii" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARIS_HUNGARY" Text="Párizs" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARIS_JAPAN" Text="Pari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARIS_NORWAY" Text="París" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARIS_POLAND" Text="Paryż" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARIS_ROME" Text="Lutetia Parisiorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PERPIGNAN" Text="Perpignan" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PERPIGNAN_GAUL" Text="Ruscino" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PERPIGNAN_ROME" Text="Ruscino" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PERPIGNAN_SPAIN" Text="Perpiñán" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POITIERS" Text="Poitiers" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POITIERS_ARABIA" Text="Buatiih" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_POITIERS_GAUL" Text="Lemonum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POITIERS_ROME" Text="Pictavium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PONTIVY" Text="Pontivy" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PONTIVY_ROME" Text="Vorgium" Language="en_US" />
@@ -609,20 +645,24 @@
 		<Replace Tag="LOC_CITY_NAME_QUIMPER_ROME" Text="Corisopitum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_REIMS" Text="Reims" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_REIMS_ENGLAND" Text="Rheims" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_REIMS_GAUL" Text="Durocorteron" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_REIMS_ROME" Text="Durocortorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RENNES" Text="Rennes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RENNES_GAUL" Text="Condate" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RENNES_ROME" Text="Condate Redonum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROANNE" Text="Roanne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROANNE_ROME" Text="Augustodunum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROCHEFORT" Text="Rochefort" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROCHEFORT_ROME" Text="Mediolanum Santonum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROUEN" Text="Rouen" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ROUEN_GAUL" Text="Ratumacos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROUEN_NORWAY" Text="Rúðuborg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROUEN_ROME" Text="Rotomagnus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROUEN_SPAIN" Text="Ruán" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_BRIEUC" Text="Saint-Brieuc" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_BRIEUC_ROME" Text="Fanum Martis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_ETIENNE" Text="Saint-Étienne" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SAINT_ETIENNE_GAUL" Text="Anicium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_ETIENNE_GERMANY" Text="Sankt Steffen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_ETIENNE_ROME" Text="Ruessium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_ETIENNE_SPAIN" Text="San Esteban" Language="en_US" />
@@ -630,6 +670,7 @@
 		<Replace Tag="LOC_CITY_NAME_SAINT_MALO_ROME" Text="Reginca" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_MALO_SPAIN" Text="Reginca" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_NAZAIRE" Text="Saint-Nazaire" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SAINT_NAZAIRE_GAUL" Text="Darioritum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_NAZAIRE_GERMANY" Text="Sankt Nazarius" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_NAZAIRE_ROME" Text="Corbilo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_NAZAIRE_SPAIN" Text="San Nazaire" Language="en_US" />
@@ -641,6 +682,7 @@
 		<Replace Tag="LOC_CITY_NAME_SAINT_QUENTIN_NETHERLANDS" Text="Brussel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAINT_QUENTIN_ROME" Text="Augusta Viromanduorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SENS" Text="Sens" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SENS_GAUL" Text="Agedincum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SENS_ROME" Text="Agedincum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRASBOURG" Text="Strasbourg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRASBOURG_GERMANY" Text="Straßburg" Language="en_US" />
@@ -653,10 +695,13 @@
 		<Replace Tag="LOC_CITY_NAME_TOULOUSE_ROME" Text="Tolosa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOULOUSE_SPAIN" Text="Tolosa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOURS" Text="Tours" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TOURS_GAUL" Text="Turones" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TOURS_ROME" Text="Cæsarodunum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TROYES" Text="Troyes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TROYES_GAUL" Text="Andematunnum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TROYES_ROME" Text="Augustobona Tricassium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VICHY" Text="Vichy" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_VICHY_GAUL" Text="Gergovia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VICHY_ROME" Text="Augustonementum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VIRE" Text="Vire" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VIRE_ROME" Text="Ingena" Language="en_US" />
@@ -668,6 +713,8 @@
 		<Replace Tag="LOC_CITY_NAME_AGRIGENTO" Text="Agrigento" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AGRIGENTO_ARABIA" Text="Kirkent" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AGRIGENTO_GREECE" Text="Akragas" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AGRIGENTO_MACEDON" Text="Akragas" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_AGRIGENTO_BYZANTIUM" Text="Akragas" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AGRIGENTO_ROME" Text="Agrigentum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AJACCIO" Text="Ajaccio" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AJACCIO_ROME" Text="Adiacium" Language="en_US" />
@@ -689,11 +736,15 @@
 		<Replace Tag="LOC_CITY_NAME_ATRIA" Text="Atria" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARI" Text="Bari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARI_GREECE" Text="Barion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARI_MACEDON" Text="Barion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BARI_BYZANTIUM" Text="Barion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BARI_ROME" Text="Barium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BASTIA" Text="Bastia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BASTIA_ROME" Text="Mariana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENEVENTO" Text="Benevento" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENEVENTO_GREECE" Text="Beneventum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENEVENTO_MACEDON" Text="Beneventum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BENEVENTO_BYZANTIUM" Text="Beneventum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BENEVENTO_ROME" Text="Beneventum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BERGAMO" Text="Bergamo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BERGAMO_FRANCE" Text="Bergame" Language="en_US" />
@@ -712,6 +763,8 @@
 		<Replace Tag="LOC_CITY_NAME_BRESCIA_ROME" Text="Brixia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRINDISI" Text="Brindisi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRINDISI_GREECE" Text="Brentesion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BRINDISI_MACEDON" Text="Brentesion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BRINDISI_BYZANTIUM" Text="Brentesion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRINDISI_ROME" Text="Brundisium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAGLIARI" Text="Cagliari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAGLIARI_FRANCE" Text="Caglier" Language="en_US" />
@@ -719,13 +772,19 @@
 		<Replace Tag="LOC_CITY_NAME_CALTANISSETTA" Text="Caltanissetta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CALTANISSETTA_ARABIA" Text="Qal'at al-Nisā'" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CALTANISSETTA_GREECE" Text="Castra Nicia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CALTANISSETTA_MACEDON" Text="Castra Nicia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CALTANISSETTA_BYZANTIUM" Text="Castra Nicia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CALTANISSETTA_ROME" Text="Castra Nicia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CALVI" Text="Calvi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANOSA" Text="Canosa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANOSA_GREECE" Text="Kanysion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CANOSA_MACEDON" Text="Kanysion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CANOSA_BYZANTIUM" Text="Kanysion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANOSA_ROME" Text="Canusium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAPO_DORLANDO" Text="Capo d'Orlando" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAPO_DORLANDO_GREECE" Text="Tyndarion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAPO_DORLANDO_MACEDON" Text="Tyndarion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAPO_DORLANDO_BYZANTIUM" Text="Tyndarion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAPO_DORLANDO_ROME" Text="Tyndaris" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARRARA" Text="Carrara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARRARA_ROME" Text="Luna" Language="en_US" />
@@ -734,26 +793,38 @@
 		<Replace Tag="LOC_CITY_NAME_CATANIA" Text="Catania" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CATANIA_ARABIA" Text="Madinat al-fīl" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CATANIA_GREECE" Text="Katane" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CATANIA_MACEDON" Text="Katane" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CATANIA_BYZANTIUM" Text="Katane" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CATANZARO" Text="Catanzaro" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CATANZARO_GREECE" Text="Katantzarion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CATANZARO_MACEDON" Text="Katantzarion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CATANZARO_BYZANTIUM" Text="Katantzarion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CATANZARO_ROME" Text="Chatacium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CONCORDIA_SAGITTARIA" Text="Concordia Sagittaria" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CONCORDIA_SAGITTARIA_ROME" Text="Iulia Concordia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CORIGLIANO_CALABRO" Text="Corigliano Calabro" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CORIGLIANO_CALABRO_GREECE" Text="Thurii" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CORIGLIANO_CALABRO_MACEDON" Text="Thurii" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CORIGLIANO_CALABRO_BYZANTIUM" Text="Thurii" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CORIGLIANO_CALABRO_ROME" Text="Thurii" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CORTE" Text="Corte" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CORTE_ROME" Text="Aleria" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COSENZA" Text="Cosenza" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COSENZA_GREECE" Text="Cosentia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_COSENZA_MACEDON" Text="Cosentia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_COSENZA_BYZANTIUM" Text="Cosentia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_COSENZA_ROME" Text="Cosentia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CREMONA" Text="Cremona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CREMONA_FRANCE" Text="Crémone" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CROTONE" Text="Crotone" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CROTONE_GREECE" Text="Kroton" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CROTONE_MACEDON" Text="Kroton" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CROTONE_BYZANTIUM" Text="Kroton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CROTONE_ROME" Text="Crotona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ELEA" Text="Elea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ELEA_GREECE" Text="Hyele" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ELEA_MACEDON" Text="Hyele" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ELEA_BYZANTIUM" Text="Hyele" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ELEA_ROME" Text="Velia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ENNA" Text="Enna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ENNA_ARABIA" Text="Qas'r Ianni" Language="en_US" />
@@ -767,17 +838,23 @@
 		<Replace Tag="LOC_CITY_NAME_FIRENZE" Text="Florence" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FIRENZE_GERMANY" Text="Florenz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FIRENZE_GREECE" Text="Florentia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FIRENZE_MACEDON" Text="Florentia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FIRENZE_BYZANTIUM" Text="Florentia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FIRENZE_HUNGARY" Text="Firenze" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FIRENZE_POLAND" Text="Florencja" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FIRENZE_ROME" Text="Florentia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FIRENZE_SPAIN" Text="Florencia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FOGGIA" Text="Foggia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FOGGIA_GREECE" Text="Argos Hippium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FOGGIA_MACEDON" Text="Argos Hippium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FOGGIA_BYZANTIUM" Text="Argos Hippium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FOGGIA_ROME" Text="Herdoniæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FOLIGNO" Text="Foligno" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FOLIGNO_ROME" Text="Fulginiæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FROSINONE" Text="Frosinone" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FROSINONE_GREECE" Text="Setia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FROSINONE_MACEDON" Text="Setia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_FROSINONE_BYZANTIUM" Text="Setia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_FROSINONE_ROME" Text="Setia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GELA" Text="Gela" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GENOA" Text="Genoa" Language="en_US" />
@@ -795,12 +872,16 @@
 		<Replace Tag="LOC_CITY_NAME_GROSSETO_ROME" Text="Vetulonia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRUMENTO_NOVA" Text="Grumento Nova" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRUMENTO_NOVA_GREECE" Text="Grumentum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GRUMENTO_NOVA_MACEDON" Text="Grumentum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GRUMENTO_NOVA_BYZANTIUM" Text="Grumentum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GRUMENTO_NOVA_ROME" Text="Grumentum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISERNIA" Text="Isernia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISERNIA_ROME" Text="Æsernia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IULIA_CONCORDIA" Text="Iulia Concordia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LATINA" Text="Latina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LATINA_GREECE" Text="Circei" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LATINA_MACEDON" Text="Circei" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LATINA_BYZANTIUM" Text="Circei" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LATINA_ROME" Text="Circei" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LA_SPEZIA" Text="La Spezia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LA_SPEZIA_ROME" Text="Luna" Language="en_US" />
@@ -828,13 +909,19 @@
 		<Replace Tag="LOC_CITY_NAME_MARSALA" Text="Marsala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSALA_ARABIA" Text="Marsa 'Alī" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSALA_GREECE" Text="Lilybaion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARSALA_MACEDON" Text="Lilybaion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MARSALA_BYZANTIUM" Text="Lilybaion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MARSALA_ROME" Text="Lilybæum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MELFI" Text="Melfi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MELFI_GREECE" Text="Aphrodisia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELFI_MACEDON" Text="Aphrodisia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MELFI_BYZANTIUM" Text="Aphrodisia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MELFI_ROME" Text="Venusia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MESSINA" Text="Messina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MESSINA_ARABIA" Text="Tabarmīn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MESSINA_GREECE" Text="Zancle" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MESSINA_MACEDON" Text="Zancle" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MESSINA_BYZANTIUM" Text="Zancle" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MESSINA_ROME" Text="Messana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MILAN" Text="Milan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MILAN_GERMANY" Text="Mailand" Language="en_US" />
@@ -843,10 +930,14 @@
 		<Replace Tag="LOC_CITY_NAME_MILAN_ROME" Text="Mediolanum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTELEONE" Text="Monteleone" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTELEONE_GREECE" Text="Hipponion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MONTELEONE_MACEDON" Text="Hipponion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MONTELEONE_BYZANTIUM" Text="Hipponion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MONTELEONE_ROME" Text="Vibo Valentia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAPLES" Text="Naples" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAPLES_GERMANY" Text="Neapel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAPLES_GREECE" Text="Parthenope" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAPLES_MACEDON" Text="Parthenope" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NAPLES_BYZANTIUM" Text="Parthenope" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAPLES_HUNGARY" Text="Nápoly" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAPLES_ROME" Text="Neapolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NAPLES_RUSSIA" Text="Neapol" Language="en_US" />
@@ -861,6 +952,8 @@
 		<Replace Tag="LOC_CITY_NAME_PALERMO" Text="Palermo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PALERMO_ARABIA" Text="Balarm" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PALERMO_GREECE" Text="Panormos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PALERMO_MACEDON" Text="Panormos" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PALERMO_BYZANTIUM" Text="Panormos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PALERMO_ROME" Text="Panormus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARMA" Text="Parma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PARMA_FRANCE" Text="Parme" Language="en_US" />
@@ -883,11 +976,15 @@
 		<Replace Tag="LOC_CITY_NAME_PISA_ROME" Text="Pisæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POLICORO" Text="Policoro" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POLICORO_GREECE" Text="Herakleia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_POLICORO_MACEDON" Text="Herakleia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_POLICORO_BYZANTIUM" Text="Herakleia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POLICORO_ROME" Text="Heraclea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POTENZA" Text="Potenza" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POTENZA_ROME" Text="Potentia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAGUSA" Text="Ragusa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAGUSA_GREECE" Text="Gela" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAGUSA_MACEDON" Text="Gela" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_RAGUSA_BYZANTIUM" Text="Gela" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAGUSA_ROME" Text="Gela" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAVENNA" Text="Ravenna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RAVENNA_FRANCE" Text="Ravenne" Language="en_US" />
@@ -895,6 +992,8 @@
 		<Replace Tag="LOC_CITY_NAME_RAVENNA_SPAIN" Text="Rávena" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_REGGIO_CALABRIA" Text="Reggio Calabria" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_REGGIO_CALABRIA_GREECE" Text="Rhegium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_REGGIO_CALABRIA_MACEDON" Text="Rhegium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_REGGIO_CALABRIA_BYZANTIUM" Text="Rhegium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_REGGIO_CALABRIA_ROME" Text="Rhegium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RIETI" Text="Rieti" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RIETI_ROME" Text="Reate" Language="en_US" />
@@ -905,6 +1004,8 @@
 		<Replace Tag="LOC_CITY_NAME_ROME_CHINA" Text="Luoma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROME_GERMANY" Text="Rom" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROME_GREECE" Text="Rómi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ROME_MACEDON" Text="Rómi" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ROME_BYZANTIUM" Text="Rómi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROME_HUNGARY" Text="Róma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROME_JAPAN" Text="Rōma" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ROME_NORWAY" Text="Rómaborg" Language="en_US" />
@@ -932,10 +1033,14 @@
 		<Replace Tag="LOC_CITY_NAME_SIRACUSA_ENGLAND" Text="Syracuse" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIRACUSA_FRANCE" Text="Syracuse" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIRACUSA_GREECE" Text="Syrakousai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIRACUSA_MACEDON" Text="Syrakousai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SIRACUSA_BYZANTIUM" Text="Syrakousai" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIRACUSA_HUNGARY" Text="Szirakúza" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SIRACUSA_ROME" Text="Syracusæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TARANTO" Text="Taranto" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TARANTO_GREECE" Text="Taras" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TARANTO_MACEDON" Text="Taras" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_TARANTO_BYZANTIUM" Text="Taras" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TARANTO_ROME" Text="Tarentum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TARQUINIA" Text="Tarquinia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TARQUINIA_ROME" Text="Tarquinii" Language="en_US" />
@@ -967,6 +1072,8 @@
 		<Replace Tag="LOC_CITY_NAME_VALLETTA_ARABIA" Text="Fālītā" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VALLETTA_FRANCE" Text="La Valette" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VALLETTA_GREECE" Text="Valéta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_VALLETTA_MACEDON" Text="Valéta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_VALLETTA_BYZANTIUM" Text="Valéta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VALLETTA_VALLETTA" Text="Il-Belt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VASTO" Text="Vasto" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VASTO_ROME" Text="Larinum" Language="en_US" />
@@ -980,6 +1087,8 @@
 		<Replace Tag="LOC_CITY_NAME_VICENZA_ROME" Text="Vicetia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VIESTE" Text="Vieste" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VIESTE_GREECE" Text="Apeneste" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_VIESTE_MACEDON" Text="Apeneste" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_VIESTE_BYZANTIUM" Text="Apeneste" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VIESTE_ROME" Text="Vesta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VITERBO" Text="Viterbo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VITERBO_ROME" Text="Ferentium" Language="en_US" />
@@ -993,6 +1102,8 @@
 		<Replace Tag="LOC_CITY_NAME_ABERDEEN_ARABIA" Text="Abradin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ABERDEEN_CHINA" Text="Yaboding" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ABERDEEN_GREECE" Text="Devana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABERDEEN_MACEDON" Text="Devana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ABERDEEN_BYZANTIUM" Text="Devana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ABERDEEN_INDIA" Text="Ebaradeen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ABERDEEN_JAPAN" Text="Abadin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ABERDEEN_NORWAY" Text="Apardion" Language="en_US" />
@@ -1014,6 +1125,8 @@
 		<Replace Tag="LOC_CITY_NAME_BIRMINGHAM_ARABIA" Text="Birmynghham" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIRMINGHAM_CHINA" Text="Bominghan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIRMINGHAM_GREECE" Text="Viroconion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIRMINGHAM_MACEDON" Text="Viroconion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BIRMINGHAM_BYZANTIUM" Text="Viroconion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIRMINGHAM_INDIA" Text="Barmingham" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIRMINGHAM_JAPAN" Text="Bamingamu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIRMINGHAM_ROME" Text="Viroconium" Language="en_US" />
@@ -1028,6 +1141,8 @@
 		<Replace Tag="LOC_CITY_NAME_BRIGHTON_CHINA" Text="Balaidun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRIGHTON_FRANCE" Text="Douvres" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRIGHTON_GREECE" Text="Anderida" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BRIGHTON_MACEDON" Text="Anderida" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BRIGHTON_BYZANTIUM" Text="Anderida" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRIGHTON_INDIA" Text="Bra'iṭana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRIGHTON_JAPAN" Text="Buraiton" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRIGHTON_ROME" Text="Noviomagus Reginorum" Language="en_US" />
@@ -1038,12 +1153,16 @@
 		<Replace Tag="LOC_CITY_NAME_BRISTOL_CHINA" Text="Bulisituor" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRISTOL_FRANCE" Text="Bains" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRISTOL_GREECE" Text="Aquæ Sulis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BRISTOL_MACEDON" Text="Aquæ Sulis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BRISTOL_BYZANTIUM" Text="Aquæ Sulis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRISTOL_JAPAN" Text="Burisutoru" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRISTOL_ROME" Text="Aquæ Sulis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAERNARFON" Text="Caernarfon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAERNARFON_ARABIA" Text="Knarvvn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAERNARFON_CHINA" Text="Kanafen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAERNARFON_GREECE" Text="Segontion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAERNARFON_MACEDON" Text="Segontion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAERNARFON_BYZANTIUM" Text="Segontion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAERNARFON_JAPAN" Text="Kanavuon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAERNARFON_NORWAY" Text="Ǫngullsey" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAERNARFON_ROME" Text="Segontium" Language="en_US" />
@@ -1055,6 +1174,8 @@
 		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_CHINA" Text="Kangqiao" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_FRANCE" Text="Bouquinquan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_GREECE" Text="Verulamion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_MACEDON" Text="Verulamion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_BYZANTIUM" Text="Verulamion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_INDIA" Text="Kyamabrija" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_JAPAN" Text="Kemburijji" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CAMBRIDGE_ROME" Text="Verulamium" Language="en_US" />
@@ -1066,6 +1187,8 @@
 		<Replace Tag="LOC_CITY_NAME_CANTERBURY_FRANCE" Text="Cantorbéry" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANTERBURY_GERMANY" Text="Kantelburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANTERBURY_GREECE" Text="Durovernon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CANTERBURY_MACEDON" Text="Durovernon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CANTERBURY_BYZANTIUM" Text="Durovernon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANTERBURY_JAPAN" Text="Kantaberi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANTERBURY_NORWAY" Text="Kantaraborg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CANTERBURY_ROME" Text="Durovernum Canticorum" Language="en_US" />
@@ -1075,6 +1198,8 @@
 		<Replace Tag="LOC_CITY_NAME_CARDIFF_ARABIA" Text="Kardif" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARDIFF_CHINA" Text="Jiadefu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARDIFF_GREECE" Text="Isca Silurum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARDIFF_MACEDON" Text="Isca Silurum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARDIFF_BYZANTIUM" Text="Isca Silurum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARDIFF_INDIA" Text="Kaardif" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARDIFF_JAPAN" Text="Kadifu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARDIFF_NORWAY" Text="Houndemammeby" Language="en_US" />
@@ -1087,6 +1212,8 @@
 		<Replace Tag="LOC_CITY_NAME_CARLISLE_ARABIA" Text="Karlayl" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARLISLE_CHINA" Text="Kalai'er" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARLISLE_GREECE" Text="Luguvalium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARLISLE_MACEDON" Text="Luguvalium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARLISLE_BYZANTIUM" Text="Luguvalium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARLISLE_JAPAN" Text="Karairu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARLISLE_NORWAY" Text="Kirkby" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARLISLE_ROME" Text="Luguvalium" Language="en_US" />
@@ -1096,6 +1223,8 @@
 		<Replace Tag="LOC_CITY_NAME_CARMARTHEN_ARABIA" Text="Karmaten" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARMARTHEN_CHINA" Text="Kamasen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARMARTHEN_GREECE" Text="Moridunon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARMARTHEN_MACEDON" Text="Moridunon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_CARMARTHEN_BYZANTIUM" Text="Moridunon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARMARTHEN_JAPAN" Text="Kamazen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARMARTHEN_NORWAY" Text="Tenby" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARMARTHEN_ROME" Text="Moridunum" Language="en_US" />
@@ -1110,6 +1239,8 @@
 		<Replace Tag="LOC_CITY_NAME_DUMFRIES_ARABIA" Text="Damfrys" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUMFRIES_CHINA" Text="Dengfulisi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUMFRIES_GREECE" Text="Uxelodunon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DUMFRIES_MACEDON" Text="Uxelodunon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DUMFRIES_BYZANTIUM" Text="Uxelodunon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUMFRIES_JAPAN" Text="Danfurizu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUMFRIES_ROME" Text="Uxelodunum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUMFRIES_RUSSIA" Text="Damfris" Language="en_US" />
@@ -1118,6 +1249,8 @@
 		<Replace Tag="LOC_CITY_NAME_DUNDEE_ARABIA" Text="Dandy" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUNDEE_CHINA" Text="Dengdi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUNDEE_GREECE" Text="Alectum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DUNDEE_MACEDON" Text="Alectum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DUNDEE_BYZANTIUM" Text="Alectum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUNDEE_INDIA" Text="Dandi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUNDEE_JAPAN" Text="Dandi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUNDEE_ROME" Text="Pinnata Castra" Language="en_US" />
@@ -1135,6 +1268,8 @@
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_FRANCE" Text="Édimbourg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_GERMANY" Text="Edinburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_GREECE" Text="Trimontion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EDINBURGH_MACEDON" Text="Trimontion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EDINBURGH_BYZANTIUM" Text="Trimontion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_INDIA" Text="Edinabara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_JAPAN" Text="Edinbara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EDINBURGH_KONGO" Text="Édimbourg" Language="en_US" />
@@ -1152,6 +1287,8 @@
 		<Replace Tag="LOC_CITY_NAME_EXETER_CHINA" Text="Aikesaite" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EXETER_FRANCE" Text="Dèrtémue" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EXETER_GREECE" Text="Iska Dumnonioron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EXETER_MACEDON" Text="Iska Dumnonioron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_EXETER_BYZANTIUM" Text="Iska Dumnonioron" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EXETER_JAPAN" Text="Ekuseta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EXETER_NORWAY" Text="Torkey" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EXETER_ROME" Text="Isca Dumnoniorum" Language="en_US" />
@@ -1173,6 +1310,8 @@
 		<Replace Tag="LOC_CITY_NAME_GLASGOW_FRANCE" Text="Glasgovie" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLASGOW_GERMANY" Text="Glaskove" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLASGOW_GREECE" Text="Glaskove" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GLASGOW_MACEDON" Text="Glaskove" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GLASGOW_BYZANTIUM" Text="Glaskove" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLASGOW_INDIA" Text="Glaasago" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLASGOW_JAPAN" Text="Gurasugo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLASGOW_ROME" Text="Glasgua" Language="en_US" />
@@ -1184,6 +1323,8 @@
 		<Replace Tag="LOC_CITY_NAME_GLOUCESTER_CHINA" Text="Gaoluoshida" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLOUCESTER_FRANCE" Text="Glochêtre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLOUCESTER_GREECE" Text="Glevum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GLOUCESTER_MACEDON" Text="Glevum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_GLOUCESTER_BYZANTIUM" Text="Glevum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLOUCESTER_JAPAN" Text="Gorusuta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLOUCESTER_ROME" Text="Glevum Nervensis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GLOUCESTER_RUSSIA" Text="Gloster" Language="en_US" />
@@ -1197,6 +1338,8 @@
 		<Replace Tag="LOC_CITY_NAME_INVERNESS" Text="Inverness" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INVERNESS_CHINA" Text="Inbonesu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INVERNESS_GREECE" Text="Banatia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_INVERNESS_MACEDON" Text="Banatia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_INVERNESS_BYZANTIUM" Text="Banatia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INVERNESS_JAPAN" Text="Invuanesu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INVERNESS_NORWAY" Text="Dingwall" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INVERNESS_ROME" Text="Banatia" Language="en_US" />
@@ -1215,6 +1358,8 @@
 		<Replace Tag="LOC_CITY_NAME_LANCASTER_CHINA" Text="Lankasite" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LANCASTER_GERMANY" Text="Lünburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LANCASTER_GREECE" Text="Setantioron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LANCASTER_MACEDON" Text="Setantioron" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LANCASTER_BYZANTIUM" Text="Setantioron" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LANCASTER_INDIA" Text="Lankastar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LANCASTER_JAPAN" Text="Rankasuta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LANCASTER_NORWAY" Text="Kirkby Kendal" Language="en_US" />
@@ -1223,6 +1368,8 @@
 		<Replace Tag="LOC_CITY_NAME_LANCASTER_SCYTHIA" Text="Lankaster" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LAUNCESTON" Text="Launceston" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LAUNCESTON_GREECE" Text="Uxelis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAUNCESTON_MACEDON" Text="Uxelis" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LAUNCESTON_BYZANTIUM" Text="Uxelis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LAUNCESTON_NORWAY" Text="Lundy" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LAUNCESTON_ROME" Text="Uxelis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LAUNCESTON_RUSSIA" Text="Lonston" Language="en_US" />
@@ -1235,6 +1382,8 @@
 		<Replace Tag="LOC_CITY_NAME_LERWICK" Text="Lerwick" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LERWICK_CHINA" Text="Leiweike" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LERWICK_GREECE" Text="Haemodae" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LERWICK_MACEDON" Text="Haemodae" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LERWICK_BYZANTIUM" Text="Haemodae" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LERWICK_JAPAN" Text="Rauikku" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LERWICK_NORWAY" Text="Leirvik" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LERWICK_ROME" Text="Haemodae" Language="en_US" />
@@ -1244,6 +1393,8 @@
 		<Replace Tag="LOC_CITY_NAME_LINCOLN_ARABIA" Text="Lanukuwwalin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LINCOLN_CHINA" Text="Linken" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LINCOLN_GREECE" Text="Lindum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LINCOLN_MACEDON" Text="Lindum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LINCOLN_BYZANTIUM" Text="Lindum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LINCOLN_JAPAN" Text="Rinkan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LINCOLN_NORWAY" Text="Torksey" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LINCOLN_ROME" Text="Lindum Colonia" Language="en_US" />
@@ -1254,6 +1405,8 @@
 		<Replace Tag="LOC_CITY_NAME_LIVERPOOL_ARABIA" Text="Lifirbul" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIVERPOOL_CHINA" Text="Ribopul" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIVERPOOL_GREECE" Text="Deva" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LIVERPOOL_MACEDON" Text="Deva" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LIVERPOOL_BYZANTIUM" Text="Deva" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIVERPOOL_JAPAN" Text="Ribapuru" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIVERPOOL_NORWAY" Text="Thingwall" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LIVERPOOL_ROME" Text="Deva Victrix" Language="en_US" />
@@ -1269,6 +1422,8 @@
 		<Replace Tag="LOC_CITY_NAME_LONDON_EGYPT" Text="Landan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LONDON_FRANCE" Text="Londres" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LONDON_GREECE" Text="Londino" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LONDON_MACEDON" Text="Londino" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_LONDON_BYZANTIUM" Text="Londino" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LONDON_INDIA" Text="Landan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LONDON_JAPAN" Text="Rondon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LONDON_KONGO" Text="Londres" Language="en_US" />
@@ -1284,6 +1439,8 @@
 		<Replace Tag="LOC_CITY_NAME_MANCHESTER_CHINA" Text="Manchesite" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANCHESTER_FRANCE" Text="Manchêtre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANCHESTER_GREECE" Text="Manceinion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MANCHESTER_MACEDON" Text="Manceinion" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_MANCHESTER_BYZANTIUM" Text="Manceinion" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANCHESTER_JAPAN" Text="Manchesuta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANCHESTER_ROME" Text="Eboracum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MANCHESTER_ROME" Text="Mancunium" Language="en_US" />
@@ -1298,6 +1455,8 @@
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_FRANCE" Text="Neufchâtel-sur-Tyne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_GERMANY" Text="Neuschloss-an-der-Tyne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_GREECE" Text="Segedunon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_MACEDON" Text="Segedunon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_BYZANTIUM" Text="Segedunon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_INDIA" Text="Niukyasala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_JAPAN" Text="Nyukassuru" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NEWCASTLE_UPON_TYNE_NORWAY" Text="Nýikastali" Language="en_US" />
@@ -1312,6 +1471,8 @@
 		<Replace Tag="LOC_CITY_NAME_NORWICH_CHINA" Text="Nuoliqi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_FRANCE" Text="Noroui" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_GREECE" Text="Venta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NORWICH_MACEDON" Text="Venta" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NORWICH_BYZANTIUM" Text="Venta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_JAPAN" Text="Noritchi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_NORWAY" Text="Norvic" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NORWICH_ROME" Text="Venta Icenorum" Language="en_US" />
@@ -1322,6 +1483,8 @@
 		<Replace Tag="LOC_CITY_NAME_NOTTINGHAM_CHINA" Text="Nuodingxian" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOTTINGHAM_FRANCE" Text="Nieuark" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOTTINGHAM_GREECE" Text="Ratai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NOTTINGHAM_MACEDON" Text="Ratai" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_NOTTINGHAM_BYZANTIUM" Text="Ratai" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOTTINGHAM_JAPAN" Text="Nottingamu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOTTINGHAM_NORWAY" Text="Deoraby" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOTTINGHAM_ROME" Text="Ratæ" Language="en_US" />
@@ -1333,6 +1496,8 @@
 		<Replace Tag="LOC_CITY_NAME_OXFORD_CHINA" Text="Niujin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OXFORD_GERMANY" Text="Ochsenfurt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OXFORD_GREECE" Text="Calleva" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OXFORD_MACEDON" Text="Calleva" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_OXFORD_BYZANTIUM" Text="Calleva" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OXFORD_INDIA" Text="Oksaphord" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OXFORD_JAPAN" Text="Okkusufodo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OXFORD_NORWAY" Text="Uxnafurða" Language="en_US" />
@@ -1342,6 +1507,8 @@
 		<Replace Tag="LOC_CITY_NAME_OXFORD_SCYTHIA" Text="Oksford" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PERTH" Text="Perth" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PERTH_GREECE" Text="Orrea" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PERTH_MACEDON" Text="Orrea" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PERTH_BYZANTIUM" Text="Orrea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PERTH_NORWAY" Text="Hundby" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PERTH_ROME" Text="Orrea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PERTH_RUSSIA" Text="Pert" Language="en_US" />
@@ -1354,6 +1521,8 @@
 		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_FRANCE" Text="Pliémue" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_GERMANY" Text="Pflaumünde" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_GREECE" Text="Tamaris" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_MACEDON" Text="Tamaris" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_BYZANTIUM" Text="Tamaris" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_INDIA" Text="Plimatha" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_JAPAN" Text="Purimasu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_NORWAY" Text="Torkey" Language="en_US" />
@@ -1362,6 +1531,8 @@
 		<Replace Tag="LOC_CITY_NAME_PLYMOUTH_SCYTHIA" Text="Plimut" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORTREE" Text="Portree" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORTREE_GREECE" Text="Ebunda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORTREE_MACEDON" Text="Ebunda" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_PORTREE_BYZANTIUM" Text="Ebunda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORTREE_NORWAY" Text="Dùn Bheagain" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORTREE_ROME" Text="Ebunda Major" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PORTREE_RUSSIA" Text="Portri" Language="en_US" />
@@ -1376,6 +1547,8 @@
 		<Replace Tag="LOC_CITY_NAME_READING_ARABIA" Text="Ridingh" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_READING_CHINA" Text="Leiding" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_READING_GREECE" Text="Pontes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_READING_MACEDON" Text="Pontes" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_READING_BYZANTIUM" Text="Pontes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_READING_JAPAN" Text="Redingu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_READING_ROME" Text="Pontes" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_READING_RUSSIA" Text="Reding" Language="en_US" />
@@ -1385,6 +1558,8 @@
 		<Replace Tag="LOC_CITY_NAME_SALISBURY_CHINA" Text="Suoerziboli" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SALISBURY_FRANCE" Text="Sarisberie" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SALISBURY_GREECE" Text="Sorviodunon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SALISBURY_MACEDON" Text="Sorviodunon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SALISBURY_BYZANTIUM" Text="Sorviodunon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SALISBURY_INDIA" Text="Sal‌s‌bari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SALISBURY_JAPAN" Text="Soruzuberi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SALISBURY_NORWAY" Text="Sjóraborg" Language="en_US" />
@@ -1394,6 +1569,8 @@
 		<Replace Tag="LOC_CITY_NAME_SCALLOWAY" Text="Scalloway" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SCALLOWAY_GERMANY" Text="Schaldewage" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SCALLOWAY_GREECE" Text="Haemodae" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SCALLOWAY_MACEDON" Text="Haemodae" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SCALLOWAY_BYZANTIUM" Text="Haemodae" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SCALLOWAY_NORWAY" Text="Skálavágr" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SCALLOWAY_ROME" Text="Haemodae" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SCARBOROUGH" Text="Scarborough" Language="en_US" />
@@ -1409,6 +1586,8 @@
 		<Replace Tag="LOC_CITY_NAME_SOUTHAMPTON_CHINA" Text="Nananpudun" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOUTHAMPTON_FRANCE" Text="Bicêtre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOUTHAMPTON_GREECE" Text="Venta Belgarum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOUTHAMPTON_MACEDON" Text="Venta Belgarum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SOUTHAMPTON_BYZANTIUM" Text="Venta Belgarum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOUTHAMPTON_INDIA" Text="Sauthahaimpatan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOUTHAMPTON_JAPAN" Text="Sausanputon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOUTHAMPTON_NORWAY" Text="Wolvesey" Language="en_US" />
@@ -1424,12 +1603,16 @@
 		<Replace Tag="LOC_CITY_NAME_STOKE_ON_TRENT_ROME" Text="Viroconium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STORNOWAY" Text="Stornoway" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STORNOWAY_GREECE" Text="Limnu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_STORNOWAY_MACEDON" Text="Limnu" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_STORNOWAY_BYZANTIUM" Text="Limnu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STORNOWAY_NORWAY" Text="Stjórnavágr" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STORNOWAY_ROME" Text="Leogus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STORNOWAY_RUSSIA" Text="Stornovei" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STORNOWAY_SCYTHIA" Text="Stornovei" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRANRAER" Text="Stranraer" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRANRAER_GREECE" Text="Rerigonium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_STRANRAER_MACEDON" Text="Rerigonium" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_STRANRAER_BYZANTIUM" Text="Rerigonium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRANRAER_NORWAY" Text="Hreyrreik" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRANRAER_ROME" Text="Rerigonium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRANRAER_RUSSIA" Text="Stranrar" Language="en_US" />
@@ -1462,6 +1645,8 @@
 		<Replace Tag="LOC_CITY_NAME_WESTON_SUPER_MARE_ROME" Text="Lindinis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICK" Text="Wick" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICK_GREECE" Text="Vervedrum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WICK_MACEDON" Text="Vervedrum" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WICK_BYZANTIUM" Text="Vervedrum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICK_NORWAY" Text="Vík" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICK_ROME" Text="Vervedrum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WICK_RUSSIA" Text="Uik" Language="en_US" />
@@ -1472,6 +1657,8 @@
 		<Replace Tag="LOC_CITY_NAME_WORCESTER_CHINA" Text="Wusite" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WORCESTER_FRANCE" Text="Oucêtre" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WORCESTER_GREECE" Text="Vigornia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WORCESTER_MACEDON" Text="Vigornia" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_WORCESTER_BYZANTIUM" Text="Vigornia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WORCESTER_JAPAN" Text="Usuta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WORCESTER_ROME" Text="Vigornia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WORCESTER_RUSSIA" Text="Vuster" Language="en_US" />
@@ -1482,6 +1669,8 @@
 		<Replace Tag="LOC_CITY_NAME_YORK_CHINA" Text="Yueke" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YORK_FRANCE" Text="Évèroui" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YORK_GREECE" Text="Eborakon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YORK_MACEDON" Text="Eborakon" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_YORK_BYZANTIUM" Text="Eborakon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YORK_JAPAN" Text="Yoku" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YORK_NORWAY" Text="Jórvík" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YORK_ROME" Text="Eboracum" Language="en_US" />
@@ -1517,6 +1706,8 @@
 		<Replace Tag="LOC_CITY_NAME_DUBLIN_CHINA" Text="Dobulin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUBLIN_FRANCE" Text="Dublîn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUBLIN_GREECE" Text="Eblana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DUBLIN_MACEDON" Text="Eblana" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_DUBLIN_BYZANTIUM" Text="Eblana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUBLIN_JAPAN" Text="Daburin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUBLIN_NORWAY" Text="Dyvlinarskire" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DUBLIN_ROME" Text="Eblana" Language="en_US" />
@@ -1536,6 +1727,8 @@
 		<Replace Tag="LOC_CITY_NAME_ROSCOMMON" Text="Roscommon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SLIGO" Text="Sligo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SLIGO_GREECE" Text="Nagnata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SLIGO_MACEDON" Text="Nagnata" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SLIGO_BYZANTIUM" Text="Nagnata" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SLIGO_ROME" Text="Nagnata" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TRALEE" Text="Tralee" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TULLAMORE" Text="Tullamore" Language="en_US" />
@@ -1920,6 +2113,7 @@
 		<Replace Tag="LOC_CITY_NAME_AACHEN_ROME" Text="Aquæ Granni" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AACHEN_RUSSIA" Text="Aakhen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AACHEN_SPAIN" Text="Aquisgrán" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ADUATUCA_GAUL" Text="Aduatuca" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMSTERDAM" Text="Amsterdam" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMSTERDAM_CHINA" Text="Amusitedan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_AMSTERDAM_GREECE" Text="Amstelodamon" Language="en_US" />
@@ -1955,6 +2149,7 @@
 		<Replace Tag="LOC_CITY_NAME_BERLIN_SPAIN" Text="Berlín" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BERN" Text="Bern" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BERN_FRANCE" Text="Berne" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_BERN_GAUL" Text="Brenodurum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BERN_ROME" Text="Aventicum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIELEFELD" Text="Bielefeld" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BONN" Text="Bonn" Language="en_US" />
@@ -2310,6 +2505,7 @@
 		<Replace Tag="LOC_CITY_NAME_ISTANBUL_AMERICA" Text="Constantinople" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISTANBUL_ARABIA" Text="Kostantiniyye" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISTANBUL_BRAZIL" Text="Constantinopla" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_ISTANBUL_BYZANTIUM" Text="Kōnstantinoupolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISTANBUL_CHINA" Text="Junshitandingbao" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISTANBUL_ENGLAND" Text="Constantinople" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ISTANBUL_FRANCE" Text="Constantinople" Language="en_US" />
@@ -2376,7 +2572,7 @@
 		<Replace Tag="LOC_CITY_NAME_SERVIA" Text="Servia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SERVIA_HUNGARY" Text="Szerbia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SMOLYAN" Text="Smolyan" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SMOLYAN_ARABIA" Text="Paşmaklı" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SMOLYAN_OTTOMAN" Text="Paşmaklı" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_HUNGARY" Text="Szmoljan" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SPARTA" Text="Sparta" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SPARTA_HUNGARY" Text="Spárta" Language="en_US" />
@@ -2437,25 +2633,25 @@
 		<Replace Tag="LOC_CITY_NAME_SAMOS" Text="Samos" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAMOS_HUNGARY" Text="Számosz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SKYROS" Text="Skyros" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SKYROS" Text="Szkürosz" Language="en_US" />
+		<Replace Tag="LOC_CITY_NAME_SKYROS_HUNGARY" Text="Szkürosz" Language="en_US" />
 
 	</LocalizedText>
 
 	<LocalizedText>		<!-- BALKANS -->
 
 		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA" Text="Alba Iulia" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA_ARABIA" Text="Erdel Belgradı" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA_OTTOMAN" Text="Erdel Belgradı" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA_FRANCE" Text="Weißenburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA_GERMANY" Text="Weißenburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA_HUNGARY" Text="Gyulafehérvár" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ALBA_IULIA_ROME" Text="Apulum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ARAD" Text="Arad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BACAU" Text="Bacău" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BACAU_ARABIA" Text="Baka" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BACAU_OTTOMAN" Text="Baka" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BACAU_GERMANY" Text="Barchau" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BACAU_HUNGARY" Text="Bákó" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BEOGRAD" Text="Belgrade" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BEOGRAD_ARABIA" Text="Belgrad" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BEOGRAD_OTTOMAN" Text="Belgrad" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BEOGRAD_GERMANY" Text="Belgrad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BEOGRAD_HUNGARY" Text="Nándorfehérvár" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BEOGRAD_NORWAY" Text="Beograd" Language="en_US" />
@@ -2464,12 +2660,12 @@
 		<Replace Tag="LOC_CITY_NAME_BEOGRAD_RUSSIA" Text="Belgrad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BEOGRAD_SWEDEN" Text="Belgrad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLAGOEVGRAD" Text="Blagoevgrad" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BLAGOEVGRAD_ARABIA" Text="Cuma-ı Bala" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BLAGOEVGRAD_OTTOMAN" Text="Cuma-ı Bala" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BLAGOEVGRAD_GREECE" Text="Scaptopara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLAGOEVGRAD_POLAND" Text="Gorna Dżumaja" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BLAGOEVGRAD_ROME" Text="Scaptopara" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRAILA" Text="Brăila" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BRAILA_ARABIA" Text="İbrail" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BRAILA_OTTOMAN" Text="İbrail" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BRAILA_HUNGARY" Text="Brajla" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRAILA_ROME" Text="Troesmis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRASOV" Text="Brașov" Language="en_US" />
@@ -2479,13 +2675,13 @@
 		<Replace Tag="LOC_CITY_NAME_BRASOV_POLAND" Text="Braszów" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BRASOV_ROME" Text="Corona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUCHAREST" Text="Bucharest" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BUCHAREST_ARABIA" Text="Bükreş" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BUCHAREST_OTTOMAN" Text="Bükreş" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BUCHAREST_GERMANY" Text="Bukarest" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUCHAREST_HUNGARY" Text="Bukarest" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUCHAREST_POLAND" Text="Bukareszt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUCHAREST_RUSSIA" Text="Bukharest" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BURGAS" Text="Burgas" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BURGAS_ARABIA" Text="Ahelo-Pirgas" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BURGAS_OTTOMAN" Text="Ahelo-Pirgas" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BURGAS_GREECE" Text="Apollonia Pontica" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BURGAS_HUNGARY" Text="Burgasz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BURGAS_ROME" Text="Apollonia Pontica" Language="en_US" />
@@ -2493,13 +2689,13 @@
 		<Replace Tag="LOC_CITY_NAME_CALARASI_GREECE" Text="Durostolon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CALARASI_ROME" Text="Durostorum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CLUJ_NAPOCA" Text="Cluj-Napoca" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_CLUJ_NAPOCA_ARABIA" Text="Kaloşvar" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_CLUJ_NAPOCA_OTTOMAN" Text="Kaloşvar" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_CLUJ_NAPOCA_GERMANY" Text="Klausenburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CLUJ_NAPOCA_HUNGARY" Text="Kolozsvár" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CLUJ_NAPOCA_POLAND" Text="Kołocz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CLUJ_NAPOCA_ROME" Text="Napoca" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CONSTANTA" Text="Constanța" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_CONSTANTA_ARABIA" Text="Köstence" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_CONSTANTA_OTTOMAN" Text="Köstence" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_CONSTANTA_GERMANY" Text="Konstanz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CONSTANTA_GREECE" Text="Konstantia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CONSTANTA_HUNGARY" Text="Konstanca" Language="en_US" />
@@ -2532,22 +2728,22 @@
 		<Replace Tag="LOC_CITY_NAME_GALATI_ROME" Text="Castra Dinogetia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GALATI_RUSSIA" Text="Galats" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GIURGU" Text="Giurgiu" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_GIURGU_ARABIA" Text="Yergöğü" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_GIURGU_OTTOMAN" Text="Yergöğü" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_GIURGU_GREECE" Text="Theodorapolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GIURGU_HUNGARY" Text="Gyurgyevó" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_GIURGU_ROME" Text="Theodorapolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IZMAIL" Text="Izmail" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_IZMAIL_ARABIA" Text="Ismailiye" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_IZMAIL_OTTOMAN" Text="Ismailiye" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_IZMAIL_HUNGARY" Text="Izmajil" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IZMAIL_ROME" Text="Noviodunum ad Istrum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KIRKLARELI" Text="Kırklareli" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KIRKLARELI_GREECE" Text="Saranta Ekklisiès" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LJUBLJANA" Text="Ljubljana" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_LJUBLJANA_ARABIA" Text="Lubliyana" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_LJUBLJANA_OTTOMAN" Text="Lubliyana" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_LJUBLJANA_GERMANY" Text="Laibach" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LJUBLJANA_ROME" Text="Æmona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_MOHACS" Text="Mohács" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_MOHACS_ARABIA" Text="Mohaç" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_MOHACS_OTTOMAN" Text="Mohaç" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_MOHACS_GERMANY" Text="Mohatsch" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NIS" Text="Niš" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NIS_GERMANY" Text="Nisch" Language="en_US" />
@@ -2555,7 +2751,7 @@
 		<Replace Tag="LOC_CITY_NAME_NIS_GREECE" Text="Naissus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NIS_ROME" Text="Naissus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOVI_PAZAR" Text="Novi Pazar" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_NOVI_PAZAR_ARABIA" Text="Yeni Pazar" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_NOVI_PAZAR_OTTOMAN" Text="Yeni Pazar" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_NOVI_PAZAR_HUNGARY" Text="Újvásár" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOVI_PAZAR_ROME" Text="Ulpiana" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOVI_SAD" Text="Novi Sad" Language="en_US" />
@@ -2565,40 +2761,40 @@
 		<Replace Tag="LOC_CITY_NAME_NOVI_SAD_POLAND" Text="Nowy Sad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_NOVI_SAD_ROME" Text="Cusum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OSIJEK" Text="Osijek" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_OSIJEK_ARABIA" Text="Ösek" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_OSIJEK_OTTOMAN" Text="Ösek" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_OSIJEK_GERMANY" Text="Esseg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OSIJEK_HUNGARY" Text="Eszék" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OSIJEK_POLAND" Text="Osiek" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_OSIJEK_ROME" Text="Mursa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PECS" Text="Pécs" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PECS_ARABIA" Text="Peç" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_PECS_OTTOMAN" Text="Peç" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_PECS_GERMANY" Text="Fünfkirchen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PECS_GREECE" Text="Sophianè" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PECS_POLAND" Text="Pięciokościoły" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PECS_ROME" Text="Sopianæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PITESTI" Text="Pitești" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLEVEN" Text="Pleven" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PLEVEN_ARABIA" Text="Plevne" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_PLEVEN_OTTOMAN" Text="Plevne" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_PLEVEN_GREECE" Text="Palatiolon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLEVEN_HUNGARY" Text="Plevna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLEVEN_ROME" Text="Oescus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLOVDIV" Text="Plovdiv" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PLOVDIV_ARABIA" Text="Filibe" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_PLOVDIV_OTTOMAN" Text="Filibe" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_PLOVDIV_GREECE" Text="Philippopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLOVDIV_HUNGARY" Text="Filippopoly" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLOVDIV_ROME" Text="Trimontium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PODGORICA" Text="Podgorica" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PODGORICA_ARABIA" Text="Böğürtlen" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_PODGORICA_OTTOMAN" Text="Böğürtlen" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_PODGORICA_GREECE" Text="Doclea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PODGORICA_ROME" Text="Doclea" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRESLAV" Text="Preslav" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PRESLAV_ARABIA" Text="Şumnu" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_PRESLAV_OTTOMAN" Text="Şumnu" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_PRESLAV_GERMANY" Text="Weliki Preslaw" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRESLAV_HUNGARY" Text="Veliki Preszlav" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRESLAV_POLAND" Text="Weliki Presław" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRESLAV_ROME" Text="Abritus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRISTINA" Text="Pristina" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PRISTINA_ARABIA" Text="Priştine" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_PRISTINA_OTTOMAN" Text="Priştine" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_PRISTINA_GERMANY" Text="Prischtina" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRISTINA_HUNGARY" Text="Rigómező" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRISTINA_ROME" Text="Ulpiana" Language="en_US" />
@@ -2613,32 +2809,32 @@
 		<Replace Tag="LOC_CITY_NAME_RIJEKA_HUNGARY" Text="Fiume" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RIJEKA_ROME" Text="Flumen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RUSE" Text="Ruse" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_RUSE_ARABIA" Text="Rusçuk" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_RUSE_OTTOMAN" Text="Rusçuk" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_RUSE_HUNGARY" Text="Oroszcsík" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_RUSE_ROME" Text="Sexaginta Prista" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SABAC" Text="Šabac" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SABAC_ARABIA" Text="Böğürdelen" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SABAC_OTTOMAN" Text="Böğürdelen" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SABAC_GERMANY" Text="Schabatz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SABAC_HUNGARY" Text="Szabács" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SABAC_ROME" Text="Sirmium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SARAJEVO" Text="Sarajevo" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SARAJEVO_ARABIA" Text="Saraybosna" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SARAJEVO_OTTOMAN" Text="Saraybosna" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SARAJEVO_GERMANY" Text="Sarajewo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SARAJEVO_HUNGARY" Text="Szarajevó" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SARAJEVO_POLAND" Text="Sarajewo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SARAJEVO_ROME" Text="Aquæ Sulphuræ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHKODER" Text="Shkodër" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SHKODER_ARABIA" Text="İşkodra" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SHKODER_OTTOMAN" Text="İşkodra" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SHKODER_GERMANY" Text="Skutari" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHKODER_GREECE" Text="Skodra" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHKODER_HUNGARY" Text="Kadar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHKODER_ROME" Text="Scodra" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHTIP" Text="Štip" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SHTIP_ARABIA" Text="İştip" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SHTIP_OTTOMAN" Text="İştip" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SHTIP_GREECE" Text="Astibo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SHTIP_ROME" Text="Estipeon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SKOPJE" Text="Skopje" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SKOPJE_ARABIA" Text="Üsküp" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SKOPJE_OTTOMAN" Text="Üsküp" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SKOPJE_POLAND" Text="Skopie" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SKOPJE_ROME" Text="Scupi" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SLATINA" Text="Slatina" Language="en_US" />
@@ -2648,12 +2844,12 @@
 		<Replace Tag="LOC_CITY_NAME_SLAVONSKI_BROD_HUNGARY" Text="Nagyrév" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SLAVONSKI_BROD_ROME" Text="Marsonia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOFIA" Text="Sofia" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SOFIA_ARABIA" Text="Sofya" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SOFIA_OTTOMAN" Text="Sofya" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SOFIA_GREECE" Text="Serdonopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOFIA_HUNGARY" Text="Szeredőc" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOFIA_ROME" Text="Serdica" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOMBOR" Text="Sombor" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SOMBOR_ARABIA" Text="Sonbor" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SOMBOR_OTTOMAN" Text="Sonbor" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SOMBOR_GERMANY" Text="Zombor" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOMBOR_HUNGARY" Text="Czoborszentmihály" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SPLIT" Text="Split" Language="en_US" />
@@ -2661,31 +2857,31 @@
 		<Replace Tag="LOC_CITY_NAME_SPLIT_HUNGARY" Text="Spalató" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SPLIT_ROME" Text="Salonæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRUMICA" Text="Strumica" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_STRUMICA_ARABIA" Text="Üstrümce" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_STRUMICA_OTTOMAN" Text="Üstrümce" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_STRUMICA_GREECE" Text="Astraîon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STRUMICA_ROME" Text="Tiveriopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SUBOTICA" Text="Subotica" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SUBOTICA_ARABIA" Text="Sobotka" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SUBOTICA_OTTOMAN" Text="Sobotka" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SUBOTICA_GERMANY" Text="Maria-Theresiopel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SUBOTICA_HUNGARY" Text="Szabadka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SVISHTOV" Text="Svishtov" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SVISHTOV_ARABIA" Text="Ziștovi" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SVISHTOV_OTTOMAN" Text="Ziștovi" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SVISHTOV_HUNGARY" Text="Szvistov" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SVISHTOV_ROME" Text="Novæ" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SZEGED" Text="Szeged" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SZEGED_ARABIA" Text="Segedin" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SZEGED_OTTOMAN" Text="Segedin" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SZEGED_GERMANY" Text="Segedin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SZEGED_GREECE" Text="Partiscon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SZEGED_POLAND" Text="Segedyn" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SZEGED_ROME" Text="Partiscum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TIMISOARA" Text="Timișoara" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TIMISOARA_ARABIA" Text="Temeşvar" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_TIMISOARA_OTTOMAN" Text="Temeşvar" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_TIMISOARA_GERMANY" Text="Temeschburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TIMISOARA_HUNGARY" Text="Temesvár" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TIMISOARA_POLAND" Text="Temeszwar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TIMISOARA_ROME" Text="Tibiscum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TULCEA" Text="Tulcea" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_TULCEA_ARABIA" Text="Hora-Tepé" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_TULCEA_OTTOMAN" Text="Hora-Tepé" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_TULCEA_GREECE" Text="Ægyssus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TULCEA_HUNGARY" Text="Tulcsa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_TULCEA_ROME" Text="Ægyssus" Language="en_US" />
@@ -2697,7 +2893,7 @@
 		<Replace Tag="LOC_CITY_NAME_VARNA_POLAND" Text="Warna" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VARNA_ROME" Text="Odessus" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VELIKO_TARNOVO" Text="Veliko Tarnovo" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_VELIKO_TARNOVO_ARABIA" Text="Tırnova" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_VELIKO_TARNOVO_OTTOMAN" Text="Tırnova" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_VELIKO_TARNOVO_GERMANY" Text="Tarnovgrad" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VELIKO_TARNOVO_GREECE" Text="Tarnovo" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VELIKO_TARNOVO_HUNGARY" Text="Tövisvár" Language="en_US" />
@@ -2707,18 +2903,18 @@
 		<Replace Tag="LOC_CITY_NAME_VIDIN_HUNGARY" Text="Bodony" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VIDIN_ROME" Text="Bononia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VRSAC" Text="Vršac" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_VRSAC_ARABIA" Text="Virșac" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_VRSAC_OTTOMAN" Text="Virșac" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_VRSAC_GERMANY" Text="Werschetz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VRSAC_HUNGARY" Text="Versec" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VRSAC_GREECE" Text="Argedauon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VRSAC_ROME" Text="Argidava" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YAMBOL" Text="Yambol" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_YAMBOL_ARABIA" Text="Yanbolu" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_YAMBOL_OTTOMAN" Text="Yanbolu" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_YAMBOL_GREECE" Text="Kabyle" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YAMBOL_HUNGARY" Text="Jambol" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_YAMBOL_ROME" Text="Diospolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZAGREB" Text="Zagreb" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ZAGREB_ARABIA" Text="Zagrep" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_ZAGREB_OTTOMAN" Text="Zagrep" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_ZAGREB_GERMANY" Text="Agram" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZAGREB_GREECE" Text="Ágranon" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZAGREB_HUNGARY" Text="Gréc" Language="en_US" />
@@ -2728,7 +2924,7 @@
 		<Replace Tag="LOC_CITY_NAME_ZENICA" Text="Zenica" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZENICA_ROME" Text="Bistua Nova" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZRENJANIN" Text="Zrenjanin" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_ARABIA" Text="Beşkelek" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_OTTOMAN" Text="Beşkelek" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_GERMANY" Text="Großbetschkerek" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_HUNGARY" Text="Nagybecskerek" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ZRENJANIN_ROME" Text="Acumincum" Language="en_US" />
@@ -2769,7 +2965,7 @@
 		<Replace Tag="LOC_CITY_NAME_BIELSKO_BIALA" Text="Bielsko-Biała" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BIELSKO_BIALA_GERMANY" Text="Bielitz-Biala" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BILHOROD_DNISTROVSKYI" Text="Bilhorod-Dnistrovskyi" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BILHOROD_DNISTROVSKYI_ARABIA" Text="Akkerman" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BILHOROD_DNISTROVSKYI_OTTOMAN" Text="Akkerman" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BILHOROD_DNISTROVSKYI_GREECE" Text="Tyras" Language="en_US" 
 		<Replace Tag="LOC_CITY_NAME_BILHOROD_DNISTROVSKYI_HUNGARY" Text="Bilhorod-Dnyisztrovszkij" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BILHOROD_DNISTROVSKYI_POLAND" Text="Białogród nad Dniestrem" Language="en_US" />
@@ -2801,22 +2997,19 @@
 		<Replace Tag="LOC_CITY_NAME_BUDA_NETHERLANDS" Text="Boeda" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUDA_ROME" Text="Aquincum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUDAPEST" Text="Budapest" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BUDAPEST_ARABIA" Text="Budapeşte" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BUDAPEST_OTTOMAN" Text="Budapeşte" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BUDAPEST_GREECE" Text="Voudapésti" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUDAPEST_POLAND" Text="Budapeszt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUDAPEST_ROME" Text="Aquincum" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BUDAPEST" Text="Budapest" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BUDAPEST_ARABIA" Text="Budapeşte" Language="en_US" /> <!-- Turkish -->
-		<Replace Tag="LOC_CITY_NAME_BUDAPEST_ROME" Text="Aquincum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUZAU" Text="Buzău" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_BUZAU_ARABIA" Text="Boze" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_BUZAU_OTTOMAN" Text="Boze" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_BUZAU_GERMANY" Text="Busäu" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BUZAU_HUNGARY" Text="Bodzavásár" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BYDGOSZCZ" Text="Bydgoszcz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BYDGOSZCZ_GERMANY" Text="Bromberg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_BYDGOSZCZ_ROME" Text="Bydgostia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARNUNTUM" Text="Vienna" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_CARNUNTUM_ARABIA" Text="Beç" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_CARNUNTUM_OTTOMAN" Text="Beç" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_CARNUNTUM_GERMANY" Text="Wien" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARNUNTUM_GREECE" Text="Viénni" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_CARNUNTUM_HUNGARY" Text="Bécs" Language="en_US" />
@@ -2850,7 +3043,7 @@
 		<Replace Tag="LOC_CITY_NAME_DAUGAVPILS" Text="Daugavpils" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DAUGAVPILS_GERMANY" Text="Dünaburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DEBRECEN" Text="Debrecen" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_DEBRECEN_ARABIA" Text="Debrezun" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_DEBRECEN_OTTOMAN" Text="Debrezun" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_DEBRECEN_GERMANY" Text="Debrezin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DEBRECEN_GREECE" Text="Ntémpretsen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_DEBRECEN_POLAND" Text="Debreczyn" Language="en_US" />
@@ -2861,7 +3054,7 @@
 		<Replace Tag="LOC_CITY_NAME_EGER_POLAND" Text="Jagier" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_EGER_ROME" Text="Agria" Language="en_US" />	
 		<Replace Tag="LOC_CITY_NAME_ESZTERGOM" Text="Esztergom" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_ESZTERGOM_ARABIA" Text="Estergon" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_ESZTERGOM_OTTOMAN" Text="Estergon" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_ESZTERGOM_GERMANY" Text="Gran" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ESZTERGOM_ROME" Text="Strigonium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ESZTERGOM_RUSSIA" Text="Estergom" Language="en_US" />
@@ -2907,7 +3100,7 @@
 		<Replace Tag="LOC_CITY_NAME_HUNEDOARA_HUNGARY" Text="Hunyadvár" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_HUNEDOARA_ROME" Text="Sarmizegetusa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IASI" Text="Iași" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_IASI_ARABIA" Text="Yaş" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_IASI_OTTOMAN" Text="Yaş" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_IASI_ENGLAND" Text="Iassy" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IASI_GERMANY" Text="Jassenmarkt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IASI_GREECE" Text="Iásio" Language="en_US" />
@@ -2922,7 +3115,7 @@
 		<Replace Tag="LOC_CITY_NAME_INTERCISA_HUNGARY" Text="Pentele" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_INTERCISA_ROME" Text="Intercisa" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IVANO_FRANKIVSK" Text="Ivano-Frankivsk" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_IVANO_FRANKIVSK_ARABIA" Text="Ivano-Frankovsk" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_IVANO_FRANKIVSK_OTTOMAN" Text="Ivano-Frankovsk" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_IVANO_FRANKIVSK_GERMANY" Text="Stanislau" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IVANO_FRANKIVSK_HUNGARY" Text="Ivano-Frankivszk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_IVANO_FRANKIVSK_RUSSIA" Text="Ivano-Frankovsk" Language="en_US" />
@@ -2934,7 +3127,7 @@
 		<Replace Tag="LOC_CITY_NAME_KARLOVY_VARY_HUNGARY" Text="Károlyfürdő" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KARLOVY_VARY_POLAND" Text="Karlowe Wary" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KATOWICE" Text="Katowice" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KATOWICE_ARABIA" Text="Katoviçe" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_KATOWICE_OTTOMAN" Text="Katoviçe" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_KATOWICE_GERMANY" Text="Kattowitz" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KAUNAS" Text="Kaunas" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KAUNAS_GERMANY" Text="Kauen" Language="en_US" />
@@ -2990,7 +3183,7 @@
 		<Replace Tag="LOC_CITY_NAME_KOROSTEN" Text="Korosten" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KOROSTEN_HUNGARY" Text="Koroszteny" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KOSICE" Text="Košice" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KOSICE_ARABIA" Text="Kaşa" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_KOSICE_OTTOMAN" Text="Kaşa" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_KOSICE_FRANCE" Text="Cassovie" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KOSICE_GERMANY" Text="Kaschau" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KOSICE_HUNGARY" Text="Kassa" Language="en_US" />
@@ -3001,7 +3194,7 @@
 		<Replace Tag="LOC_CITY_NAME_KOVEL" Text="Kovel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KOVEL_GERMANY" Text="Kowel" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KRAKOW" Text="Kraków" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_KRAKOW_ARABIA" Text="Krakov" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_KRAKOW_OTTOMAN" Text="Krakov" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_KRAKOW_ENGLAND" Text="Crakow" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KRAKOW_FRANCE" Text="Cracovie" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_KRAKOW_GERMANY" Text="Krakau" Language="en_US" />
@@ -3022,7 +3215,7 @@
 		<Replace Tag="LOC_CITY_NAME_LINZ_ROME" Text="Lauriacum" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LINZ_ROME" Text="Lentia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LJUBLJANA" Text="Ljubljana" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_LJUBLJANA_ARABIA" Text="Lubliyana" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_LJUBLJANA_OTTOMAN" Text="Lubliyana" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_LJUBLJANA_GERMANY" Text="Laibach" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LJUBLJANA_ROME" Text="Æmona" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_LODZ" Text="Łódź" Language="en_US" />
@@ -3109,7 +3302,7 @@
 		<Replace Tag="LOC_CITY_NAME_PLOCK" Text="Płock" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLOCK_HUNGARY" Text="Palacka" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLOVDIV" Text="Plovdiv" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PLOVDIV_ARABIA" Text="Filibe" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_PLOVDIV_OTTOMAN" Text="Filibe" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_PLOVDIV_GERMANY" Text="Plowdiw" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLOVDIV_GREECE" Text="Philippopolis" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PLOVDIV_HUNGARY" Text="Filippopoly" Language="en_US" />
@@ -3126,7 +3319,7 @@
 		<Replace Tag="LOC_CITY_NAME_POZNAN_GERMANY" Text="Posen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_POZNAN_ROME" Text="Posnania" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRAHA" Text="Prague" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_PRAHA_ARABIA" Text="Prag" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_PRAHA_OTTOMAN" Text="Prag" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_PRAHA_GERMANY" Text="Prag" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRAHA_GREECE" Text="Prága" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_PRAHA_HUNGARY" Text="Prága" Language="en_US" />
@@ -3155,7 +3348,7 @@
 		<Replace Tag="LOC_CITY_NAME_SAROSPATAK" Text="Sárospatak" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SAROSPATAK_GERMANY" Text="Patak am Bodrog" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SATU_MARE" Text="Satu Mare" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SATU_MARE_ARABIA" Text="Sokmar" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SATU_MARE_OTTOMAN" Text="Sokmar" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SATU_MARE_GERMANY" Text="Sathmar" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SATU_MARE_HUNGARY" Text="Szatmárnémeti" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SATU_MARE_ROME" Text="Castrum Zotmar" Language="en_US" />
@@ -3183,7 +3376,7 @@
 		<Replace Tag="LOC_CITY_NAME_SOPRON_GERMANY" Text="Ödenburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SOPRON_ROME" Text="Scarbantia" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STUROVO" Text="Štúrovo" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_STUROVO_ARABIA" Text="Ciğerdelen" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_STUROVO_OTTOMAN" Text="Ciğerdelen" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_STUROVO_GERMANY" Text="Gockern" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_STUROVO_HUNGARY" Text="Párkány" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_ST_POLTEN" Text="St Pölten" Language="en_US" />
@@ -3200,7 +3393,7 @@
 		<Replace Tag="LOC_CITY_NAME_SZCZECIN_GERMANY" Text="Stettin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SZCZECIN_NORWAY" Text="Stettin" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SZEKESFEHERVAR" Text="Székesfehérvár" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_SZEKESFEHERVAR_ARABIA" Text="İstolni Belgrad" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_SZEKESFEHERVAR_OTTOMAN" Text="İstolni Belgrad" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_SZEKESFEHERVAR_FRANCE" Text="Albe Royale" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SZEKESFEHERVAR_GERMANY" Text="Stuhlweißenburg" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_SZEKESFEHERVAR_POLAND" Text="Białogród Stołeczny" Language="en_US" />
@@ -3247,7 +3440,7 @@
 		<Replace Tag="LOC_CITY_NAME_UZHHOROD_POLAND" Text="Użhorod" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_UZHHOROD_RUSSIA" Text="Užhorod" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VAC" Text="Vác" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_VAC_ARABIA" Text="Vácz" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_VAC_OTTOMAN" Text="Vácz" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_VAC_GERMANY" Text="Waitzen" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VAC_ROME" Text="Vacium" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VASLUI" Text="Vaslui" Language="en_US" />
@@ -3284,7 +3477,7 @@
 		<Replace Tag="LOC_CITY_NAME_VITEBSK_HUNGARY" Text="Vicebszk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_VITEBSK_POLAND" Text="Witebsk" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WARSZAW" Text="Warsaw" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_WARSZAW_ARABIA" Text="Varşova" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_WARSZAW_OTTOMAN" Text="Varşova" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_WARSZAW_FRANCE" Text="Varsovie" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WARSZAW_GERMANY" Text="Warschau" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WARSZAW_GREECE" Text="Varsovía" Language="en_US" />
@@ -3297,7 +3490,7 @@
 		<Replace Tag="LOC_CITY_NAME_WIENER_NEUSTADT" Text="Wiener Neustadt" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WIENER_NEUSTADT_HUNGARY" Text="Bécsújhely" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WIENER_NEUSTADT_ROME" Text="Scarbantia" Language="en_US" />
-		<Replace Tag="LOC_CITY_NAME_WIEN_ARABIA" Text="Beç" Language="en_US" /> <!-- Turkish -->
+		<Replace Tag="LOC_CITY_NAME_WIEN_OTTOMAN" Text="Beç" Language="en_US" /> <!-- Turkish -->
 		<Replace Tag="LOC_CITY_NAME_WIEN_FRANCE" Text="Vienne" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WIEN_GERMANY" Text="Wien" Language="en_US" />
 		<Replace Tag="LOC_CITY_NAME_WIEN_GREECE" Text="Viénni" Language="en_US" />


### PR DESCRIPTION
Changes:
* Istanbul: Byzantine name (Kōnstantinoupolis)
* changing ARABIA to OTTOMAN where there is a "Turkish" tag
* duplicating copying Greek names for Macedon and Byzantium (finished up to, not including Germany)
* Greek (Macedonian, Byzantine) name for Nantes
* Gaulish names for Amiens, Arras, Bern, Besancon, Bourges, Caen, Calais, Coutances, Dijon, Le Havre, Le Mans, Limoges, Lyon, Metz, Nantes, Orléans, Paris, Perpignan, Poitiers, Reims, Rennes, Rouen, Saint Etienne, Saint Nazaire, Tours, Troyes, Vichy
* Added "Aduatuca" as city name for Gaul on Tongeren starting location
* Orléans: changed Orléans to default (instead of unaccented)